### PR TITLE
Corrected command line option help

### DIFF
--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -448,11 +448,11 @@ int main(int argc, char *argv[])
                                                     QStringLiteral("Application file of to use with the server (usually in build/src/lib*.so), if not set it will try to auto-detect"),
                                                     QStringLiteral("file_name"));
     parser.addOption(appFile);
-    QCommandLineOption serverPort = QCommandLineOption(QStringList() << QStringLiteral("server-port"), QStringLiteral("p"),
+    QCommandLineOption serverPort = QCommandLineOption(QStringList() << QStringLiteral("server-port") << QStringLiteral("p"),
                                                        QStringLiteral("Development server port"),
                                                        QStringLiteral("port"));
     parser.addOption(serverPort);
-    QCommandLineOption restart = QCommandLineOption(QStringList() << QStringLiteral("restart"), QStringLiteral("r"),
+    QCommandLineOption restart = QCommandLineOption(QStringList() << QStringLiteral("restart") << QStringLiteral("r"),
                                                     QStringLiteral("Restarts the development server when the application file changes"));
     parser.addOption(restart);
 


### PR DESCRIPTION
The QCommandLineOption for server-port and restart needs the two
QStringLiterals for the option names added to the QStringList, not
separated as two function parameters, thus squishing everything to the
right in the terminal
![cutelyst-cmdlinehelp](https://cloud.githubusercontent.com/assets/6833954/15231714/1ae71a96-189d-11e6-964a-06161516fb77.png)
