### PR TITLE
Validator: make ValidatorRule::validate() const and returning a QString

### DIFF
--- a/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
+++ b/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
@@ -116,6 +116,9 @@ set(plugin_validator_SRC
     validatorurl.cpp
     validatorurl_p.h
     validatorurl.h
+    validatorresult.cpp
+    validatorresult_p.h
+    validatorresult.h
 ) 
 
 
@@ -162,6 +165,8 @@ set(plugin_validator_HEADERS
     validatortime.h
     validatorurl.h
     Validators
+    validatorresult.h
+    ValidatorResult
 )
 
 add_library(cutelyst_qt5_plugin_utils_validator SHARED

--- a/Cutelyst/Plugins/Utils/Validator/ValidatorResult
+++ b/Cutelyst/Plugins/Utils/Validator/ValidatorResult
@@ -1,0 +1,1 @@
+#include "validatorresult.h"

--- a/Cutelyst/Plugins/Utils/Validator/validator.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validator.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or

--- a/Cutelyst/Plugins/Utils/Validator/validator.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validator.cpp
@@ -71,7 +71,7 @@ Cutelyst::ValidatorResult Validator::validate(Context *c, ValidatorFlags flags) 
 
     if (!result && flags.testFlag(FillStashOnError)) {
         c->setStash(QStringLiteral("validationErrorStrings"), result.errorStrings());
-        c->setStash(QStringLiteral("validationErrorFields"), result.errorFields());
+        c->setStash(QStringLiteral("validationErrors"), QVariant::fromValue<QHash<QString,QStringList>>(result.errors()));
 
         if (!params.isEmpty()) {
             QMap<QString,QString>::const_iterator i = params.constBegin();

--- a/Cutelyst/Plugins/Utils/Validator/validator.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validator.cpp
@@ -59,13 +59,15 @@ void Validator::clear()
 
 Cutelyst::ValidatorResult Validator::validate(Context *c, ValidatorFlags flags) const
 {
+    ValidatorResult result;
+
     if (!c) {
         qCWarning(C_VALIDATOR) << "No valid Context set, aborting validation.";
-        return ValidatorResult();
+        return result;
     }
 
     const ParamsMultiMap params = c->request()->parameters();
-    const ValidatorResult result = validate(params, flags);
+    result = validate(params, flags);
 
     if (!result && flags.testFlag(FillStashOnError)) {
         c->setStash(QStringLiteral("validationErrorStrings"), result.errorStrings());
@@ -87,9 +89,9 @@ Cutelyst::ValidatorResult Validator::validate(Context *c, ValidatorFlags flags) 
 
 ValidatorResult Validator::validate(const ParamsMultiMap &params, ValidatorFlags flags) const
 {
-    Q_D(const Validator);
-
     ValidatorResult result;
+
+    Q_D(const Validator);
 
     if (d->validators.empty()) {
         qCWarning(C_VALIDATOR) << "Validation started with empty validator list.";

--- a/Cutelyst/Plugins/Utils/Validator/validator.h
+++ b/Cutelyst/Plugins/Utils/Validator/validator.h
@@ -145,8 +145,8 @@ class ValidatorRule;
  * information and field values that are not sensible (field names that do not contain \c password).
  *
  * Beside the field values added with their field names, Validator will add two more entries to the stash:
- * \li \a validationErrorStrings - a QStringList containing a list of all validation error messages
- * \li \a validationErrorFields - a QStringList containting a list of field names that have validation errors
+ * \li \a validationErrorStrings - a QStringList containing a list of all validation error messages, returned by ValidatorResult::errorStrings()
+ * \li \a validationErrors - a QHash containing a dictionary with field names and their error strings, returned by ValidatorResult::errors()
  *
  * Let's assume that a user enters the following values into the form fields from the above example:
  * \li \c username = detlef
@@ -159,10 +159,39 @@ class ValidatorRule;
  * \li \c username: "detlef"
  * \li \c email: "detlef@irgendwo"
  * \li \c validationErrorStrings: ["The email address in the “Email” field is not valid.", "Please enter the same password again in the confirmation field."]
- * \li \c validationErrorFields: ["email", "password"]
+ * \li \c validationErrors: ["email":["The email address in the “Email” field is not valid."], "password":[""Please enter the same password again in the confirmation field.""]]
  *
  * The sensible data of the password fields is not part of the stash, but the other values can be used to prefill the form fields for the next attempt of
  * our little Schalke fan and can give him some hints what was wrong.
+ *
+ * \par Usage with Grantlee
+ *
+ * The following example shows possible usage of the error data with \link GrantleeView Grantlee \endlink and the Bootstrap framework.
+ *
+ * \code{.html}
+ * {% if validationErrorStrings.count %}
+    <div class="alert alert-warning" role="alert">
+        <h4 class="alert-heading">Errors in input data</h4>
+        <p>
+        <ul>
+            {% for errorString in validationErrorStrings %}
+            <li>{{ errorString }}</li>
+            {% endfor %}
+        </ul>
+        </p>
+    </div>
+    {% endif %}
+
+    <form>
+
+        <div class="form-group{% if validationErrors.email.count %} has-warning{% endif %}">
+            <label for="email">Email</label>
+            <input type="email" id="email" name="email" maxlength="255" class="form-control{% if validationErrors.email.count %} form-control-warning{% endif %}" placeholder="Email" aria-describedby="emailHelpBlock" required value="{{ email }}">
+            <small id="emailHelpBlock" class="form-text text-muted">The email address will be used to send notifications and to restore lost passwords. Maximum length: 255</small>
+        </div>
+
+    </form>
+ * \endcode
  */
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT Validator
 {

--- a/Cutelyst/Plugins/Utils/Validator/validator.h
+++ b/Cutelyst/Plugins/Utils/Validator/validator.h
@@ -158,8 +158,8 @@ class ValidatorRule;
  * Validator will add the following entries to the \link Context::stash() stash \endlink:
  * \li \c username: "detlef"
  * \li \c email: "detlef@irgendwo"
- * \li \c validationErrorStrings: ["The email address in the “Email” field is not valid.", "Please enter the same password again in the confirmation field."]
- * \li \c validationErrors: ["email":["The email address in the “Email” field is not valid."], "password":[""Please enter the same password again in the confirmation field.""]]
+ * \li \c validationErrorStrings: ["The email address in the Email field is not valid.", "Please enter the same password again in the confirmation field."]
+ * \li \c validationErrors: ["email":["The email address in the Email field is not valid."], "password":[""Please enter the same password again in the confirmation field.""]]
  *
  * The sensible data of the password fields is not part of the stash, but the other values can be used to prefill the form fields for the next attempt of
  * our little Schalke fan and can give him some hints what was wrong.

--- a/Cutelyst/Plugins/Utils/Validator/validator.h
+++ b/Cutelyst/Plugins/Utils/Validator/validator.h
@@ -22,6 +22,7 @@
 #include <Cutelyst/cutelyst_global.h>
 #include <Cutelyst/ParamsMultiMap>
 #include <QScopedPointer>
+#include "validatorresult.h"
 
 namespace Cutelyst {
 
@@ -37,10 +38,7 @@ class ValidatorRule;
  * all validations will be performed until the end. Validations will be performed in the order they were added
  * on construction or via addValidator(). Any field can have any amount of validators.
  *
- * The validators are designed to check common input data together with this processor, but might be used
- * for other purposes and standalone, too.
- *
- * Any validator requires at least the name of the field that should be validated. Some validators have
+ * Any validator requires at least the name of the \a field that should be validated. Some validators have
  * additional mandatory parameters that have to be set. The ValidatorSame for example has a mandatory parameter to set
  * the name of the other field to compare the values.
  *
@@ -52,12 +50,12 @@ class ValidatorRule;
  * the label for every field and validator.
  *
  * The other comfort function can be used via the Validator::FillStashOnError flag. If you set the flag on the validate() function that takes
- * the Context as parameter, it will add all error information as well as the not sensible input data to the \link Context::stash() stash \endlink
+ * the Context pointer as parameter, it will add all error information as well as the not sensible input data to the \link Context::stash() stash \endlink
  * using the fillStash() function.
  *
  * \par Usage example
  *
- * As written before, validators can be used standalone, but that is not their intention - they are designed to validate input
+ * Validators can be used standalone, but that is not their intention - they are designed to validate input
  * data of form fields and API requests and so on. So they work best together with this main Validator and directly on the
  * Context \link Context::stash() stash \endlink.
  *
@@ -68,9 +66,15 @@ class ValidatorRule;
  * at ValidatorRule and for sure in the documentation for every single validator. Information about writing your own
  * validators that work with this concept can be found at ValidatorRule.
  *
+ * Validator will retrun a ValidatorResult after validation has been performed. The result can be used to check the validity of the
+ * input data. It will contain error messages from every failed ValidatorRule and a list of field names for which validation failed.
+ * If there are no failed validation, the result will be valid, what you can check via ValidatorResult::isValid() or directly with
+ * an if statement.
+ *
  * \code{.cpp}
  * #include <Cutelyst/Plugins/Utils/Validator> // includes the main validator
  * #include <Cutelyst/Plugins/Utils/Validators> // includes all validator rules
+ * #include <Cutelyst/Plugins/Utils/ValidatorResult> // includes the validator result
  *
  * void MyController::myform(Context *c)
  * {
@@ -116,6 +120,8 @@ class ValidatorRule;
  *
  *          // ok, now we have all our validators in place - let the games begin
  *          // we will set the FillStashOnError flag to automatically fill the context stash with error data
+ *          // and as you can see, we can directly use the ValidatorResult in an if statement, because of it's
+ *          // bool operator in this situation, because we are filling the stash directly in the Valiator
  *          if (v.validate(c, FillStashOnError)) {
  *              // ok everything is valid, we can now process the input data and advance to the next
  *              // step for example
@@ -131,6 +137,32 @@ class ValidatorRule;
  *      c->setStash({QStringLiteral("template), QStringLiteral("myform.html")});
  * }
  * \endcode
+ *
+ * \par Automatically filling the stash
+ *
+ * If you set the Validator::FillStashOnError on the validate() function that takes a Context pointer,
+ * the Validator will automatically fill the \link Context::stash() stash \endlink of the Context with error
+ * information and field values that are not sensible (field names that do not contain \c password).
+ *
+ * Beside the field values added with their field names, Validator will add two more entries to the stash:
+ * \li \a validationErrorStrings - a QStringList containing a list of all validation error messages
+ * \li \a validationErrorFields - a QStringList containting a list of field names that have validation errors
+ *
+ * Let's assume that a user enters the following values into the form fields from the above example:
+ * \li \c username = detlef
+ * \li \c email = detlef\@irgendwo
+ * \li \c password = schalke04
+ * \li \c password_confirmation = schalke05
+ *
+ * The validation will fail, because the email address is not valid and the password confirmation does not match the password.
+ * Validator will add the following entries to the \link Context::stash() stash \endlink:
+ * \li \c username: "detlef"
+ * \li \c email: "detlef@irgendwo"
+ * \li \c validationErrorStrings: ["The email address in the “Email” field is not valid.", "Please enter the same password again in the confirmation field."]
+ * \li \c validationErrorFields: ["email", "password"]
+ *
+ * The sensible data of the password fields is not part of the stash, but the other values can be used to prefill the form fields for the next attempt of
+ * our little Schalke fan and can give him some hints what was wrong.
  */
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT Validator
 {
@@ -141,7 +173,7 @@ public:
     enum ValidatorFlag {
         NoSpecialBehavior   = 0,    /**< No special behavior, the default. */
         StopOnFirstError    = 1,    /**< Will stop the validation process on the first failed validation. */
-        FillStashOnError    = 2,    /**< Will use the fillStash() function to fill the context's stash with error information. Will therfore only have an effect, if validate() has been started with a valid Context. */
+        FillStashOnError    = 2,    /**< Will fill the context's stash with error information. Will therefore only have an effect, if validate() has been started with a valid Context. */
         NoTrimming          = 4,    /**< Will set ValidatorRule::setTrimBefore() to \c false on every validator. (default behavior is \c true) */
     };
     Q_DECLARE_FLAGS(ValidatorFlags, ValidatorFlag)
@@ -158,7 +190,7 @@ public:
      *
      * This constructor is only available if the compiler supports C++11 std::initializer_list.
      */
-    Validator(std::initializer_list<ValidatorRule*> validators);
+    explicit Validator(std::initializer_list<ValidatorRule*> validators);
 
     /*!
      * \brief Constructs a new Validator using the defined \a validators and \a labelDictionary.
@@ -184,26 +216,28 @@ public:
     void clear();
 
     /*!
-     * \brief Starts the validation process on Context \a c and returns \c true on success.
+     * \brief Starts the validation process on Context \a c and returns a ValidatorResult.
      *
      * Requests the input parameters from Context \a c and processes any validator added through
-     * the constructor or via addValidator() (unless Validator::StopOnFirstError is set). Returns \c true on succeess
-     * and \c false if any validator fails.
+     * the constructor or via addValidator() (unless Validator::StopOnFirstError is set). Returns a
+     * ValidatorResult that contains information about validation errors, if any. The result can be checked
+     * directly in \c if statements.
      *
-     * If Validator::FillStashOnError is set, it will use fillStash() to fill the stash of Context \c with error data
-     * and the input values.
+     * If Validator::FillStashOnError is set, it will fill the stash of Context \c with error data and not
+     * sensible input values.
      */
-    bool validate(Context *c, ValidatorFlags flags = NoSpecialBehavior) const;
+    ValidatorResult validate(Context *c, ValidatorFlags flags = NoSpecialBehavior) const;
 
     /*!
      * \brief Starts the validation process on the \a parameters and returns \c true on success.
      *
      * Processes any validator added through the constructor or via addValidator() (unless Validator::StopOnFirstError is set).
-     * Returns \c true on success and \c false if any validator fails.
+     * Returns a ValidatorResult that contains information about validation errors, if any. The result can be checked
+     * directly in \c if statements.
      *
      * Validator::FillStashOnError will not have any effect if using this function.
      */
-    bool validate(const ParamsMultiMap &parameters, ValidatorFlags flags = NoSpecialBehavior) const;
+    ValidatorResult validate(const ParamsMultiMap &parameters, ValidatorFlags flags = NoSpecialBehavior) const;
 
     /*!
      * \brief Adds a new validator to the list of validators.
@@ -212,20 +246,6 @@ public:
      * all added rules will get destroyed, too.
      */
     void addValidator(ValidatorRule *v);
-
-    /*!
-     * \brief Returns a list of all error strings.
-     *
-     * If validation fails, this will return a list of error messages from every failed validator.
-     */
-    QVariantList errorStrings() const;
-
-    /*!
-     * \brief Returns a list of all fields with errors.
-     *
-     * If validation fails, this will return a list of field names where validation failed.
-     */
-    QVariantList errorFields() const;
 
     /*!
      * \brief Sets a new label dictionary.
@@ -262,62 +282,6 @@ public:
      * \sa setLabelDictionary(), addLabelDictionary()
      */
     void addLabel(const QString &field, const QString &label);
-
-    /*!
-     * \brief Fills the stash of Context \a c with error information and input data.
-     *
-     * Fills the \link Context::stash() stash \endlink of Context \a c with error information and the input data.
-     *
-     * Validator will add all input fields with their names back to the stash, except those that contain the word \a password.
-     * Additionally it will set two more entries to the stash: \a validationErrorStrings contains a list of all validation
-     * error messages and \a validationErrorFields will contain a list of field names that have validation errors.
-     *
-     * If you call validate() with a valid Context and set the FillStashOnError flag, the Validator will automatically
-     * call this function with the Context provided to the validate() function.
-     *
-     * \par Example
-     *
-     * \code{.cpp}
-     * void MyController::MyForm(Context *c)
-     * {
-     *      if (c->req()->isPost()) {
-     *          Validator v;
-     *          v.addValidator(new ValidatorRequired("name"));
-     *          v.addValidator(new ValiadtorRequired("email"));
-     *          v.addValidator(new ValidatorEmail("email"));
-     *          v.addValidator(new ValidatorRequired("password"));
-     *          v.addValidator(new ValidatorConfirmed("password"));
-     *
-     *          if (v.validate(c)) {
-     *              // do something useful with the input data
-     *              c->response()->redirect(uriFor("nextstep"));
-     *          } else {
-     *              // handle the errors
-     *              v.fillStash(c);
-     *          }
-     *      }
-     *
-     *      c->setStash("template", "myform.html");
-     * }
-     * \endcode
-     *
-     * Lets now assume the user enters the following values:
-     * \li \c username = detlef
-     * \li \c email = detlef\@irgendwo
-     * \li \c password = schalke04
-     * \li \c password_confirmation = schalke05
-     *
-     * The validation will fail, because the email address is not valid and the password confirmation does not match the password. The stash will contain the
-     * following values:
-     * \li \c username: "detlef"
-     * \li \c email: "detlef@irgendwo"
-     * \li \c validationErrorStrings: ["The email address in the “email” field is not valid.", "The content of the “password” field has not been confirmed."]
-     * \li \c validationErrorFields: ["email", "password"]
-     *
-     * The sensible data of the password fields is not part of the stash, but the other values can be used to prefill the form fields for the next attempt of
-     * our little Schalke fan and can give him some hints what was wrong.
-     */
-    void fillStash(Context *c) const;
 
 protected:
     const QScopedPointer<ValidatorPrivate> d_ptr;

--- a/Cutelyst/Plugins/Utils/Validator/validatoraccepted.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoraccepted.cpp
@@ -40,12 +40,14 @@ ValidatorAccepted::~ValidatorAccepted()
 
 QString ValidatorAccepted::validate() const
 {
-    QStringList l({QStringLiteral("yes"), QStringLiteral("on"), QStringLiteral("1"), QStringLiteral("true")});
-    if (l.contains(value(), Qt::CaseInsensitive)) {
-        return QString();
-    } else {
-        return validationError();
+    QString result;
+
+    static const QStringList l({QStringLiteral("yes"), QStringLiteral("on"), QStringLiteral("1"), QStringLiteral("true")});
+    if (!l.contains(value(), Qt::CaseInsensitive)) {
+        result = validationError();
     }
+
+    return result;
 }
 
 QString ValidatorAccepted::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatoraccepted.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoraccepted.cpp
@@ -52,5 +52,5 @@ QString ValidatorAccepted::validate() const
 
 QString ValidatorAccepted::genericValidationError() const
 {
-    return QStringLiteral("The “%1” has to be accepted.").arg(fieldLabel());
+    return QStringLiteral("The %1 has to be accepted.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoraccepted.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoraccepted.cpp
@@ -38,18 +38,17 @@ ValidatorAccepted::~ValidatorAccepted()
 
 }
 
-bool ValidatorAccepted::validate()
+QString ValidatorAccepted::validate() const
 {
     QStringList l({QStringLiteral("yes"), QStringLiteral("on"), QStringLiteral("1"), QStringLiteral("true")});
     if (l.contains(value(), Qt::CaseInsensitive)) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     } else {
-        return false;
+        return validationError();
     }
 }
 
-QString ValidatorAccepted::genericErrorMessage() const
+QString ValidatorAccepted::genericValidationError() const
 {
-    return QStringLiteral("The “%1” has to be accepted.").arg(genericFieldName());
+    return QStringLiteral("The “%1” has to be accepted.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoraccepted.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoraccepted.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -52,5 +52,11 @@ QString ValidatorAccepted::validate() const
 
 QString ValidatorAccepted::genericValidationError() const
 {
-    return QStringLiteral("The %1 has to be accepted.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Has to be accepted.");
+    } else {
+        error = QStringLiteral("The “%1” has to be accepted.").arg(label());
+    }
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoraccepted.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoraccepted.h
@@ -55,17 +55,15 @@ public:
     ~ValidatorAccepted();
 
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
 protected:
     /*!
      * \brief Creates a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
 
     ValidatorAccepted(ValidatorAcceptedPrivate &dd);
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorafter.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorafter.cpp
@@ -123,17 +123,17 @@ QString ValidatorAfter::genericValidationError() const
 
     switch(d->date.type()) {
     case QVariant::Date:
-        error = QStringLiteral("The date in the “%1” field must be after %2.").arg(fieldLabel(),
+        error = QStringLiteral("The date in the %1 field must be after %2.").arg(fieldLabel(),
                                                                                    //: date shown in validator error message
                                                                                    d->date.toDate().toString(QStringLiteral("dd.MM.yyyy")));
         break;
     case QVariant::DateTime:
-        error = QStringLiteral("The date and time in the “%1” field must be after %2.").arg(fieldLabel(),
+        error = QStringLiteral("The date and time in the %1 field must be after %2.").arg(fieldLabel(),
                                                                                             //: date and time shown in validator error message
                                                                                             d->date.toDateTime().toString(QStringLiteral("dd.MM.yyyy HH:mm")));
         break;
     case QVariant::Time:
-        error = QStringLiteral("The time in the “%1” field must be after %2.").arg(fieldLabel(),
+        error = QStringLiteral("The time in the %1 field must be after %2.").arg(fieldLabel(),
                                                                                    //: time shown in the validator error message
                                                                                    d->date.toTime().toString(QStringLiteral("dd.MM.yyyy HH:mm")));
         break;

--- a/Cutelyst/Plugins/Utils/Validator/validatorafter.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorafter.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -121,25 +121,45 @@ QString ValidatorAfter::genericValidationError() const
 
     Q_D(const ValidatorAfter);
 
-    switch(d->date.type()) {
+    QString compDateTime;
+
+    switch (d->date.type()) {
     case QVariant::Date:
-        error = QStringLiteral("The date in the %1 field must be after %2.").arg(fieldLabel(),
-                                                                                   //: date shown in validator error message
-                                                                                   d->date.toDate().toString(QStringLiteral("dd.MM.yyyy")));
+        //: date shown in validator error message
+        compDateTime = d->date.toDate().toString(QStringLiteral("dd.MM.yyyy"));
         break;
     case QVariant::DateTime:
-        error = QStringLiteral("The date and time in the %1 field must be after %2.").arg(fieldLabel(),
-                                                                                            //: date and time shown in validator error message
-                                                                                            d->date.toDateTime().toString(QStringLiteral("dd.MM.yyyy HH:mm")));
+        //: date and time shown in validator error message
+        compDateTime = d->date.toDateTime().toString(QStringLiteral("dd.MM.yyyy HH:mm"));
         break;
     case QVariant::Time:
-        error = QStringLiteral("The time in the %1 field must be after %2.").arg(fieldLabel(),
-                                                                                   //: time shown in the validator error message
-                                                                                   d->date.toTime().toString(QStringLiteral("dd.MM.yyyy HH:mm")));
-        break;
+        //: time shown in the validator error message
+        compDateTime = d->date.toTime().toString(QStringLiteral("dd.MM.yyyy HH:mm"));
     default:
-        error = validationDataError();
         break;
+    }
+
+    if (label().isEmpty()) {
+
+        error = QStringLiteral("Has to be after %1.").arg(compDateTime);
+
+    } else {
+
+        switch(d->date.type()) {
+        case QVariant::Date:
+            error = QStringLiteral("The date in the “%1” field must be after %2.").arg(label(), compDateTime);
+            break;
+        case QVariant::DateTime:
+            error = QStringLiteral("The date and time in the “%1” field must be after %2.").arg(label(), compDateTime);
+            break;
+        case QVariant::Time:
+            error = QStringLiteral("The time in the “%1” field must be after %2.").arg(label(), compDateTime);
+            break;
+        default:
+            error = validationDataError();
+            break;
+        }
+
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatorafter.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorafter.cpp
@@ -42,110 +42,99 @@ ValidatorAfter::~ValidatorAfter()
 
 }
 
-bool ValidatorAfter::validate()
+QString ValidatorAfter::validate() const
 {
-    Q_D(ValidatorAfter);
+    Q_D(const ValidatorAfter);
 
     QString v = value();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     if (d->date.type() == QVariant::Date) {
 
         QDate odate = d->date.toDate();
         if (!odate.isValid()) {
-            setError(ValidatorRule::ValidationDataError);
             qCWarning(C_VALIDATORAFTER) << "Invalid validation date.";
-            return false;
+            return validationDataError();
         }
         QDate date = d->extractDate(v, d->inputFormat);
         if (!date.isValid()) {
-            setError(ValidatorRule::ParsingError);
             qCWarning(C_VALIDATORAFTER) << "Can not parse input date:" << v;
-            return false;
+            return parsingError();
         }
         if (date > odate) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         } else {
-            return false;
+            return validationError();
         }
 
     } else if (d->date.type() == QVariant::DateTime) {
 
         QDateTime odatetime = d->date.toDateTime();
         if (!odatetime.isValid()) {
-            setError(ValidatorRule::ValidationDataError);
             qCWarning(C_VALIDATORAFTER) << "Invalid validation date and time.";
-            return false;
+            return validationDataError();
         }
         QDateTime datetime = d->extractDateTime(v, d->inputFormat);
         if (!datetime.isValid()) {
-            setError(ValidatorRule::ParsingError);
             qCWarning(C_VALIDATORAFTER) << "Can not parse input date and time:" << v;
-            return false;
+            return parsingError();
         }
         if (datetime > odatetime) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         } else {
-            return false;
+            return validationError();
         }
 
     } else if (d->date.type() == QVariant::Time) {
 
         QTime otime = d->date.toTime();
         if (!otime.isValid()) {
-            setError(ValidatorRule::ValidationDataError);
             qCWarning(C_VALIDATORAFTER) << "Invalid validation time.";
-            return false;
+            return validationDataError();
         }
         QTime time = d->extractTime(v, d->inputFormat);
         if (!time.isValid()) {
-            setError(ValidatorRule::ParsingError);
             qCWarning(C_VALIDATORAFTER) << "Can not parse input time:" << v;
-            return false;
+            return parsingError();
         }
         if (time > otime) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         } else {
-            return false;
+            return validationError();
         }
 
     } else {
 
         qCWarning(C_VALIDATORAFTER) << "Invalid validation data:" << d->date;
-        setError(ValidatorRule::ValidationDataError);
-        return false;
+        return validationDataError();
 
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorAfter::genericErrorMessage() const
+QString ValidatorAfter::genericValidationError() const
 {
     Q_D(const ValidatorAfter);
 
     switch(d->date.type()) {
     case QVariant::Date:
-        return QStringLiteral("The date in the “%1” field must be after %2.").arg(genericFieldName(),
+        return QStringLiteral("The date in the “%1” field must be after %2.").arg(fieldLabel(),
                                                                       //: date shown in validator error message
                                                                       d->date.toDate().toString(QStringLiteral("dd.MM.yyyy")));
     case QVariant::DateTime:
-        return QStringLiteral("The date and time in the “%1” field must be after %2.").arg(genericFieldName(),
+        return QStringLiteral("The date and time in the “%1” field must be after %2.").arg(fieldLabel(),
                                                                                //: date and time shown in validator error message
                                                                                d->date.toDateTime().toString(QStringLiteral("dd.MM.yyyy HH:mm")));
     case QVariant::Time:
-        return QStringLiteral("The time in the “%1” field must be after %2.").arg(genericFieldName(),
+        return QStringLiteral("The time in the “%1” field must be after %2.").arg(fieldLabel(),
                                                                       //: time shown in the validator error message
                                                                       d->date.toTime().toString(QStringLiteral("dd.MM.yyyy HH:mm")));
     default:
-        return QString();
+        return validationDataError();
     }
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorafter.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorafter.cpp
@@ -44,98 +44,105 @@ ValidatorAfter::~ValidatorAfter()
 
 QString ValidatorAfter::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorAfter);
 
-    QString v = value();
+    const QString v = value();
 
-    if (v.isEmpty()) {
-        return QString();
+    if (!v.isEmpty()) {
+
+        if (d->date.type() == QVariant::Date) {
+
+            QDate odate = d->date.toDate();
+            if (!odate.isValid()) {
+                qCWarning(C_VALIDATORAFTER) << "Invalid validation date.";
+                result = validationDataError();
+            } else {
+                QDate date = d->extractDate(v, d->inputFormat);
+                if (!date.isValid()) {
+                    qCWarning(C_VALIDATORAFTER) << "Can not parse input date:" << v;
+                    result = parsingError();
+                } else {
+                    if (date <= odate) {
+                        result = validationError();
+                    }
+                }
+            }
+
+        } else if (d->date.type() == QVariant::DateTime) {
+
+            QDateTime odatetime = d->date.toDateTime();
+            if (!odatetime.isValid()) {
+                qCWarning(C_VALIDATORAFTER) << "Invalid validation date and time.";
+                result = validationDataError();
+            } else {
+                QDateTime datetime = d->extractDateTime(v, d->inputFormat);
+                if (!datetime.isValid()) {
+                    qCWarning(C_VALIDATORAFTER) << "Can not parse input date and time:" << v;
+                    result = parsingError();
+                } else {
+                    if (datetime <= odatetime) {
+                        result = validationError();
+                    }
+                }
+            }
+
+        } else if (d->date.type() == QVariant::Time) {
+
+            QTime otime = d->date.toTime();
+            if (!otime.isValid()) {
+                qCWarning(C_VALIDATORAFTER) << "Invalid validation time.";
+                result = validationDataError();
+            } else {
+                QTime time = d->extractTime(v, d->inputFormat);
+                if (!time.isValid()) {
+                    qCWarning(C_VALIDATORAFTER) << "Can not parse input time:" << v;
+                    result = parsingError();
+                } else {
+                    if (time <= otime) {
+                        result = validationError();
+                    }
+                }
+            }
+
+        } else {
+            qCWarning(C_VALIDATORAFTER) << "Invalid validation data:" << d->date;
+            result = validationDataError();
+        }
     }
 
-    if (d->date.type() == QVariant::Date) {
-
-        QDate odate = d->date.toDate();
-        if (!odate.isValid()) {
-            qCWarning(C_VALIDATORAFTER) << "Invalid validation date.";
-            return validationDataError();
-        }
-        QDate date = d->extractDate(v, d->inputFormat);
-        if (!date.isValid()) {
-            qCWarning(C_VALIDATORAFTER) << "Can not parse input date:" << v;
-            return parsingError();
-        }
-        if (date > odate) {
-            return QString();
-        } else {
-            return validationError();
-        }
-
-    } else if (d->date.type() == QVariant::DateTime) {
-
-        QDateTime odatetime = d->date.toDateTime();
-        if (!odatetime.isValid()) {
-            qCWarning(C_VALIDATORAFTER) << "Invalid validation date and time.";
-            return validationDataError();
-        }
-        QDateTime datetime = d->extractDateTime(v, d->inputFormat);
-        if (!datetime.isValid()) {
-            qCWarning(C_VALIDATORAFTER) << "Can not parse input date and time:" << v;
-            return parsingError();
-        }
-        if (datetime > odatetime) {
-            return QString();
-        } else {
-            return validationError();
-        }
-
-    } else if (d->date.type() == QVariant::Time) {
-
-        QTime otime = d->date.toTime();
-        if (!otime.isValid()) {
-            qCWarning(C_VALIDATORAFTER) << "Invalid validation time.";
-            return validationDataError();
-        }
-        QTime time = d->extractTime(v, d->inputFormat);
-        if (!time.isValid()) {
-            qCWarning(C_VALIDATORAFTER) << "Can not parse input time:" << v;
-            return parsingError();
-        }
-        if (time > otime) {
-            return QString();
-        } else {
-            return validationError();
-        }
-
-    } else {
-
-        qCWarning(C_VALIDATORAFTER) << "Invalid validation data:" << d->date;
-        return validationDataError();
-
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorAfter::genericValidationError() const
 {
+    QString error;
+
     Q_D(const ValidatorAfter);
 
     switch(d->date.type()) {
     case QVariant::Date:
-        return QStringLiteral("The date in the “%1” field must be after %2.").arg(fieldLabel(),
-                                                                      //: date shown in validator error message
-                                                                      d->date.toDate().toString(QStringLiteral("dd.MM.yyyy")));
+        error = QStringLiteral("The date in the “%1” field must be after %2.").arg(fieldLabel(),
+                                                                                   //: date shown in validator error message
+                                                                                   d->date.toDate().toString(QStringLiteral("dd.MM.yyyy")));
+        break;
     case QVariant::DateTime:
-        return QStringLiteral("The date and time in the “%1” field must be after %2.").arg(fieldLabel(),
-                                                                               //: date and time shown in validator error message
-                                                                               d->date.toDateTime().toString(QStringLiteral("dd.MM.yyyy HH:mm")));
+        error = QStringLiteral("The date and time in the “%1” field must be after %2.").arg(fieldLabel(),
+                                                                                            //: date and time shown in validator error message
+                                                                                            d->date.toDateTime().toString(QStringLiteral("dd.MM.yyyy HH:mm")));
+        break;
     case QVariant::Time:
-        return QStringLiteral("The time in the “%1” field must be after %2.").arg(fieldLabel(),
-                                                                      //: time shown in the validator error message
-                                                                      d->date.toTime().toString(QStringLiteral("dd.MM.yyyy HH:mm")));
+        error = QStringLiteral("The time in the “%1” field must be after %2.").arg(fieldLabel(),
+                                                                                   //: time shown in the validator error message
+                                                                                   d->date.toTime().toString(QStringLiteral("dd.MM.yyyy HH:mm")));
+        break;
     default:
-        return validationDataError();
+        error = validationDataError();
+        break;
     }
+
+    return error;
 }
 
 void ValidatorAfter::setDateTime(const QVariant &dateTime)

--- a/Cutelyst/Plugins/Utils/Validator/validatorafter.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorafter.h
@@ -66,11 +66,9 @@ public:
     ~ValidatorAfter();
 
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the QDate, QTime or QDateTime to compare against.
@@ -83,7 +81,7 @@ public:
     void setInputFormat(const QString &format);
 
 protected:
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
 
     ValidatorAfter(ValidatorAfterPrivate &dd);
 

--- a/Cutelyst/Plugins/Utils/Validator/validatoralpha.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralpha.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -52,5 +52,11 @@ QString ValidatorAlpha::validate() const
 
 QString ValidatorAlpha::genericValidationError() const
 {
-    return QStringLiteral("The text in the %1 field must be entirely alphabetic characters.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Must be entirely alphabetic characters.");
+    } else {
+        error = QStringLiteral("The text in the “%1” field must be entirely alphabetic characters.").arg(label());
+    }
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoralpha.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralpha.cpp
@@ -41,15 +41,13 @@ ValidatorAlpha::~ValidatorAlpha()
 
 QString ValidatorAlpha::validate() const
 {
-    if (value().isEmpty()) {
-        return QString();
+    QString result;
+
+    if (!value().isEmpty() && !value().contains(QRegularExpression(QStringLiteral("^[\\pL\\pM]+$")))) {
+        result = validationError();
     }
 
-    if (value().contains(QRegularExpression(QStringLiteral("^[\\pL\\pM]+$")))) {
-        return QString();
-    } else {
-        return validationError();
-    }
+    return result;
 }
 
 QString ValidatorAlpha::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatoralpha.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralpha.cpp
@@ -52,5 +52,5 @@ QString ValidatorAlpha::validate() const
 
 QString ValidatorAlpha::genericValidationError() const
 {
-    return QStringLiteral("The text in the “%1” field must be entirely alphabetic characters.").arg(fieldLabel());
+    return QStringLiteral("The text in the %1 field must be entirely alphabetic characters.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoralpha.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralpha.cpp
@@ -39,22 +39,20 @@ ValidatorAlpha::~ValidatorAlpha()
 
 }
 
-bool ValidatorAlpha::validate()
+QString ValidatorAlpha::validate() const
 {
     if (value().isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     if (value().contains(QRegularExpression(QStringLiteral("^[\\pL\\pM]+$")))) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     } else {
-        return false;
+        return validationError();
     }
 }
 
-QString ValidatorAlpha::genericErrorMessage() const
+QString ValidatorAlpha::genericValidationError() const
 {
-    return QStringLiteral("The text in the “%1” field must be entirely alphabetic characters.").arg(genericFieldName());
+    return QStringLiteral("The text in the “%1” field must be entirely alphabetic characters.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoralpha.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralpha.h
@@ -65,17 +65,15 @@ public:
     ~ValidatorAlpha();
 
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
 protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
 
     ValidatorAlpha(ValidatorAlphaPrivate &dd);
 

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphadash.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphadash.cpp
@@ -41,15 +41,13 @@ ValidatorAlphaDash::~ValidatorAlphaDash()
 
 QString ValidatorAlphaDash::validate() const
 {
-    if (value().isEmpty()) {
-        return QString();
+    QString result;
+
+    if (!value().isEmpty() && !value().contains(QRegularExpression(QStringLiteral("^[\\pL\\pM\\pN_-]+$")))) {
+        result = validationError();
     }
 
-    if (value().contains(QRegularExpression(QStringLiteral("^[\\pL\\pM\\pN_-]+$")))) {
-        return QString();
-    } else {
-        return validationError();
-    }
+    return result;
 }
 
 QString ValidatorAlphaDash::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphadash.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphadash.cpp
@@ -52,5 +52,5 @@ QString ValidatorAlphaDash::validate() const
 
 QString ValidatorAlphaDash::genericValidationError() const
 {
-    return QStringLiteral("The “%1” field can only contain alpha-numeric characters, as well as dashes and underscores, but nothing else.").arg(fieldLabel());
+    return QStringLiteral("The %1 field can only contain alpha-numeric characters, as well as dashes and underscores, but nothing else.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphadash.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphadash.cpp
@@ -39,22 +39,20 @@ ValidatorAlphaDash::~ValidatorAlphaDash()
 
 }
 
-bool ValidatorAlphaDash::validate()
+QString ValidatorAlphaDash::validate() const
 {
     if (value().isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     if (value().contains(QRegularExpression(QStringLiteral("^[\\pL\\pM\\pN_-]+$")))) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     } else {
-        return false;
+        return validationError();
     }
 }
 
-QString ValidatorAlphaDash::genericErrorMessage() const
+QString ValidatorAlphaDash::genericValidationError() const
 {
-    return QStringLiteral("The “%1” field can only contain alpha-numeric characters, as well as dashes and underscores, but nothing else.").arg(genericFieldName());
+    return QStringLiteral("The “%1” field can only contain alpha-numeric characters, as well as dashes and underscores, but nothing else.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphadash.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphadash.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -52,5 +52,11 @@ QString ValidatorAlphaDash::validate() const
 
 QString ValidatorAlphaDash::genericValidationError() const
 {
-    return QStringLiteral("The %1 field can only contain alpha-numeric characters, as well as dashes and underscores, but nothing else.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Can only contain alpha-numeric characters, dashes and underscores.");
+    } else {
+        error = QStringLiteral("The “%1” field can only contain alpha-numeric characters, as well as dashes and underscores, but nothing else.").arg(label());
+    }
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphadash.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphadash.h
@@ -64,17 +64,15 @@ public:
     ~ValidatorAlphaDash();
 
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
 protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
 
     ValidatorAlphaDash(ValidatorAlphaDashPrivate &dd);
 

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphanum.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphanum.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -52,5 +52,11 @@ QString ValidatorAlphaNum::validate() const
 
 QString ValidatorAlphaNum::genericValidationError() const
 {
-    return QStringLiteral("The text in the %1 field must be entirely alpha-numeric characters.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Must be entirely alpha-numeric characters.");
+    } else {
+        error = QStringLiteral("The text in the “%1” field must be entirely alpha-numeric characters.").arg(label());
+    }
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphanum.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphanum.cpp
@@ -41,15 +41,13 @@ ValidatorAlphaNum::~ValidatorAlphaNum()
 
 QString ValidatorAlphaNum::validate() const
 {
-    if (value().isEmpty()) {
-        return QString();
+    QString result;
+
+    if (!value().isEmpty() && !value().contains(QRegularExpression(QStringLiteral("^[\\pL\\pM\\pN]+$")))) {
+        result = validationError();
     }
 
-    if (value().contains(QRegularExpression(QStringLiteral("^[\\pL\\pM\\pN]+$")))) {
-        return QString();
-    } else {
-        return validationError();
-    }
+    return result;
 }
 
 QString ValidatorAlphaNum::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphanum.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphanum.cpp
@@ -39,22 +39,20 @@ ValidatorAlphaNum::~ValidatorAlphaNum()
 
 }
 
-bool ValidatorAlphaNum::validate()
+QString ValidatorAlphaNum::validate() const
 {
     if (value().isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     if (value().contains(QRegularExpression(QStringLiteral("^[\\pL\\pM\\pN]+$")))) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     } else {
-        return false;
+        return validationError();
     }
 }
 
-QString ValidatorAlphaNum::genericErrorMessage() const
+QString ValidatorAlphaNum::genericValidationError() const
 {
-    return QStringLiteral("The text in the “%1” field must be entirely alpha-numeric characters.").arg(genericFieldName());
+    return QStringLiteral("The text in the “%1” field must be entirely alpha-numeric characters.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphanum.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphanum.cpp
@@ -52,5 +52,5 @@ QString ValidatorAlphaNum::validate() const
 
 QString ValidatorAlphaNum::genericValidationError() const
 {
-    return QStringLiteral("The text in the “%1” field must be entirely alpha-numeric characters.").arg(fieldLabel());
+    return QStringLiteral("The text in the %1 field must be entirely alpha-numeric characters.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphanum.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphanum.h
@@ -64,17 +64,15 @@ public:
     ~ValidatorAlphaNum();
 
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
 protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
 
     ValidatorAlphaNum(ValidatorAlphaNumPrivate &dd);
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorbefore.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbefore.cpp
@@ -120,17 +120,17 @@ QString ValidatorBefore::genericValidationError() const
 
     switch(d->date.type()) {
     case QVariant::Date:
-        error = QStringLiteral("The date in the “%1” field must be before %2.").arg(fieldLabel(),
+        error = QStringLiteral("The date in the %1 field must be before %2.").arg(fieldLabel(),
                                                                                     //: date shown in validator error message
                                                                                     d->date.toDate().toString(QStringLiteral("dd.MM.yyyy")));
         break;
     case QVariant::DateTime:
-        error = QStringLiteral("The date and time in the “%1” field must be before %2.").arg(fieldLabel(),
+        error = QStringLiteral("The date and time in the %1 field must be before %2.").arg(fieldLabel(),
                                                                                              //: date and time shown in validator error message
                                                                                              d->date.toDateTime().toString(QStringLiteral("dd.MM.yyyy HH:mm")));
         break;
     case QVariant::Time:
-        error = QStringLiteral("The time in the “%1” field must be before %2.").arg(fieldLabel(),
+        error = QStringLiteral("The time in the %1 field must be before %2.").arg(fieldLabel(),
                                                                                     //: time shown in the validator error message
                                                                                     d->date.toTime().toString(QStringLiteral("HH:mm")));
         break;

--- a/Cutelyst/Plugins/Utils/Validator/validatorbefore.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbefore.cpp
@@ -39,110 +39,99 @@ ValidatorBefore::~ValidatorBefore()
 {
 }
 
-bool ValidatorBefore::validate()
+QString ValidatorBefore::validate() const
 {
-    Q_D(ValidatorBefore);
+    Q_D(const ValidatorBefore);
 
     QString v = value();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     if (d->date.type() == QVariant::Date) {
 
         QDate odate = d->date.toDate();
         if (!odate.isValid()) {
-            setError(ValidatorRule::ValidationDataError);
             qCWarning(C_VALIDATORBEFORE) << "Invalid validation date.";
-            return false;
+            return validationDataError();
         }
         QDate date = d->extractDate(v, d->inputFormat);
         if (!date.isValid()) {
-            setError(ValidatorRule::ParsingError);
             qCWarning(C_VALIDATORBEFORE) << "Can not parse input date:" << v;
-            return false;
+            return parsingError();
         }
         if (date < odate) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         } else {
-            return false;
+            return validationError();
         }
 
     } else if (d->date.type() == QVariant::DateTime) {
 
         QDateTime odatetime = d->date.toDateTime();
         if (!odatetime.isValid()) {
-            setError(ValidatorRule::ValidationDataError);
             qCWarning(C_VALIDATORBEFORE) << "Invalid validation date and time.";
-            return false;
+            return validationDataError();
         }
         QDateTime datetime = d->extractDateTime(v, d->inputFormat);
         if (!datetime.isValid()) {
-            setError(ValidatorRule::ParsingError);
             qCWarning(C_VALIDATORBEFORE) << "Can not parse input date and time:" << v;
-            return false;
+            return parsingError();
         }
         if (datetime < odatetime) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         } else {
-            return false;
+            return validationError();
         }
 
     } else if (d->date.type() == QVariant::Time) {
 
         QTime otime = d->date.toTime();
         if (!otime.isValid()) {
-            setError(ValidatorRule::ValidationDataError);
             qCWarning(C_VALIDATORBEFORE) << "Invalid validation time.";
-            return false;
+            return validationDataError();
         }
         QTime time = d->extractTime(v, d->inputFormat);
         if (!time.isValid()) {
-            setError(ValidatorRule::ParsingError);
             qCWarning(C_VALIDATORBEFORE) << "Can not parse input time:" << v;
-            return false;
+            return parsingError();
         }
         if (time < otime) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         } else {
-            return false;
+            return validationError();
         }
 
     } else {
 
         qCWarning(C_VALIDATORBEFORE) << "Invalid validation data:" << d->date;
-        setError(ValidatorRule::ValidationDataError);
-        return false;
+        return validationDataError();
 
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorBefore::genericErrorMessage() const
+QString ValidatorBefore::genericValidationError() const
 {
     Q_D(const ValidatorBefore);
 
     switch(d->date.type()) {
     case QVariant::Date:
-        return QStringLiteral("The date in the “%1” field must be before %2.").arg(genericFieldName(),
+        return QStringLiteral("The date in the “%1” field must be before %2.").arg(fieldLabel(),
                                                                       //: date shown in validator error message
                                                                       d->date.toDate().toString(QStringLiteral("dd.MM.yyyy")));
     case QVariant::DateTime:
-        return QStringLiteral("The date and time in the “%1” field must be before %2.").arg(genericFieldName(),
+        return QStringLiteral("The date and time in the “%1” field must be before %2.").arg(fieldLabel(),
                                                                                //: date and time shown in validator error message
                                                                                d->date.toDateTime().toString(QStringLiteral("dd.MM.yyyy HH:mm")));
     case QVariant::Time:
-        return QStringLiteral("The time in the “%1” field must be before %2.").arg(genericFieldName(),
+        return QStringLiteral("The time in the “%1” field must be before %2.").arg(fieldLabel(),
                                                                       //: time shown in the validator error message
                                                                       d->date.toTime().toString(QStringLiteral("HH:mm")));
     default:
-        return QString();
+        return validationDataError();
     }
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorbefore.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbefore.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -118,25 +118,44 @@ QString ValidatorBefore::genericValidationError() const
 
     Q_D(const ValidatorBefore);
 
-    switch(d->date.type()) {
+    QString compDateTime;
+
+    switch (d->date.type()) {
     case QVariant::Date:
-        error = QStringLiteral("The date in the %1 field must be before %2.").arg(fieldLabel(),
-                                                                                    //: date shown in validator error message
-                                                                                    d->date.toDate().toString(QStringLiteral("dd.MM.yyyy")));
+        //: date shown in validator error message
+        compDateTime = d->date.toDate().toString(QStringLiteral("dd.MM.yyyy"));
         break;
     case QVariant::DateTime:
-        error = QStringLiteral("The date and time in the %1 field must be before %2.").arg(fieldLabel(),
-                                                                                             //: date and time shown in validator error message
-                                                                                             d->date.toDateTime().toString(QStringLiteral("dd.MM.yyyy HH:mm")));
+        //: date and time shown in validator error message
+        compDateTime = d->date.toDateTime().toString(QStringLiteral("dd.MM.yyyy HH:mm"));
         break;
     case QVariant::Time:
-        error = QStringLiteral("The time in the %1 field must be before %2.").arg(fieldLabel(),
-                                                                                    //: time shown in the validator error message
-                                                                                    d->date.toTime().toString(QStringLiteral("HH:mm")));
-        break;
+        //: time shown in the validator error message
+        compDateTime = d->date.toTime().toString(QStringLiteral("dd.MM.yyyy HH:mm"));
     default:
-        error = validationDataError();
         break;
+    }
+
+    if (label().isEmpty()) {
+
+        error = QStringLiteral("Must be before %1.").arg(compDateTime);
+
+    } else {
+
+        switch(d->date.type()) {
+        case QVariant::Date:
+            error = QStringLiteral("The date in the “%1” field must be before “%2”.").arg(label(), compDateTime);
+            break;
+        case QVariant::DateTime:
+            error = QStringLiteral("The date and time in the “%1” field must be before “%2”.").arg(label(), compDateTime);
+            break;
+        case QVariant::Time:
+            error = QStringLiteral("The time in the “%1” field must be before “%2”.").arg(label(), compDateTime);
+            break;
+        default:
+            error = validationDataError();
+            break;
+        }
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatorbefore.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbefore.h
@@ -66,11 +66,9 @@ public:
     ~ValidatorBefore();
 
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the QDate, QTime or QDateTime to compare against.
@@ -86,7 +84,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
 
     ValidatorBefore(ValidatorBeforePrivate &dd);
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorbetween.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbetween.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -88,14 +88,44 @@ QString ValidatorBetween::genericValidationError() const
 
     Q_D(const ValidatorBetween);
 
-    if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        error = QStringLiteral("The value of the %1 field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
-    } else if (d->type == QMetaType::Float) {
-        error = QStringLiteral("The value of the %1 field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min), QString::number(d->max));
-    } else if (d->type == QMetaType::QString) {
-        error = QStringLiteral("The length of the %1 field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
+    QString min, max;
+    if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::QString) {
+        min = QString::number(d->min, 'f', 0);
+        max = QString::number(d->max, 'f', 0);
     } else {
-        error = validationDataError();
+        min = QString::number(d->min);
+        max = QString::number(d->max);
+    }
+
+    if (label().isEmpty()) {
+
+        switch (d->type) {
+        case QMetaType::Int:
+        case QMetaType::UInt:
+        case QMetaType::Float:
+            error = QStringLiteral("Value has to be between %1 and %2.").arg(min, max);
+            break;
+        case QMetaType::QString:
+            error = QStringLiteral("Length has to be between %1 and %2.").arg(min, max);
+        default:
+            error = validationDataError();
+            break;
+        }
+
+    } else {
+
+        switch (d->type) {
+        case QMetaType::Int:
+        case QMetaType::UInt:
+        case QMetaType::Float:
+            error = QStringLiteral("The value of the “%1” field has to be between %2 and %3.").arg(label(), min, max);
+            break;
+        case QMetaType::QString:
+            error = QStringLiteral("The length of the “%1” field has to be between %2 and %3.").arg(label(), min, max);
+        default:
+            error = validationDataError();
+            break;
+        }
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatorbetween.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbetween.cpp
@@ -89,11 +89,11 @@ QString ValidatorBetween::genericValidationError() const
     Q_D(const ValidatorBetween);
 
     if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        error = QStringLiteral("The value of the “%1” field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
+        error = QStringLiteral("The value of the %1 field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
     } else if (d->type == QMetaType::Float) {
-        error = QStringLiteral("The value of the “%1” field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min), QString::number(d->max));
+        error = QStringLiteral("The value of the %1 field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min), QString::number(d->max));
     } else if (d->type == QMetaType::QString) {
-        error = QStringLiteral("The length of the “%1” field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
+        error = QStringLiteral("The length of the %1 field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
     } else {
         error = validationDataError();
     }

--- a/Cutelyst/Plugins/Utils/Validator/validatorbetween.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbetween.cpp
@@ -41,60 +41,64 @@ ValidatorBetween::~ValidatorBetween()
 
 QString ValidatorBetween::validate() const
 {
-    QString v = value();
+    QString result;
 
-    if (v.isEmpty()) {
-        return QString();
+    const QString v = value();
+
+    if (!v.isEmpty()) {
+        Q_D(const ValidatorBetween);
+
+        if (d->type == QMetaType::Int) {
+            qlonglong val = v.toLongLong();
+            qlonglong min = (qlonglong)d->min;
+            qlonglong max = (qlonglong)d->max;
+            if ((val < min) || (val > max)) {
+                result = validationError();
+            }
+        } else if (d->type == QMetaType::UInt) {
+            qulonglong val = v.toULongLong();
+            qulonglong min = (qulonglong)d->min;
+            qulonglong max = (qulonglong)d->max;
+            if ((val < min) || (val > max)) {
+                result = validationError();
+            }
+        } else if (d->type == QMetaType::Float) {
+            double val = v.toDouble();
+            if ((val < d->min) || (val > d->max)) {
+                result = validationError();
+            }
+        } else if (d->type == QMetaType::QString) {
+            int val = v.length();
+            int min = (int)d->min;
+            int max = (int)d->max;
+            if ((val < min) || (val > max)) {
+                result = validationError();
+            }
+        } else {
+            result = validationDataError();
+        }
     }
 
-    Q_D(const ValidatorBetween);
-
-    if (d->type == QMetaType::Int) {
-        qlonglong val = v.toLongLong();
-        qlonglong min = (qlonglong)d->min;
-        qlonglong max = (qlonglong)d->max;
-        if ((val >= min) && (val <= max)) {
-            return QString();
-        }
-    } else if (d->type == QMetaType::UInt) {
-        qulonglong val = v.toULongLong();
-        qulonglong min = (qulonglong)d->min;
-        qulonglong max = (qulonglong)d->max;
-        if ((val >= min) && (val <= max)) {
-            return QString();
-        }
-    } else if (d->type == QMetaType::Float) {
-        double val = v.toDouble();
-        if ((val >= d->min) && (val <= d->max)) {
-            return QString();
-        }
-    } else if (d->type == QMetaType::QString) {
-        int val = v.length();
-        int min = (int)d->min;
-        int max = (int)d->max;
-        if ((val >= min) && (val <= max)) {
-            return QString();
-        }
-    } else {
-        return validationDataError();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorBetween::genericValidationError() const
 {
+    QString error;
+
     Q_D(const ValidatorBetween);
 
     if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        return QStringLiteral("The value of the “%1” field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
+        error = QStringLiteral("The value of the “%1” field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
     } else if (d->type == QMetaType::Float) {
-        return QStringLiteral("The value of the “%1” field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min), QString::number(d->max));
+        error = QStringLiteral("The value of the “%1” field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min), QString::number(d->max));
     } else if (d->type == QMetaType::QString) {
-        return QStringLiteral("The length of the “%1” field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
+        error = QStringLiteral("The length of the “%1” field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
     } else {
-        return validationDataError();
+        error = validationDataError();
     }
+
+    return error;
 }
 
 void ValidatorBetween::setType(QMetaType::Type type)

--- a/Cutelyst/Plugins/Utils/Validator/validatorbetween.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbetween.cpp
@@ -39,66 +39,61 @@ ValidatorBetween::~ValidatorBetween()
 
 
 
-bool ValidatorBetween::validate()
+QString ValidatorBetween::validate() const
 {
     QString v = value();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    Q_D(ValidatorBetween);
+    Q_D(const ValidatorBetween);
 
     if (d->type == QMetaType::Int) {
         qlonglong val = v.toLongLong();
         qlonglong min = (qlonglong)d->min;
         qlonglong max = (qlonglong)d->max;
         if ((val >= min) && (val <= max)) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else if (d->type == QMetaType::UInt) {
         qulonglong val = v.toULongLong();
         qulonglong min = (qulonglong)d->min;
         qulonglong max = (qulonglong)d->max;
         if ((val >= min) && (val <= max)) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else if (d->type == QMetaType::Float) {
         double val = v.toDouble();
         if ((val >= d->min) && (val <= d->max)) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else if (d->type == QMetaType::QString) {
         int val = v.length();
         int min = (int)d->min;
         int max = (int)d->max;
         if ((val >= min) && (val <= max)) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else {
-        setError(ValidatorRule::ValidationDataError);
+        return validationDataError();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorBetween::genericErrorMessage() const
+QString ValidatorBetween::genericValidationError() const
 {
     Q_D(const ValidatorBetween);
 
     if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        return QStringLiteral("The value of the “%1” field has to be between %2 and %3.").arg(genericFieldName(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
+        return QStringLiteral("The value of the “%1” field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
     } else if (d->type == QMetaType::Float) {
-        return QStringLiteral("The value of the “%1” field has to be between %2 and %3.").arg(genericFieldName(), QString::number(d->min), QString::number(d->max));
+        return QStringLiteral("The value of the “%1” field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min), QString::number(d->max));
     } else if (d->type == QMetaType::QString) {
-        return QStringLiteral("The length of the “%1” field has to be between %2 and %3.").arg(genericFieldName(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
+        return QStringLiteral("The length of the “%1” field has to be between %2 and %3.").arg(fieldLabel(), QString::number(d->min, 'f', 0), QString::number(d->max, 'f', 0));
     } else {
-        return QString();
+        return validationDataError();
     }
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorbetween.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbetween.h
@@ -70,11 +70,9 @@ public:
     ~ValidatorBetween();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the type to compare.
@@ -97,7 +95,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorBetween(ValidatorBetweenPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorboolean.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorboolean.cpp
@@ -52,6 +52,6 @@ QString ValidatorBoolean::validate() const
 
 QString ValidatorBoolean::genericValidationError() const
 {
-    return QStringLiteral("The data in the “%1” field can not be interpreted as a boolean.").arg(fieldLabel());
+    return QStringLiteral("The data in the %1 field can not be interpreted as a boolean.").arg(fieldLabel());
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorboolean.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorboolean.cpp
@@ -38,16 +38,16 @@ ValidatorBoolean::~ValidatorBoolean()
 
 QString ValidatorBoolean::validate() const
 {
-    if (value().isEmpty()) {
-        return QString();
+    QString result;
+
+    if (!value().isEmpty()) {
+        static const QStringList l({QStringLiteral("1"), QStringLiteral("0"), QStringLiteral("true"), QStringLiteral("false"), QStringLiteral("on"), QStringLiteral("off")});
+        if (!l.contains(value(), Qt::CaseInsensitive)) {
+            result = validationError();
+        }
     }
 
-    QStringList l({QStringLiteral("1"), QStringLiteral("0"), QStringLiteral("true"), QStringLiteral("false"), QStringLiteral("on"), QStringLiteral("off")});
-    if (l.contains(value(), Qt::CaseInsensitive)) {
-        return QString();
-    } else {
-        return validationError();
-    }
+    return result;
 }
 
 QString ValidatorBoolean::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorboolean.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorboolean.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -52,6 +52,12 @@ QString ValidatorBoolean::validate() const
 
 QString ValidatorBoolean::genericValidationError() const
 {
-    return QStringLiteral("The data in the %1 field can not be interpreted as a boolean.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Can not be interpreted as boolean.");
+    } else {
+        error = QStringLiteral("The data in the “%1” field can not be interpreted as a boolean.").arg(label());
+    }
+    return error;
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorboolean.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorboolean.cpp
@@ -36,24 +36,22 @@ ValidatorBoolean::~ValidatorBoolean()
 {
 }
 
-bool ValidatorBoolean::validate()
+QString ValidatorBoolean::validate() const
 {
     if (value().isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     QStringList l({QStringLiteral("1"), QStringLiteral("0"), QStringLiteral("true"), QStringLiteral("false"), QStringLiteral("on"), QStringLiteral("off")});
     if (l.contains(value(), Qt::CaseInsensitive)) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     } else {
-        return false;
+        return validationError();
     }
 }
 
-QString ValidatorBoolean::genericErrorMessage() const
+QString ValidatorBoolean::genericValidationError() const
 {
-    return QStringLiteral("The data in the “%1” field can not be interpreted as a boolean.").arg(genericFieldName());
+    return QStringLiteral("The data in the “%1” field can not be interpreted as a boolean.").arg(fieldLabel());
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorboolean.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorboolean.h
@@ -56,17 +56,15 @@ public:
     ~ValidatorBoolean();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
     
 protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorBoolean(ValidatorBooleanPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorconfirmed.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorconfirmed.cpp
@@ -37,18 +37,18 @@ ValidatorConfirmed::~ValidatorConfirmed()
 
 QString ValidatorConfirmed::validate() const
 {
-    if (value().trimmed().isEmpty()) {
-        return QString();
+    QString result;
+
+    if (!value().isEmpty()) {
+        QString ofn = field();
+        ofn.append(QLatin1String("_confirmation"));
+
+        if (value() != parameters().value(ofn)) {
+            result = validationError();
+        }
     }
 
-    QString ofn = field();
-    ofn.append(QLatin1String("_confirmation"));
-
-    if (value() == parameters().value(ofn)) {
-        return QString();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorConfirmed::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorconfirmed.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorconfirmed.cpp
@@ -53,5 +53,5 @@ QString ValidatorConfirmed::validate() const
 
 QString ValidatorConfirmed::genericValidationError() const
 {
-    return QStringLiteral("The content of the “%1” field has not been confirmed.").arg(fieldLabel());
+    return QStringLiteral("The content of the %1 field has not been confirmed.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorconfirmed.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorconfirmed.cpp
@@ -35,25 +35,23 @@ ValidatorConfirmed::~ValidatorConfirmed()
 {
 }
 
-bool ValidatorConfirmed::validate()
+QString ValidatorConfirmed::validate() const
 {
     if (value().trimmed().isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     QString ofn = field();
     ofn.append(QLatin1String("_confirmation"));
 
     if (value() == parameters().value(ofn)) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorConfirmed::genericErrorMessage() const
+QString ValidatorConfirmed::genericValidationError() const
 {
-    return QStringLiteral("The content of the “%1” field has not been confirmed.").arg(genericFieldName());
+    return QStringLiteral("The content of the “%1” field has not been confirmed.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorconfirmed.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorconfirmed.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -53,5 +53,11 @@ QString ValidatorConfirmed::validate() const
 
 QString ValidatorConfirmed::genericValidationError() const
 {
-    return QStringLiteral("The content of the %1 field has not been confirmed.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Confirmation failed.");
+    } else {
+        error = QStringLiteral("The content of the “%1” field has not been confirmed.").arg(label());
+    }
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorconfirmed.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorconfirmed.h
@@ -58,17 +58,15 @@ public:
     ~ValidatorConfirmed();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
     
 protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorConfirmed(ValidatorConfirmedPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatordate.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordate.cpp
@@ -63,9 +63,9 @@ QString ValidatorDate::genericValidationError() const
     Q_D(const ValidatorDate);
 
     if (!d->format.isEmpty()) {
-        error = QStringLiteral("The data in the “%1” field can not be interpreted as date of this schema: %2").arg(fieldLabel(), d->format);
+        error = QStringLiteral("The data in the %1 field can not be interpreted as date of this schema: %2").arg(fieldLabel(), d->format);
     } else {
-        error = QStringLiteral("The data in the “%1” field can not be interpreted as date.").arg(fieldLabel());
+        error = QStringLiteral("The data in the %1 field can not be interpreted as date.").arg(fieldLabel());
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatordate.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordate.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -62,10 +62,17 @@ QString ValidatorDate::genericValidationError() const
 
     Q_D(const ValidatorDate);
 
-    if (!d->format.isEmpty()) {
-        error = QStringLiteral("The data in the %1 field can not be interpreted as date of this schema: %2").arg(fieldLabel(), d->format);
+    if (label().isEmpty()) {
+
+        error = QStringLiteral("Not a valid date.");
+
     } else {
-        error = QStringLiteral("The data in the %1 field can not be interpreted as date.").arg(fieldLabel());
+
+        if (!d->format.isEmpty()) {
+            error = QStringLiteral("The data in the “%1” field can not be interpreted as date of this schema: “%2”").arg(label(), d->format);
+        } else {
+            error = QStringLiteral("The data in the “%1” field can not be interpreted as date.").arg(label());
+        }
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatordate.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordate.cpp
@@ -37,35 +37,33 @@ ValidatorDate::~ValidatorDate()
 }
 
 
-bool ValidatorDate::validate()
+QString ValidatorDate::validate() const
 {
-    Q_D(ValidatorDate);
+    Q_D(const ValidatorDate);
 
     QString v = value();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     QDate date = d->extractDate(v, d->format);
 
     if (date.isValid()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorDate::genericErrorMessage() const
+QString ValidatorDate::genericValidationError() const
 {
     Q_D(const ValidatorDate);
 
     if (!d->format.isEmpty()) {
-        return QStringLiteral("The data in the “%1” field can not be interpreted as date of this schema: %2").arg(genericFieldName(), d->format);
+        return QStringLiteral("The data in the “%1” field can not be interpreted as date of this schema: %2").arg(fieldLabel(), d->format);
     } else {
-        return QStringLiteral("The data in the “%1” field can not be interpreted as date.").arg(genericFieldName());
+        return QStringLiteral("The data in the “%1” field can not be interpreted as date.").arg(fieldLabel());
     }
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatordate.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordate.cpp
@@ -39,32 +39,36 @@ ValidatorDate::~ValidatorDate()
 
 QString ValidatorDate::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorDate);
 
-    QString v = value();
+    const QString v = value();
 
-    if (v.isEmpty()) {
-        return QString();
+    if (!v.isEmpty()) {
+        const QDate date = d->extractDate(v, d->format);
+
+        if (!date.isValid()) {
+            result = validationError();
+        }
     }
 
-    QDate date = d->extractDate(v, d->format);
-
-    if (date.isValid()) {
-        return QString();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorDate::genericValidationError() const
 {
+    QString error;
+
     Q_D(const ValidatorDate);
 
     if (!d->format.isEmpty()) {
-        return QStringLiteral("The data in the “%1” field can not be interpreted as date of this schema: %2").arg(fieldLabel(), d->format);
+        error = QStringLiteral("The data in the “%1” field can not be interpreted as date of this schema: %2").arg(fieldLabel(), d->format);
     } else {
-        return QStringLiteral("The data in the “%1” field can not be interpreted as date.").arg(fieldLabel());
+        error = QStringLiteral("The data in the “%1” field can not be interpreted as date.").arg(fieldLabel());
     }
+
+    return error;
 }
 
 void ValidatorDate::setFormat(const QString &format)

--- a/Cutelyst/Plugins/Utils/Validator/validatordate.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordate.h
@@ -61,11 +61,9 @@ public:
     ~ValidatorDate();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets an optional date format.
@@ -76,7 +74,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorDate(ValidatorDatePrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatordatetime.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordatetime.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -63,10 +63,17 @@ QString ValidatorDateTime::genericValidationError() const
 
     Q_D(const ValidatorDateTime);
 
-    if (!d->format.isEmpty()) {
-        error = QStringLiteral("The data in the %1 field can not be interpreted as date and time of this schema: %2").arg(fieldLabel(), d->format);
+    if (label().isEmpty()) {
+
+        error = QStringLiteral("Not a valid date and time.");
+
     } else {
-        error = QStringLiteral("The data in the %1 field can not be interpreted as date and time.").arg(fieldLabel());
+
+        if (!d->format.isEmpty()) {
+            error = QStringLiteral("The data in the “%1” field can not be interpreted as date and time of this schema: “%2”").arg(label(), d->format);
+        } else {
+            error = QStringLiteral("The data in the “%1” field can not be interpreted as date and time.").arg(label());
+        }
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatordatetime.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordatetime.cpp
@@ -64,9 +64,9 @@ QString ValidatorDateTime::genericValidationError() const
     Q_D(const ValidatorDateTime);
 
     if (!d->format.isEmpty()) {
-        error = QStringLiteral("The data in the “%1” field can not be interpreted as date and time of this schema: %2").arg(fieldLabel(), d->format);
+        error = QStringLiteral("The data in the %1 field can not be interpreted as date and time of this schema: %2").arg(fieldLabel(), d->format);
     } else {
-        error = QStringLiteral("The data in the “%1” field can not be interpreted as date and time.").arg(fieldLabel());
+        error = QStringLiteral("The data in the %1 field can not be interpreted as date and time.").arg(fieldLabel());
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatordatetime.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordatetime.cpp
@@ -38,35 +38,33 @@ ValidatorDateTime::~ValidatorDateTime()
 {
 }
 
-bool ValidatorDateTime::validate()
+QString ValidatorDateTime::validate() const
 {
-    Q_D(ValidatorDateTime);
+    Q_D(const ValidatorDateTime);
 
     QString v = value().trimmed();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     QDateTime dt = d->extractDateTime(v, d->format);
 
     if (dt.isValid()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorDateTime::genericErrorMessage() const
+QString ValidatorDateTime::genericValidationError() const
 {
     Q_D(const ValidatorDateTime);
 
     if (!d->format.isEmpty()) {
-        return QStringLiteral("The data in the “%1” field can not be interpreted as date and time of this schema: %2").arg(genericFieldName(), d->format);
+        return QStringLiteral("The data in the “%1” field can not be interpreted as date and time of this schema: %2").arg(fieldLabel(), d->format);
     } else {
-        return QStringLiteral("The data in the “%1” field can not be interpreted as date and time.").arg(genericFieldName());
+        return QStringLiteral("The data in the “%1” field can not be interpreted as date and time.").arg(fieldLabel());
     }
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatordatetime.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordatetime.cpp
@@ -40,32 +40,36 @@ ValidatorDateTime::~ValidatorDateTime()
 
 QString ValidatorDateTime::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorDateTime);
 
-    QString v = value().trimmed();
+    const QString v = value().trimmed();
 
-    if (v.isEmpty()) {
-        return QString();
+    if (!v.isEmpty()) {
+        const QDateTime dt = d->extractDateTime(v, d->format);
+
+        if (!dt.isValid()) {
+            result = validationError();
+        }
     }
 
-    QDateTime dt = d->extractDateTime(v, d->format);
-
-    if (dt.isValid()) {
-        return QString();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorDateTime::genericValidationError() const
 {
+    QString error;
+
     Q_D(const ValidatorDateTime);
 
     if (!d->format.isEmpty()) {
-        return QStringLiteral("The data in the “%1” field can not be interpreted as date and time of this schema: %2").arg(fieldLabel(), d->format);
+        error = QStringLiteral("The data in the “%1” field can not be interpreted as date and time of this schema: %2").arg(fieldLabel(), d->format);
     } else {
-        return QStringLiteral("The data in the “%1” field can not be interpreted as date and time.").arg(fieldLabel());
+        error = QStringLiteral("The data in the “%1” field can not be interpreted as date and time.").arg(fieldLabel());
     }
+
+    return error;
 }
 
 void ValidatorDateTime::setFormat(const QString &format)

--- a/Cutelyst/Plugins/Utils/Validator/validatordatetime.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordatetime.h
@@ -60,11 +60,9 @@ public:
     ~ValidatorDateTime();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets an optional date format.
@@ -75,7 +73,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorDateTime(ValidatorDateTimePrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatordifferent.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordifferent.cpp
@@ -35,35 +35,33 @@ ValidatorDifferent::~ValidatorDifferent()
 {
 }
 
-bool ValidatorDifferent::validate()
+QString ValidatorDifferent::validate() const
 {
-    Q_D(ValidatorDifferent);
+    Q_D(const ValidatorDifferent);
 
     QString v = value();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     QString o = d->parameters.value(d->otherField).trimmed();
 
     if (v != o) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorDifferent::genericErrorMessage() const
+QString ValidatorDifferent::genericValidationError() const
 {
     Q_D(const ValidatorDifferent);
 
     QString ogn = !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField;
 
-    return QStringLiteral("The value in the “%1” field has to be different from the value in the “%2” field.").arg(genericFieldName(), ogn);
+    return QStringLiteral("The value in the “%1” field has to be different from the value in the “%2” field.").arg(fieldLabel(), ogn);
 }
 
 void ValidatorDifferent::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatordifferent.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordifferent.cpp
@@ -54,7 +54,7 @@ QString ValidatorDifferent::genericValidationError() const
 {
     Q_D(const ValidatorDifferent);
 
-    return QStringLiteral("The value in the “%1” field has to be different from the value in the “%2” field.").arg(fieldLabel(), !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
+    return QStringLiteral("The value in the %1 field has to be different from the value in the %2 field.").arg(fieldLabel(), !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
 }
 
 void ValidatorDifferent::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatordifferent.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordifferent.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -52,9 +52,17 @@ QString ValidatorDifferent::validate() const
 
 QString ValidatorDifferent::genericValidationError() const
 {
+    QString error;
+
     Q_D(const ValidatorDifferent);
 
-    return QStringLiteral("The value in the %1 field has to be different from the value in the %2 field.").arg(fieldLabel(), !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
+    if (label().isEmpty()) {
+        error = QStringLiteral("Has to be different from the value in “%1”.").arg(!d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
+    } else {
+        error = QStringLiteral("The value in the “%1” field has to be different from the value in the “%2” field.").arg(label(), !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
+    }
+
+    return error;
 }
 
 void ValidatorDifferent::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatordifferent.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordifferent.cpp
@@ -37,31 +37,24 @@ ValidatorDifferent::~ValidatorDifferent()
 
 QString ValidatorDifferent::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorDifferent);
 
-    QString v = value();
+    const QString v = value();
 
-    if (v.isEmpty()) {
-        return QString();
+    if (!v.isEmpty() && (v == d->parameters.value(d->otherField).trimmed())) {
+        result = validationError();
     }
 
-    QString o = d->parameters.value(d->otherField).trimmed();
-
-    if (v != o) {
-        return QString();
-    }
-
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorDifferent::genericValidationError() const
 {
     Q_D(const ValidatorDifferent);
 
-    QString ogn = !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField;
-
-    return QStringLiteral("The value in the “%1” field has to be different from the value in the “%2” field.").arg(fieldLabel(), ogn);
+    return QStringLiteral("The value in the “%1” field has to be different from the value in the “%2” field.").arg(fieldLabel(), !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
 }
 
 void ValidatorDifferent::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatordifferent.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordifferent.h
@@ -59,11 +59,9 @@ public:
     ~ValidatorDifferent();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the name of the other field.
@@ -81,7 +79,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorDifferent(ValidatorDifferentPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatordigits.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigits.cpp
@@ -37,38 +37,36 @@ ValidatorDigits::~ValidatorDigits()
 {
 }
 
-bool ValidatorDigits::validate()
+QString ValidatorDigits::validate() const
 {
-    Q_D(ValidatorDigits);
+    Q_D(const ValidatorDigits);
 
     if (value().isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     if (value().contains(QRegularExpression(QStringLiteral("^[0-9]+$")))) {
         if (d->length > 0) {
             if (value().length() == d->length) {
-                setError(ValidatorRule::NoError);
-                return true;
+                return QString();
             } else {
-                return false;
+                return validationError();
             }
         } else {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else {
-        return false;
+        return validationError();
     }
 }
 
-QString ValidatorDigits::genericErrorMessage() const
+QString ValidatorDigits::genericValidationError() const
 {
-    Q_D(const ValidatorDigits);    if (d->length > 0) {
-        return QStringLiteral("The “%1” field must only contain exactly %2 digits.").arg(genericFieldName(), QString::number(d->length));
+    Q_D(const ValidatorDigits);
+    if (d->length > 0) {
+        return QStringLiteral("The “%1” field must only contain exactly %2 digits.").arg(fieldLabel(), QString::number(d->length));
     } else {
-        return QStringLiteral("The “%1” field must only contain digits.").arg(genericFieldName());
+        return QStringLiteral("The “%1” field must only contain digits.").arg(fieldLabel());
     }
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatordigits.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigits.cpp
@@ -39,35 +39,36 @@ ValidatorDigits::~ValidatorDigits()
 
 QString ValidatorDigits::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorDigits);
 
-    if (value().isEmpty()) {
-        return QString();
-    }
+    if (!value().isEmpty()) {
 
-    if (value().contains(QRegularExpression(QStringLiteral("^[0-9]+$")))) {
-        if (d->length > 0) {
-            if (value().length() == d->length) {
-                return QString();
-            } else {
-                return validationError();
+        if (value().contains(QRegularExpression(QStringLiteral("^[0-9]+$")))) {
+            if ((d->length > 0) && (value().length() != d->length)) {
+                result = validationError();
             }
         } else {
-            return QString();
+            result = validationError();
         }
-    } else {
-        return validationError();
     }
+
+    return result;
 }
 
 QString ValidatorDigits::genericValidationError() const
 {
+    QString error;
+
     Q_D(const ValidatorDigits);
     if (d->length > 0) {
-        return QStringLiteral("The “%1” field must only contain exactly %2 digits.").arg(fieldLabel(), QString::number(d->length));
+        error = QStringLiteral("The “%1” field must only contain exactly %2 digits.").arg(fieldLabel(), QString::number(d->length));
     } else {
-        return QStringLiteral("The “%1” field must only contain digits.").arg(fieldLabel());
+        error = QStringLiteral("The “%1” field must only contain digits.").arg(fieldLabel());
     }
+
+    return error;
 }
 
 void ValidatorDigits::setLength(int length)

--- a/Cutelyst/Plugins/Utils/Validator/validatordigits.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigits.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -62,10 +62,22 @@ QString ValidatorDigits::genericValidationError() const
     QString error;
 
     Q_D(const ValidatorDigits);
-    if (d->length > 0) {
-        error = QStringLiteral("The %1 field must only contain exactly %2 digits.").arg(fieldLabel(), QString::number(d->length));
+
+    if (label().isEmpty()) {
+
+        if (d->length > 0) {
+            error = QStringLiteral("Must only contain exactly %1 digits.").arg(d->length);
+        } else {
+            error = QStringLiteral("Must only contain digits.");
+        }
+
     } else {
-        error = QStringLiteral("The %1 field must only contain digits.").arg(fieldLabel());
+
+        if (d->length > 0) {
+            error = QStringLiteral("The “%1” field must only contain exactly %2 digits.").arg(label(), QString::number(d->length));
+        } else {
+            error = QStringLiteral("The “%1” field must only contain digits.").arg(label());
+        }
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatordigits.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigits.cpp
@@ -63,9 +63,9 @@ QString ValidatorDigits::genericValidationError() const
 
     Q_D(const ValidatorDigits);
     if (d->length > 0) {
-        error = QStringLiteral("The “%1” field must only contain exactly %2 digits.").arg(fieldLabel(), QString::number(d->length));
+        error = QStringLiteral("The %1 field must only contain exactly %2 digits.").arg(fieldLabel(), QString::number(d->length));
     } else {
-        error = QStringLiteral("The “%1” field must only contain digits.").arg(fieldLabel());
+        error = QStringLiteral("The %1 field must only contain digits.").arg(fieldLabel());
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatordigits.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigits.h
@@ -60,11 +60,9 @@ public:
     ~ValidatorDigits();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the allowed length of the input data.
@@ -77,7 +75,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorDigits(ValidatorDigitsPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.cpp
@@ -39,35 +39,39 @@ ValidatorDigitsBetween::~ValidatorDigitsBetween()
 
 QString ValidatorDigitsBetween::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorDigitsBetween);
 
-    if (value().isEmpty()) {
-        return QString();
-    }
+    if (!value().isEmpty()) {
+        if (value().contains(QRegularExpression(QStringLiteral("^[0-9]+$")))) {
 
-    if (value().contains(QRegularExpression(QStringLiteral("^[0-9]+$")))) {
-
-        if (d->min < 1 || d->max < 1) {
-            return QString();
-        } else {
-
-            if ((value().length() >= d->min) && (value().length() <= d->max)) {
-                return QString();
+            if ((d->min > 0) && (d->max > d->min)) {
+                if ((value().length() < d->min) || (value().length() > d->max)) {
+                    result = validationError();
+                }
             }
+
+        } else {
+            result = validationError();
         }
     }
 
-    return validationError();
+    return result;
 }
 
 QString ValidatorDigitsBetween::genericValidationError() const
 {
+    QString error;
+
     Q_D(const ValidatorDigitsBetween);
     if (d->min < 1 || d->max < 1) {
-        return QStringLiteral("The “%1” field must only contain digits.").arg(fieldLabel());
+        error = QStringLiteral("The “%1” field must only contain digits.").arg(fieldLabel());
     } else {
-        return QStringLiteral("The “%1” field must only contain digits with a length between %2 and %3.").arg(fieldLabel(), QString::number(d->min), QString::number(d->max));
+        error = QStringLiteral("The “%1” field must only contain digits with a length between %2 and %3.").arg(fieldLabel(), QString::number(d->min), QString::number(d->max));
     }
+
+    return error;
 }
 
 void ValidatorDigitsBetween::setMin(int min)

--- a/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.cpp
@@ -66,9 +66,9 @@ QString ValidatorDigitsBetween::genericValidationError() const
 
     Q_D(const ValidatorDigitsBetween);
     if (d->min < 1 || d->max < 1) {
-        error = QStringLiteral("The “%1” field must only contain digits.").arg(fieldLabel());
+        error = QStringLiteral("The %1 field must only contain digits.").arg(fieldLabel());
     } else {
-        error = QStringLiteral("The “%1” field must only contain digits with a length between %2 and %3.").arg(fieldLabel(), QString::number(d->min), QString::number(d->max));
+        error = QStringLiteral("The %1 field must only contain digits with a length between %2 and %3.").arg(fieldLabel(), QString::number(d->min), QString::number(d->max));
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -65,10 +65,19 @@ QString ValidatorDigitsBetween::genericValidationError() const
     QString error;
 
     Q_D(const ValidatorDigitsBetween);
-    if (d->min < 1 || d->max < 1) {
-        error = QStringLiteral("The %1 field must only contain digits.").arg(fieldLabel());
+
+    if (label().isEmpty()) {
+        if (d->min < 1 || d->max < 1) {
+            error = QStringLiteral("Must only contain digits.");
+        } else {
+            error = QStringLiteral("Must only contain digits with a length between %1 and %2.").arg(QString::number(d->min), QString::number(d->max));
+        }
     } else {
-        error = QStringLiteral("The %1 field must only contain digits with a length between %2 and %3.").arg(fieldLabel(), QString::number(d->min), QString::number(d->max));
+        if (d->min < 1 || d->max < 1) {
+            error = QStringLiteral("The “%1” field must only contain digits.").arg(label());
+        } else {
+            error = QStringLiteral("The “%1” field must only contain digits with a length between %2 and %3.").arg(label(), QString::number(d->min), QString::number(d->max));
+        }
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.cpp
@@ -37,39 +37,36 @@ ValidatorDigitsBetween::~ValidatorDigitsBetween()
 {
 }
 
-bool ValidatorDigitsBetween::validate()
+QString ValidatorDigitsBetween::validate() const
 {
-    Q_D(ValidatorDigitsBetween);
+    Q_D(const ValidatorDigitsBetween);
 
     if (value().isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     if (value().contains(QRegularExpression(QStringLiteral("^[0-9]+$")))) {
 
         if (d->min < 1 || d->max < 1) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         } else {
 
             if ((value().length() >= d->min) && (value().length() <= d->max)) {
-                setError(ValidatorRule::NoError);
-                return true;
+                return QString();
             }
         }
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorDigitsBetween::genericErrorMessage() const
+QString ValidatorDigitsBetween::genericValidationError() const
 {
     Q_D(const ValidatorDigitsBetween);
     if (d->min < 1 || d->max < 1) {
-        return QStringLiteral("The “%1” field must only contain digits.").arg(genericFieldName());
+        return QStringLiteral("The “%1” field must only contain digits.").arg(fieldLabel());
     } else {
-        return QStringLiteral("The “%1” field must only contain digits with a length between %2 and %3.").arg(genericFieldName(), QString::number(d->min), QString::number(d->max));
+        return QStringLiteral("The “%1” field must only contain digits with a length between %2 and %3.").arg(fieldLabel(), QString::number(d->min), QString::number(d->max));
     }
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.h
@@ -61,11 +61,9 @@ public:
     ~ValidatorDigitsBetween();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the minimum length.
@@ -81,7 +79,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorDigitsBetween(ValidatorDigitsBetweenPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
@@ -38,51 +38,46 @@ ValidatorEmail::~ValidatorEmail()
 
 QString ValidatorEmail::validate() const
 {
-    if (value().isEmpty()) {
-        return QString();
-    }
+    QString result;
 
 //    bool isEmail = value().contains(QRegularExpression(QStringLiteral("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")));
 
-    // regex taken from https://regex101.com/library/gJ7pU0
-    bool isEmail = value().contains(QRegularExpression(QStringLiteral("(?(DEFINE)"
-                                                                      "(?<addr_spec> (?&local_part) @ (?&domain) )"
-                                                                      "(?<local_part> (?&dot_atom) | (?&quoted_string) | (?&obs_local_part) )"
-                                                                      "(?<domain> (?&dot_atom) | (?&domain_literal) | (?&obs_domain) )"
-                                                                      "(?<domain_literal> (?&CFWS)? \\[ (?: (?&FWS)? (?&dtext) )* (?&FWS)? \\] (?&CFWS)? )"
-                                                                      "(?<dtext> [\\x21-\\x5a] | [\\x5e-\\x7e] | (?&obs_dtext) )"
-                                                                      "(?<quoted_pair> \\\\ (?: (?&VCHAR) | (?&WSP) ) | (?&obs_qp) )"
-                                                                      "(?<dot_atom> (?&CFWS)? (?&dot_atom_text) (?&CFWS)? )"
-                                                                      "(?<dot_atom_text> (?&atext) (?: \\. (?&atext) )* )"
-                                                                      "(?<atext> [a-zA-Z0-9!#$%&'*+\\/=?^_`{|}~-]+ )"
-                                                                      "(?<atom> (?&CFWS)? (?&atext) (?&CFWS)? )"
-                                                                      "(?<word> (?&atom) | (?&quoted_string) )"
-                                                                      "(?<quoted_string> (?&CFWS)? \" (?: (?&FWS)? (?&qcontent) )* (?&FWS)? \" (?&CFWS)? )"
-                                                                      "(?<qcontent> (?&qtext) | (?&quoted_pair) )"
-                                                                      "(?<qtext> \\x21 | [\\x23-\\x5b] | [\\x5d-\\x7e] | (?&obs_qtext) )"
-                                                                      "(?<FWS> (?: (?&WSP)* \\r\\n )? (?&WSP)+ | (?&obs_FWS) )"
-                                                                      "(?<CFWS> (?: (?&FWS)? (?&comment) )+ (?&FWS)? | (?&FWS) )"
-                                                                      "(?<comment> \\( (?: (?&FWS)? (?&ccontent) )* (?&FWS)? \\) )"
-                                                                      "(?<ccontent> (?&ctext) | (?&quoted_pair) | (?&comment) )"
-                                                                      "(?<ctext> [\\x21-\\x27] | [\\x2a-\\x5b] | [\\x5d-\\x7e] | (?&obs_ctext) )"
-                                                                      "(?<obs_domain> (?&atom) (?: \\. (?&atom) )* )"
-                                                                      "(?<obs_local_part> (?&word) (?: \\. (?&word) )* )"
-                                                                      "(?<obs_dtext> (?&obs_NO_WS_CTL) | (?&quoted_pair) )"
-                                                                      "(?<obs_qp> \\\\ (?: \\x00 | (?&obs_NO_WS_CTL) | \\n | \\r ) )"
-                                                                      "(?<obs_FWS> (?&WSP)+ (?: \\r\\n (?&WSP)+ )* )"
-                                                                      "(?<obs_ctext> (?&obs_NO_WS_CTL) )"
-                                                                      "(?<obs_qtext> (?&obs_NO_WS_CTL) )"
-                                                                      "(?<obs_NO_WS_CTL> [\\x01-\\x08] | \\x0b | \\x0c | [\\x0e-\\x1f] | \\x7f )"
-                                                                      "(?<VCHAR> [\\x21-\\x7E] )"
-                                                                      "(?<WSP> [ \\t] )"
-                                                                  ")"
-                                                                  "^(?&addr_spec)$"), QRegularExpression::ExtendedPatternSyntaxOption));
-
-    if (isEmail) {
-        return QString();
+    if (!value().isEmpty() && !value().contains(QRegularExpression(QStringLiteral("(?(DEFINE)"
+                                                                                 "(?<addr_spec> (?&local_part) @ (?&domain) )"
+                                                                                 "(?<local_part> (?&dot_atom) | (?&quoted_string) | (?&obs_local_part) )"
+                                                                                 "(?<domain> (?&dot_atom) | (?&domain_literal) | (?&obs_domain) )"
+                                                                                 "(?<domain_literal> (?&CFWS)? \\[ (?: (?&FWS)? (?&dtext) )* (?&FWS)? \\] (?&CFWS)? )"
+                                                                                 "(?<dtext> [\\x21-\\x5a] | [\\x5e-\\x7e] | (?&obs_dtext) )"
+                                                                                 "(?<quoted_pair> \\\\ (?: (?&VCHAR) | (?&WSP) ) | (?&obs_qp) )"
+                                                                                 "(?<dot_atom> (?&CFWS)? (?&dot_atom_text) (?&CFWS)? )"
+                                                                                 "(?<dot_atom_text> (?&atext) (?: \\. (?&atext) )* )"
+                                                                                 "(?<atext> [a-zA-Z0-9!#$%&'*+\\/=?^_`{|}~-]+ )"
+                                                                                 "(?<atom> (?&CFWS)? (?&atext) (?&CFWS)? )"
+                                                                                 "(?<word> (?&atom) | (?&quoted_string) )"
+                                                                                 "(?<quoted_string> (?&CFWS)? \" (?: (?&FWS)? (?&qcontent) )* (?&FWS)? \" (?&CFWS)? )"
+                                                                                 "(?<qcontent> (?&qtext) | (?&quoted_pair) )"
+                                                                                 "(?<qtext> \\x21 | [\\x23-\\x5b] | [\\x5d-\\x7e] | (?&obs_qtext) )"
+                                                                                 "(?<FWS> (?: (?&WSP)* \\r\\n )? (?&WSP)+ | (?&obs_FWS) )"
+                                                                                 "(?<CFWS> (?: (?&FWS)? (?&comment) )+ (?&FWS)? | (?&FWS) )"
+                                                                                 "(?<comment> \\( (?: (?&FWS)? (?&ccontent) )* (?&FWS)? \\) )"
+                                                                                 "(?<ccontent> (?&ctext) | (?&quoted_pair) | (?&comment) )"
+                                                                                 "(?<ctext> [\\x21-\\x27] | [\\x2a-\\x5b] | [\\x5d-\\x7e] | (?&obs_ctext) )"
+                                                                                 "(?<obs_domain> (?&atom) (?: \\. (?&atom) )* )"
+                                                                                 "(?<obs_local_part> (?&word) (?: \\. (?&word) )* )"
+                                                                                 "(?<obs_dtext> (?&obs_NO_WS_CTL) | (?&quoted_pair) )"
+                                                                                 "(?<obs_qp> \\\\ (?: \\x00 | (?&obs_NO_WS_CTL) | \\n | \\r ) )"
+                                                                                 "(?<obs_FWS> (?&WSP)+ (?: \\r\\n (?&WSP)+ )* )"
+                                                                                 "(?<obs_ctext> (?&obs_NO_WS_CTL) )"
+                                                                                 "(?<obs_qtext> (?&obs_NO_WS_CTL) )"
+                                                                                 "(?<obs_NO_WS_CTL> [\\x01-\\x08] | \\x0b | \\x0c | [\\x0e-\\x1f] | \\x7f )"
+                                                                                 "(?<VCHAR> [\\x21-\\x7E] )"
+                                                                                 "(?<WSP> [ \\t] )"
+                                                                             ")"
+                                                                             "^(?&addr_spec)$"), QRegularExpression::ExtendedPatternSyntaxOption))) {
+        result = validationError();
     }
 
-    return validationError();
+    return result;
 }
 
 QString ValidatorEmail::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
@@ -36,11 +36,10 @@ ValidatorEmail::~ValidatorEmail()
 {
 }
 
-bool ValidatorEmail::validate()
+QString ValidatorEmail::validate() const
 {
     if (value().isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
 //    bool isEmail = value().contains(QRegularExpression(QStringLiteral("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")));
@@ -80,14 +79,13 @@ bool ValidatorEmail::validate()
                                                                   "^(?&addr_spec)$"), QRegularExpression::ExtendedPatternSyntaxOption));
 
     if (isEmail) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorEmail::genericErrorMessage() const
+QString ValidatorEmail::genericValidationError() const
 {
-    return QStringLiteral("The email address in the “%1” field is not valid.").arg(genericFieldName());
+    return QStringLiteral("The email address in the “%1” field is not valid.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
@@ -82,5 +82,5 @@ QString ValidatorEmail::validate() const
 
 QString ValidatorEmail::genericValidationError() const
 {
-    return QStringLiteral("The email address in the “%1” field is not valid.").arg(fieldLabel());
+    return QStringLiteral("The email address in the %1 field is not valid.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -82,5 +82,11 @@ QString ValidatorEmail::validate() const
 
 QString ValidatorEmail::genericValidationError() const
 {
-    return QStringLiteral("The email address in the %1 field is not valid.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Not a valid email address.");
+    } else {
+        error = QStringLiteral("The email address in the “%1” field is not valid.").arg(label());
+    }
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail.h
@@ -60,17 +60,15 @@ public:
     ~ValidatorEmail();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
     
 protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorEmail(ValidatorEmailPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorfilled.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorfilled.cpp
@@ -35,22 +35,20 @@ ValidatorFilled::~ValidatorFilled()
 {
 }
 
-bool ValidatorFilled::validate()
+QString ValidatorFilled::validate() const
 {
     if (!parameters().contains(field())) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     } else {
         if (!value().isEmpty()) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorFilled::genericErrorMessage() const
+QString ValidatorFilled::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(genericFieldName());
+    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorfilled.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorfilled.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -48,5 +48,11 @@ QString ValidatorFilled::validate() const
 
 QString ValidatorFilled::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Must be filled.");
+    } else {
+        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+    }
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorfilled.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorfilled.cpp
@@ -48,5 +48,5 @@ QString ValidatorFilled::validate() const
 
 QString ValidatorFilled::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
+    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorfilled.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorfilled.cpp
@@ -37,15 +37,13 @@ ValidatorFilled::~ValidatorFilled()
 
 QString ValidatorFilled::validate() const
 {
-    if (!parameters().contains(field())) {
-        return QString();
-    } else {
-        if (!value().isEmpty()) {
-            return QString();
-        }
+    QString result;
+
+    if (parameters().contains(field()) && value().isEmpty()) {
+        result = validationError();
     }
 
-    return validationError();
+    return result;
 }
 
 QString ValidatorFilled::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorfilled.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorfilled.h
@@ -56,17 +56,15 @@ public:
     ~ValidatorFilled();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
     
 protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorFilled(ValidatorFilledPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorin.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorin.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -54,8 +54,14 @@ QString ValidatorIn::validate() const
 
 QString ValidatorIn::genericValidationError() const
 {
+    QString error;
     Q_D(const ValidatorIn);
-    return QStringLiteral("The value in the %1 field has to be one of the following: %2").arg(fieldLabel(), d->values.join(QStringLiteral(", ")));
+    if (label().isEmpty()) {
+        error = QStringLiteral("Has to be one of the following: %1").arg(d->values.join(QStringLiteral(", ")));
+    } else {
+        error = QStringLiteral("The value in the “%1” field has to be one of the following: %2").arg(label(), d->values.join(QStringLiteral(", ")));
+    }
+    return error;
 }
 
 void ValidatorIn::setValues(const QStringList &values)

--- a/Cutelyst/Plugins/Utils/Validator/validatorin.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorin.cpp
@@ -55,7 +55,7 @@ QString ValidatorIn::validate() const
 QString ValidatorIn::genericValidationError() const
 {
     Q_D(const ValidatorIn);
-    return QStringLiteral("The value in the “%1“ field has to be one of the following: %2").arg(fieldLabel(), d->values.join(QStringLiteral(", ")));
+    return QStringLiteral("The value in the %1 field has to be one of the following: %2").arg(fieldLabel(), d->values.join(QStringLiteral(", ")));
 }
 
 void ValidatorIn::setValues(const QStringList &values)

--- a/Cutelyst/Plugins/Utils/Validator/validatorin.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorin.cpp
@@ -37,21 +37,19 @@ ValidatorIn::~ValidatorIn()
 
 QString ValidatorIn::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorIn);
 
-    if (d->values.isEmpty()) {
-        return validationDataError();
+    if (!d->values.isEmpty()) {
+        if (!value().isEmpty() && !d->values.contains(value())) {
+            result = validationError();
+        }
+    } else {
+        result = validationDataError();
     }
 
-    if (value().isEmpty()) {
-        return QString();
-    }
-
-    if (d->values.contains(value())) {
-        return QString();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorIn::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorin.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorin.cpp
@@ -35,32 +35,29 @@ ValidatorIn::~ValidatorIn()
 {
 }
 
-bool ValidatorIn::validate()
+QString ValidatorIn::validate() const
 {
-    Q_D(ValidatorIn);
+    Q_D(const ValidatorIn);
 
     if (d->values.isEmpty()) {
-        setError(ValidatorRule::ValidationDataError);
-        return false;
+        return validationDataError();
     }
 
     if (value().isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     if (d->values.contains(value())) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorIn::genericErrorMessage() const
+QString ValidatorIn::genericValidationError() const
 {
     Q_D(const ValidatorIn);
-    return QStringLiteral("The value in the “%1“ field has to be one of the following: %2").arg(genericFieldName(), d->values.join(QStringLiteral(", ")));
+    return QStringLiteral("The value in the “%1“ field has to be one of the following: %2").arg(fieldLabel(), d->values.join(QStringLiteral(", ")));
 }
 
 void ValidatorIn::setValues(const QStringList &values)

--- a/Cutelyst/Plugins/Utils/Validator/validatorin.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorin.h
@@ -58,11 +58,9 @@ public:
     ~ValidatorIn();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the values to compare against.
@@ -73,7 +71,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorIn(ValidatorInPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorinteger.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorinteger.cpp
@@ -40,17 +40,15 @@ ValidatorInteger::~ValidatorInteger()
 
 QString ValidatorInteger::validate() const
 {
-    QString v = value();
+    QString result;
 
-    if (v.isEmpty()) {
-        return QString();
+    const QString v = value();
+
+    if (!v.isEmpty() && !v.contains(QRegularExpression(QStringLiteral("^-?\\d+$")))) {
+        result = validationError();
     }
 
-    if (value().contains(QRegularExpression(QStringLiteral("^-?\\d+$")))) {
-        return QString();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorInteger::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorinteger.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorinteger.cpp
@@ -53,5 +53,5 @@ QString ValidatorInteger::validate() const
 
 QString ValidatorInteger::genericValidationError() const
 {
-    return QStringLiteral("You have to enter an integer (1,2,-3 etc.) into the “%1” field.").arg(fieldLabel());
+    return QStringLiteral("You have to enter an integer (1,2,-3 etc.) into the %1 field.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorinteger.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorinteger.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -53,5 +53,11 @@ QString ValidatorInteger::validate() const
 
 QString ValidatorInteger::genericValidationError() const
 {
-    return QStringLiteral("You have to enter an integer (1,2,-3 etc.) into the %1 field.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Has to be an integer (1,2,-3 etc).");
+    } else {
+        error = QStringLiteral("You have to enter an integer (1,2,-3 etc.) into the “%1” field.").arg(label());
+    }
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorinteger.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorinteger.cpp
@@ -38,24 +38,22 @@ ValidatorInteger::~ValidatorInteger()
 {
 }
 
-bool ValidatorInteger::validate()
+QString ValidatorInteger::validate() const
 {
     QString v = value();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     if (value().contains(QRegularExpression(QStringLiteral("^-?\\d+$")))) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorInteger::genericErrorMessage() const
+QString ValidatorInteger::genericValidationError() const
 {
-    return QStringLiteral("You have to enter an integer (1,2,-3 etc.) into the “%1” field.").arg(genericFieldName());
+    return QStringLiteral("You have to enter an integer (1,2,-3 etc.) into the “%1” field.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorinteger.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorinteger.h
@@ -57,17 +57,15 @@ public:
     ~ValidatorInteger();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
     
 protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorInteger(ValidatorIntegerPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorip.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorip.cpp
@@ -39,222 +39,218 @@ ValidatorIp::~ValidatorIp()
 
 QString ValidatorIp::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorIp);
 
-    QString v = value();
+    const QString v = value();
 
-    if (v.isEmpty()) {
-        return QString();
-    }
+    if (!v.isEmpty()) {
 
-    // simple check for an IPv4 address with four parts, because QHostAddress also tolerates addresses like 192.168.2 and fills them with 0 somewhere
-    if (!v.contains(QStringLiteral(":")) && !v.contains(QRegularExpression(QStringLiteral("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$")))) {
-        return validationError();
-    }
+        // simple check for an IPv4 address with four parts, because QHostAddress also tolerates addresses like 192.168.2 and fills them with 0 somewhere
+        if (!v.contains(QStringLiteral(":")) && !v.contains(QRegularExpression(QStringLiteral("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$")))) {
 
-    QHostAddress a;
-    if (a.setAddress(value())) {
-
-        if (d->constraints.testFlag(NoConstraint)) {
-
-            return QString();
+            result = validationError();
 
         } else {
 
-            if (a.protocol() == QAbstractSocket::IPv4Protocol) {
+            bool valid = true;
 
-                if (d->constraints.testFlag(IPv6Only)) {
-                    return validationError();
+            // private IPv4 subnets
+            static const std::vector<QPair<QHostAddress,int>> ipv4Private({
+                                                                              // Used for local communications within a private network
+                                                                              // https://tools.ietf.org/html/rfc1918
+                                                                              {QHostAddress(QStringLiteral("10.0.0.0")), 8},
+
+                                                                              // Used for link-local addresses between two hosts on a single link when no IP address
+                                                                              // is otherwise specified, such as would have normally been retrieved from a DHCP server
+                                                                              // https://tools.ietf.org/html/rfc3927
+                                                                              {QHostAddress(QStringLiteral("169.254.0.0")), 16},
+
+                                                                              // Used for local communications within a private network
+                                                                              // https://tools.ietf.org/html/rfc1918
+                                                                              {QHostAddress(QStringLiteral("172.16.0.0")), 12},
+
+                                                                              // Used for local communications within a private network
+                                                                              // https://tools.ietf.org/html/rfc1918
+                                                                              {QHostAddress(QStringLiteral("192.168.0.0")), 12}
+                                                                          });
+
+            // reserved IPv4 subnets
+            static const std::vector<QPair<QHostAddress,int>> ipv4Reserved({
+                                                                               // Used for broadcast messages to the current ("this")
+                                                                               // https://tools.ietf.org/html/rfc1700
+                                                                               {QHostAddress(QStringLiteral("0.0.0.0")), 8},
+
+                                                                               // Used for communications between a service provider and its subscribers when using a carrier-grade NAT
+                                                                               // https://tools.ietf.org/html/rfc6598
+                                                                               {QHostAddress(QStringLiteral("100.64.0.0")), 10},
+
+                                                                               // Used for loopback addresses to the local host
+                                                                               // https://tools.ietf.org/html/rfc990
+                                                                               {QHostAddress(QStringLiteral("127.0.0.1")), 8},
+
+                                                                               // Used for the IANA IPv4 Special Purpose Address Registry
+                                                                               // https://tools.ietf.org/html/rfc5736
+                                                                               {QHostAddress(QStringLiteral("192.0.0.0")), 24},
+
+                                                                               // Assigned as "TEST-NET" for use in documentation and examples. It should not be used publicly.
+                                                                               // https://tools.ietf.org/html/rfc5737
+                                                                               {QHostAddress(QStringLiteral("192.0.2.0")), 24},
+
+                                                                               // Used by 6to4 anycast relays
+                                                                               // https://tools.ietf.org/html/rfc3068
+                                                                               {QHostAddress(QStringLiteral("192.88.99.0")), 24},
+
+                                                                               // Used for testing of inter-network communications between two separate subnets
+                                                                               // https://tools.ietf.org/html/rfc2544
+                                                                               {QHostAddress(QStringLiteral("198.18.0.0")), 15},
+
+                                                                               // Assigned as "TEST-NET-2" for use in documentation and examples. It should not be used publicly.
+                                                                               // https://tools.ietf.org/html/rfc5737
+                                                                               {QHostAddress(QStringLiteral("198.51.100.0")), 24},
+
+                                                                               // Assigned as "TEST-NET-3" for use in documentation and examples. It should not be used publicly.
+                                                                               // https://tools.ietf.org/html/rfc5737
+                                                                               {QHostAddress(QStringLiteral("203.0.113.0")), 24},
+
+                                                                               // Reserved for future use
+                                                                               // https://tools.ietf.org/html/rfc6890
+                                                                               {QHostAddress(QStringLiteral("240.0.0.0")), 4},
+
+                                                                               // Reserved for the "limited broadcast" destination address
+                                                                               // https://tools.ietf.org/html/rfc6890
+                                                                               {QHostAddress(QStringLiteral("255.255.255.255")), 32}
+                                                                           });
+
+
+            // private IPv6 subnets
+            static const std::vector<QPair<QHostAddress,int>> ipv6Private({
+                                                                              // unique local address
+                                                                              {QHostAddress(QStringLiteral("fc00::")), 7},
+
+                                                                              // link-local address
+                                                                              {QHostAddress(QStringLiteral("fe80::")), 10}
+                                                                          });
+
+            // reserved IPv6 subnets
+            static const std::vector<QPair<QHostAddress,int>> ipv6Reserved({
+                                                                               // unspecified address
+                                                                               {QHostAddress(QStringLiteral("::")), 128},
+
+                                                                               // loopback address to the loca host
+                                                                               {QHostAddress(QStringLiteral("::1")), 128},
+
+                                                                               // IPv4 mapped addresses
+                                                                               {QHostAddress(QStringLiteral("::ffff:0:0")), 96},
+
+                                                                               // discard prefix
+                                                                               // https://tools.ietf.org/html/rfc6666
+                                                                               {QHostAddress(QStringLiteral("100::")), 64},
+
+                                                                               // IPv4/IPv6 translation
+                                                                               // https://tools.ietf.org/html/rfc6052
+                                                                               {QHostAddress(QStringLiteral("64:ff9b::")), 96},
+
+                                                                               // Teredo tunneling
+                                                                               {QHostAddress(QStringLiteral("2001::")), 32},
+
+                                                                               // deprected (previously ORCHID)
+                                                                               {QHostAddress(QStringLiteral("2001:10::")), 28},
+
+                                                                               // ORCHIDv2
+                                                                               {QHostAddress(QStringLiteral("2001:20::")), 28},
+
+                                                                               // addresses used in documentation and example source code
+                                                                               {QHostAddress(QStringLiteral("2001:db8::")), 32},
+
+                                                                               // 6to4
+                                                                               {QHostAddress(QStringLiteral("2002::")), 16}
+                                                                           });
+
+            QHostAddress a;
+
+            if (a.setAddress(value())) {
+
+                if (!d->constraints.testFlag(NoConstraint)) {
+
+                    if (a.protocol() == QAbstractSocket::IPv4Protocol) {
+
+                        if (d->constraints.testFlag(IPv6Only)) {
+                            valid = false;
+                        }
+
+                        if (valid && (d->constraints.testFlag(NoPrivateRange) || d->constraints.testFlag(PublicOnly))) {
+
+                            for (const QPair<QHostAddress,int> &subnet : ipv4Private) {
+                                if (a.isInSubnet(subnet)) {
+                                    valid = false;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (valid && (d->constraints.testFlag(NoReservedRange) || d->constraints.testFlag(PublicOnly))) {
+
+                            for (const QPair<QHostAddress,int> &subnet : ipv4Reserved) {
+                                if (a.isInSubnet(subnet)) {
+                                    valid = false;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (valid && (d->constraints.testFlag(NoMultiCast) || d->constraints.testFlag(PublicOnly))) {
+                            if (a.isInSubnet(QHostAddress(QStringLiteral("224.0.0.0")), 4)) {
+                                valid = false;
+                            }
+                        }
+
+                    } else {
+
+                        if (d->constraints.testFlag(IPv4Only)) {
+                            valid = false;
+                        }
+
+                        if (valid && (d->constraints.testFlag(NoPrivateRange) || d->constraints.testFlag(PublicOnly))) {
+
+                            for (const QPair<QHostAddress,int> &subnet : ipv6Private) {
+                                if (a.isInSubnet(subnet)) {
+                                    valid = false;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (valid && (d->constraints.testFlag(NoReservedRange) || d->constraints.testFlag(PublicOnly))) {
+
+                            for (const QPair<QHostAddress,int> &subnet : ipv6Reserved) {
+                                if (a.isInSubnet(subnet)) {
+                                    valid = false;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (valid && (d->constraints.testFlag(NoMultiCast) || d->constraints.testFlag(PublicOnly))) {
+                            if (a.isInSubnet(QHostAddress(QStringLiteral("ff00::")), 8)) {
+                                valid = false;
+                            }
+                        }
+                    }
                 }
-
-                if (d->constraints.testFlag(NoPrivateRange) || d->constraints.testFlag(PublicOnly)) {
-                    // Used for local communications within a private network
-                    // https://tools.ietf.org/html/rfc1918
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("10.0.0.0")), 8)) {
-                        return validationError();
-                    }
-
-                    // Used for link-local addresses between two hosts on a single link when no IP address is otherwise specified, such as would have normally been retrieved from a DHCP server
-                    // https://tools.ietf.org/html/rfc3927
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("169.254.0.0")), 16)) {
-                        return validationError();
-                    }
-
-                    // Used for local communications within a private network
-                    // https://tools.ietf.org/html/rfc1918
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("172.16.0.0")), 12)) {
-                        return validationError();
-                    }
-
-                    // Used for local communications within a private network
-                    // https://tools.ietf.org/html/rfc1918
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("192.168.0.0")), 12)) {
-                        return validationError();
-                    }
-                }
-
-                if (d->constraints.testFlag(NoReservedRange) || d->constraints.testFlag(PublicOnly)) {
-                    // Used for broadcast messages to the current ("this")
-                    // https://tools.ietf.org/html/rfc1700
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("0.0.0.0")), 8)) {
-                        return validationError();
-                    }
-
-                    // Used for communications between a service provider and its subscribers when using a carrier-grade NAT
-                    // https://tools.ietf.org/html/rfc6598
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("100.64.0.0")), 10)) {
-                        return validationError();
-                    }
-
-                    // Used for loopback addresses to the local host
-                    // https://tools.ietf.org/html/rfc990
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("127.0.0.1")), 8)) {
-                        return validationError();
-                    }
-
-                    // Used for the IANA IPv4 Special Purpose Address Registry
-                    // https://tools.ietf.org/html/rfc5736
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("192.0.0.0")), 24)) {
-                        return validationError();
-                    }
-
-                    // Assigned as "TEST-NET" for use in documentation and examples. It should not be used publicly.
-                    // https://tools.ietf.org/html/rfc5737
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("192.0.2.0")), 24)) {
-                        return validationError();
-                    }
-
-                    // Used by 6to4 anycast relays
-                    // https://tools.ietf.org/html/rfc3068
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("192.88.99.0")), 24)) {
-                        return validationError();
-                    }
-
-                    // Used for testing of inter-network communications between two separate subnets
-                    // https://tools.ietf.org/html/rfc2544
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("198.18.0.0")), 15)) {
-                        return validationError();
-                    }
-
-                    // Assigned as "TEST-NET-2" for use in documentation and examples. It should not be used publicly.
-                    // https://tools.ietf.org/html/rfc5737
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("198.51.100.0")), 24)) {
-                        return validationError();
-                    }
-
-                    // Assigned as "TEST-NET-3" for use in documentation and examples. It should not be used publicly.
-                    // https://tools.ietf.org/html/rfc5737
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("203.0.113.0")), 24)) {
-                        return validationError();
-                    }
-
-                    // Reserved for future use
-                    // https://tools.ietf.org/html/rfc6890
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("240.0.0.0")), 4)) {
-                        return validationError();
-                    }
-
-                    // Reserved for the "limited broadcast" destination address
-                    // https://tools.ietf.org/html/rfc6890
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("255.255.255.255")), 32)) {
-                        return validationError();
-                    }
-                }
-
-                if (d->constraints.testFlag(NoMultiCast) || d->constraints.testFlag(PublicOnly)) {
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("224.0.0.0")), 4)) {
-                        return validationError();
-                    }
-                }
-
-                return QString();
 
             } else {
+                valid = false;
+            }
 
-                if (d->constraints.testFlag(IPv4Only)) {
-                    return validationError();
-                }
-
-                if (d->constraints.testFlag(NoPrivateRange) || d->constraints.testFlag(PublicOnly)) {
-
-                    // unique local address
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("fc00::")), 7)) {
-                        return validationError();
-                    }
-
-                    // link-local address
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("fe80::")), 10)) {
-                        return validationError();
-                    }
-                }
-
-                if (d->constraints.testFlag(NoReservedRange) || d->constraints.testFlag(PublicOnly)) {
-
-                    // unspecified address
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("::")), 128)) {
-                        return validationError();
-                    }
-
-                    // loopback address to the loca host
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("::1")), 128)) {
-                        return validationError();
-                    }
-
-                    // IPv4 mapped addresses
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("::ffff:0:0")), 96)) {
-                        return validationError();
-                    }
-
-                    // discard prefix
-                    // https://tools.ietf.org/html/rfc6666
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("100::")), 64)) {
-                        return validationError();
-                    }
-
-                    // IPv4/IPv6 translation
-                    // https://tools.ietf.org/html/rfc6052
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("64:ff9b::")), 96)) {
-                        return validationError();
-                    }
-
-                    // Teredo tunneling
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("2001::")), 32)) {
-                        return validationError();
-                    }
-
-                    // deprected (previously ORCHID)
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("2001:10::")), 28)) {
-                        return validationError();
-                    }
-
-                    // ORCHIDv2
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("2001:20::")), 28)) {
-                        return validationError();
-                    }
-
-                    // addresses used in documentation and example source code
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("2001:db8::")), 32)) {
-                        return validationError();
-                    }
-
-                    // 6to4
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("2002::")), 16)) {
-                        return validationError();
-                    }
-                }
-
-                if (d->constraints.testFlag(NoMultiCast) || d->constraints.testFlag(PublicOnly)) {
-                    if (a.isInSubnet(QHostAddress(QStringLiteral("ff00::")), 8)) {
-                        return validationError();
-                    }
-                }
-
-                return QString();
+            if (!valid) {
+                result = validationError();
             }
         }
     }
 
-    return validationError();
+    return result;
 }
 
 QString ValidatorIp::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorip.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorip.cpp
@@ -255,7 +255,7 @@ QString ValidatorIp::validate() const
 
 QString ValidatorIp::genericValidationError() const
 {
-    return QStringLiteral("You have to enter a valid IP address into the “%1“ field.").arg(fieldLabel());
+    return QStringLiteral("You have to enter a valid IP address into the %1 field.").arg(fieldLabel());
 }
 
 void ValidatorIp::setConstraints(Constraints constraints)

--- a/Cutelyst/Plugins/Utils/Validator/validatorip.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorip.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -255,7 +255,13 @@ QString ValidatorIp::validate() const
 
 QString ValidatorIp::genericValidationError() const
 {
-    return QStringLiteral("You have to enter a valid IP address into the %1 field.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("IP address is invalid or not acceptable.");
+    } else {
+        error = QStringLiteral("You have to enter a valid IP address into the “%1” field.").arg(label());
+    }
+    return error;
 }
 
 void ValidatorIp::setConstraints(Constraints constraints)

--- a/Cutelyst/Plugins/Utils/Validator/validatorip.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorip.cpp
@@ -37,20 +37,19 @@ ValidatorIp::~ValidatorIp()
 {
 }
 
-bool ValidatorIp::validate()
+QString ValidatorIp::validate() const
 {
-    Q_D(ValidatorIp);
+    Q_D(const ValidatorIp);
 
     QString v = value();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     // simple check for an IPv4 address with four parts, because QHostAddress also tolerates addresses like 192.168.2 and fills them with 0 somewhere
     if (!v.contains(QStringLiteral(":")) && !v.contains(QRegularExpression(QStringLiteral("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$")))) {
-        return false;
+        return validationError();
     }
 
     QHostAddress a;
@@ -58,40 +57,39 @@ bool ValidatorIp::validate()
 
         if (d->constraints.testFlag(NoConstraint)) {
 
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
 
         } else {
 
             if (a.protocol() == QAbstractSocket::IPv4Protocol) {
 
                 if (d->constraints.testFlag(IPv6Only)) {
-                    return false;
+                    return validationError();
                 }
 
                 if (d->constraints.testFlag(NoPrivateRange) || d->constraints.testFlag(PublicOnly)) {
                     // Used for local communications within a private network
                     // https://tools.ietf.org/html/rfc1918
                     if (a.isInSubnet(QHostAddress(QStringLiteral("10.0.0.0")), 8)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Used for link-local addresses between two hosts on a single link when no IP address is otherwise specified, such as would have normally been retrieved from a DHCP server
                     // https://tools.ietf.org/html/rfc3927
                     if (a.isInSubnet(QHostAddress(QStringLiteral("169.254.0.0")), 16)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Used for local communications within a private network
                     // https://tools.ietf.org/html/rfc1918
                     if (a.isInSubnet(QHostAddress(QStringLiteral("172.16.0.0")), 12)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Used for local communications within a private network
                     // https://tools.ietf.org/html/rfc1918
                     if (a.isInSubnet(QHostAddress(QStringLiteral("192.168.0.0")), 12)) {
-                        return false;
+                        return validationError();
                     }
                 }
 
@@ -99,95 +97,94 @@ bool ValidatorIp::validate()
                     // Used for broadcast messages to the current ("this")
                     // https://tools.ietf.org/html/rfc1700
                     if (a.isInSubnet(QHostAddress(QStringLiteral("0.0.0.0")), 8)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Used for communications between a service provider and its subscribers when using a carrier-grade NAT
                     // https://tools.ietf.org/html/rfc6598
                     if (a.isInSubnet(QHostAddress(QStringLiteral("100.64.0.0")), 10)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Used for loopback addresses to the local host
                     // https://tools.ietf.org/html/rfc990
                     if (a.isInSubnet(QHostAddress(QStringLiteral("127.0.0.1")), 8)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Used for the IANA IPv4 Special Purpose Address Registry
                     // https://tools.ietf.org/html/rfc5736
                     if (a.isInSubnet(QHostAddress(QStringLiteral("192.0.0.0")), 24)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Assigned as "TEST-NET" for use in documentation and examples. It should not be used publicly.
                     // https://tools.ietf.org/html/rfc5737
                     if (a.isInSubnet(QHostAddress(QStringLiteral("192.0.2.0")), 24)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Used by 6to4 anycast relays
                     // https://tools.ietf.org/html/rfc3068
                     if (a.isInSubnet(QHostAddress(QStringLiteral("192.88.99.0")), 24)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Used for testing of inter-network communications between two separate subnets
                     // https://tools.ietf.org/html/rfc2544
                     if (a.isInSubnet(QHostAddress(QStringLiteral("198.18.0.0")), 15)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Assigned as "TEST-NET-2" for use in documentation and examples. It should not be used publicly.
                     // https://tools.ietf.org/html/rfc5737
                     if (a.isInSubnet(QHostAddress(QStringLiteral("198.51.100.0")), 24)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Assigned as "TEST-NET-3" for use in documentation and examples. It should not be used publicly.
                     // https://tools.ietf.org/html/rfc5737
                     if (a.isInSubnet(QHostAddress(QStringLiteral("203.0.113.0")), 24)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Reserved for future use
                     // https://tools.ietf.org/html/rfc6890
                     if (a.isInSubnet(QHostAddress(QStringLiteral("240.0.0.0")), 4)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Reserved for the "limited broadcast" destination address
                     // https://tools.ietf.org/html/rfc6890
                     if (a.isInSubnet(QHostAddress(QStringLiteral("255.255.255.255")), 32)) {
-                        return false;
+                        return validationError();
                     }
                 }
 
                 if (d->constraints.testFlag(NoMultiCast) || d->constraints.testFlag(PublicOnly)) {
                     if (a.isInSubnet(QHostAddress(QStringLiteral("224.0.0.0")), 4)) {
-                        return false;
+                        return validationError();
                     }
                 }
 
-                setError(ValidatorRule::NoError);
-                return true;
+                return QString();
 
             } else {
 
                 if (d->constraints.testFlag(IPv4Only)) {
-                    return false;
+                    return validationError();
                 }
 
                 if (d->constraints.testFlag(NoPrivateRange) || d->constraints.testFlag(PublicOnly)) {
 
                     // unique local address
                     if (a.isInSubnet(QHostAddress(QStringLiteral("fc00::")), 7)) {
-                        return false;
+                        return validationError();
                     }
 
                     // link-local address
                     if (a.isInSubnet(QHostAddress(QStringLiteral("fe80::")), 10)) {
-                        return false;
+                        return validationError();
                     }
                 }
 
@@ -195,77 +192,74 @@ bool ValidatorIp::validate()
 
                     // unspecified address
                     if (a.isInSubnet(QHostAddress(QStringLiteral("::")), 128)) {
-                        return false;
+                        return validationError();
                     }
 
                     // loopback address to the loca host
                     if (a.isInSubnet(QHostAddress(QStringLiteral("::1")), 128)) {
-                        return false;
+                        return validationError();
                     }
 
                     // IPv4 mapped addresses
                     if (a.isInSubnet(QHostAddress(QStringLiteral("::ffff:0:0")), 96)) {
-                        return false;
+                        return validationError();
                     }
 
                     // discard prefix
                     // https://tools.ietf.org/html/rfc6666
                     if (a.isInSubnet(QHostAddress(QStringLiteral("100::")), 64)) {
-                        return false;
+                        return validationError();
                     }
 
                     // IPv4/IPv6 translation
                     // https://tools.ietf.org/html/rfc6052
                     if (a.isInSubnet(QHostAddress(QStringLiteral("64:ff9b::")), 96)) {
-                        return false;
+                        return validationError();
                     }
 
                     // Teredo tunneling
                     if (a.isInSubnet(QHostAddress(QStringLiteral("2001::")), 32)) {
-                        return false;
+                        return validationError();
                     }
 
                     // deprected (previously ORCHID)
                     if (a.isInSubnet(QHostAddress(QStringLiteral("2001:10::")), 28)) {
-                        return false;
+                        return validationError();
                     }
 
                     // ORCHIDv2
                     if (a.isInSubnet(QHostAddress(QStringLiteral("2001:20::")), 28)) {
-                        return false;
+                        return validationError();
                     }
 
                     // addresses used in documentation and example source code
                     if (a.isInSubnet(QHostAddress(QStringLiteral("2001:db8::")), 32)) {
-                        return false;
+                        return validationError();
                     }
 
                     // 6to4
                     if (a.isInSubnet(QHostAddress(QStringLiteral("2002::")), 16)) {
-                        return false;
+                        return validationError();
                     }
                 }
 
                 if (d->constraints.testFlag(NoMultiCast) || d->constraints.testFlag(PublicOnly)) {
                     if (a.isInSubnet(QHostAddress(QStringLiteral("ff00::")), 8)) {
-                        return false;
+                        return validationError();
                     }
                 }
 
-                setError(ValidatorRule::NoError);
-                return true;
-
+                return QString();
             }
-
         }
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorIp::genericErrorMessage() const
+QString ValidatorIp::genericValidationError() const
 {
-    return QStringLiteral("You have to enter a valid IP address into the “%1“ field.").arg(genericFieldName());
+    return QStringLiteral("You have to enter a valid IP address into the “%1“ field.").arg(fieldLabel());
 }
 
 void ValidatorIp::setConstraints(Constraints constraints)

--- a/Cutelyst/Plugins/Utils/Validator/validatorip.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorip.h
@@ -71,11 +71,9 @@ public:
     ~ValidatorIp();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets optional validation contraints.
@@ -86,7 +84,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorIp(ValidatorIpPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorjson.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorjson.cpp
@@ -38,18 +38,18 @@ ValidatorJson::~ValidatorJson()
 
 QString ValidatorJson::validate() const
 {
-    QString v = value();
+    QString result;
 
-    if (v.isEmpty()) {
-        return QString();
+    const QString v = value();
+
+    if (!v.isEmpty()) {
+        const QJsonDocument json = QJsonDocument::fromJson(v.toUtf8());
+        if (json.isEmpty() || json.isNull()) {
+            result = validationError();
+        }
     }
 
-    QJsonDocument json = QJsonDocument::fromJson(v.toUtf8());
-    if (!json.isEmpty() && !json.isNull()) {
-        return QString();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorJson::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorjson.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorjson.cpp
@@ -54,5 +54,5 @@ QString ValidatorJson::validate() const
 
 QString ValidatorJson::genericValidationError() const
 {
-    return QStringLiteral("The data entered in the “%1” field is not valid JSON.").arg(fieldLabel());
+    return QStringLiteral("The data entered in the %1 field is not valid JSON.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorjson.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorjson.cpp
@@ -38,8 +38,6 @@ ValidatorJson::~ValidatorJson()
 
 QString ValidatorJson::validate() const
 {
-    Q_D(const ValidatorJson);
-
     QString v = value();
 
     if (v.isEmpty()) {

--- a/Cutelyst/Plugins/Utils/Validator/validatorjson.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorjson.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -54,5 +54,11 @@ QString ValidatorJson::validate() const
 
 QString ValidatorJson::genericValidationError() const
 {
-    return QStringLiteral("The data entered in the %1 field is not valid JSON.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Invalid JSON data.");
+    } else {
+        error = QStringLiteral("The data entered in the “%1” field is not valid JSON.").arg(label());
+    }
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorjson.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorjson.h
@@ -21,7 +21,6 @@
 
 #include <Cutelyst/cutelyst_global.h>
 #include "validatorrule.h"
-#include <QJsonParseError>
 
 namespace Cutelyst {
     
@@ -56,22 +55,15 @@ public:
     ~ValidatorJson();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
-
-    /*!
-     * \brief Returns information about parsing error if validation fails.
-     */
-    QJsonParseError jsonParseError() const;
+    QString validate() const override;
     
 protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorJson(ValidatorJsonPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorjson_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorjson_p.h
@@ -30,8 +30,6 @@ public:
     ValidatorJsonPrivate(const QString &f, const QString &l, const QString &e) :
         ValidatorRulePrivate(f, l, e)
     {}
-
-    QJsonParseError jsonParseError;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatormax.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatormax.cpp
@@ -35,63 +35,58 @@ ValidatorMax::~ValidatorMax()
 {
 }
 
-bool ValidatorMax::validate()
+QString ValidatorMax::validate() const
 {
     QString v = value();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    Q_D(ValidatorMax);
+    Q_D(const ValidatorMax);
 
     if (d->type == QMetaType::Int) {
         qlonglong val = v.toLongLong();
         qlonglong max = (qlonglong)d->max;
         if (val <= max) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else if (d->type == QMetaType::UInt) {
         qulonglong val = v.toULongLong();
         qulonglong max = (qulonglong)d->max;
         if (val <= max) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else if (d->type == QMetaType::Float) {
         double val = v.toDouble();
         if (val <= d->max) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else if (d->type == QMetaType::QString) {
         int val = v.length();
         int max = (int)d->max;
         if (val <= max) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else {
-        setError(ValidatorRule::ValidationDataError);
+        return validationDataError();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorMax::genericErrorMessage() const
+QString ValidatorMax::genericValidationError() const
 {
     Q_D(const ValidatorMax);
 
     if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        return QStringLiteral("The value of the “%1” field has to be lower than or equal to %2.").arg(genericFieldName(),QString::number(d->max, 'f', 0));
+        return QStringLiteral("The value of the “%1” field has to be lower than or equal to %2.").arg(fieldLabel(),QString::number(d->max, 'f', 0));
     } else if (d->type == QMetaType::Float) {
-        return QStringLiteral("The value of the “%1” field has to be lower than or equal to %2.").arg(genericFieldName(), QString::number(d->max));
+        return QStringLiteral("The value of the “%1” field has to be lower than or equal to %2.").arg(fieldLabel(), QString::number(d->max));
     } else if (d->type == QMetaType::QString) {
-        return QStringLiteral("The length of the “%1” field has to be lower than or equal to %2.").arg(genericFieldName(), QString::number(d->max, 'f', 0));
+        return QStringLiteral("The length of the “%1” field has to be lower than or equal to %2.").arg(fieldLabel(), QString::number(d->max, 'f', 0));
     } else {
-        return QString();
+        return validationDataError();
     }
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatormax.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatormax.cpp
@@ -82,11 +82,11 @@ QString ValidatorMax::genericValidationError() const
     Q_D(const ValidatorMax);
 
     if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        error = QStringLiteral("The value of the “%1” field has to be lower than or equal to %2.").arg(fieldLabel(),QString::number(d->max, 'f', 0));
+        error = QStringLiteral("The value of the %1 field has to be lower than or equal to %2.").arg(fieldLabel(),QString::number(d->max, 'f', 0));
     } else if (d->type == QMetaType::Float) {
-        error =  QStringLiteral("The value of the “%1” field has to be lower than or equal to %2.").arg(fieldLabel(), QString::number(d->max));
+        error =  QStringLiteral("The value of the %1 field has to be lower than or equal to %2.").arg(fieldLabel(), QString::number(d->max));
     } else if (d->type == QMetaType::QString) {
-        error =  QStringLiteral("The length of the “%1” field has to be lower than or equal to %2.").arg(fieldLabel(), QString::number(d->max, 'f', 0));
+        error =  QStringLiteral("The length of the %1 field has to be lower than or equal to %2.").arg(fieldLabel(), QString::number(d->max, 'f', 0));
     } else {
         error =  validationDataError();
     }

--- a/Cutelyst/Plugins/Utils/Validator/validatormax.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatormax.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -81,14 +81,29 @@ QString ValidatorMax::genericValidationError() const
 
     Q_D(const ValidatorMax);
 
-    if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        error = QStringLiteral("The value of the %1 field has to be lower than or equal to %2.").arg(fieldLabel(),QString::number(d->max, 'f', 0));
-    } else if (d->type == QMetaType::Float) {
-        error =  QStringLiteral("The value of the %1 field has to be lower than or equal to %2.").arg(fieldLabel(), QString::number(d->max));
-    } else if (d->type == QMetaType::QString) {
-        error =  QStringLiteral("The length of the %1 field has to be lower than or equal to %2.").arg(fieldLabel(), QString::number(d->max, 'f', 0));
+    QString max;
+    if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::QString) {
+        max = QString::number(d->max, 'f', 0);
     } else {
-        error =  validationDataError();
+        max = QString::number(d->max);
+    }
+
+    if (label().isEmpty()) {
+        if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::Float) {
+            error = QStringLiteral("Has to be lower than or equal to %1.").arg(max);
+        } else if (d->type == QMetaType::QString) {
+            error = QStringLiteral("Has to be shorter than or equal to %1.").arg(max);
+        } else {
+            error = validationDataError();
+        }
+    } else {
+        if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::Float) {
+            error = QStringLiteral("The value of the “%1” field has to be lower than or equal to %2.").arg(label(), max);
+        } else if (d->type == QMetaType::QString) {
+            error = QStringLiteral("The length of the “%1” field has to be shorter than or equal to %2.").arg(label(), max);
+        } else {
+            error = validationDataError();
+        }
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatormax.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatormax.cpp
@@ -37,57 +37,61 @@ ValidatorMax::~ValidatorMax()
 
 QString ValidatorMax::validate() const
 {
-    QString v = value();
+    QString result;
 
-    if (v.isEmpty()) {
-        return QString();
+    const QString v = value();
+
+    if (!v.isEmpty()) {
+        Q_D(const ValidatorMax);
+
+        if (d->type == QMetaType::Int) {
+            qlonglong val = v.toLongLong();
+            qlonglong max = (qlonglong)d->max;
+            if (val > max) {
+                result = validationError();
+            }
+        } else if (d->type == QMetaType::UInt) {
+            qulonglong val = v.toULongLong();
+            qulonglong max = (qulonglong)d->max;
+            if (val > max) {
+                result = validationError();
+            }
+        } else if (d->type == QMetaType::Float) {
+            double val = v.toDouble();
+            if (val > d->max) {
+                result = validationError();
+            }
+        } else if (d->type == QMetaType::QString) {
+            int val = v.length();
+            int max = (int)d->max;
+            if (val > max) {
+                result = validationError();
+            }
+        } else {
+            result = validationDataError();
+        }
     }
 
-    Q_D(const ValidatorMax);
-
-    if (d->type == QMetaType::Int) {
-        qlonglong val = v.toLongLong();
-        qlonglong max = (qlonglong)d->max;
-        if (val <= max) {
-            return QString();
-        }
-    } else if (d->type == QMetaType::UInt) {
-        qulonglong val = v.toULongLong();
-        qulonglong max = (qulonglong)d->max;
-        if (val <= max) {
-            return QString();
-        }
-    } else if (d->type == QMetaType::Float) {
-        double val = v.toDouble();
-        if (val <= d->max) {
-            return QString();
-        }
-    } else if (d->type == QMetaType::QString) {
-        int val = v.length();
-        int max = (int)d->max;
-        if (val <= max) {
-            return QString();
-        }
-    } else {
-        return validationDataError();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorMax::genericValidationError() const
 {
+    QString error;
+
     Q_D(const ValidatorMax);
 
     if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        return QStringLiteral("The value of the “%1” field has to be lower than or equal to %2.").arg(fieldLabel(),QString::number(d->max, 'f', 0));
+        error = QStringLiteral("The value of the “%1” field has to be lower than or equal to %2.").arg(fieldLabel(),QString::number(d->max, 'f', 0));
     } else if (d->type == QMetaType::Float) {
-        return QStringLiteral("The value of the “%1” field has to be lower than or equal to %2.").arg(fieldLabel(), QString::number(d->max));
+        error =  QStringLiteral("The value of the “%1” field has to be lower than or equal to %2.").arg(fieldLabel(), QString::number(d->max));
     } else if (d->type == QMetaType::QString) {
-        return QStringLiteral("The length of the “%1” field has to be lower than or equal to %2.").arg(fieldLabel(), QString::number(d->max, 'f', 0));
+        error =  QStringLiteral("The length of the “%1” field has to be lower than or equal to %2.").arg(fieldLabel(), QString::number(d->max, 'f', 0));
     } else {
-        return validationDataError();
+        error =  validationDataError();
     }
+
+    return error;
 }
 
 void ValidatorMax::setType(QMetaType::Type type)

--- a/Cutelyst/Plugins/Utils/Validator/validatormax.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatormax.h
@@ -67,11 +67,9 @@ public:
     ~ValidatorMax();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the type to validate.
@@ -87,7 +85,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorMax(ValidatorMaxPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatormin.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatormin.cpp
@@ -82,11 +82,11 @@ QString ValidatorMin::genericValidationError() const
     Q_D(const ValidatorMin);
 
     if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        error = QStringLiteral("The value of the “%1” field has to be greater than or equal to %2.").arg(fieldLabel(),QString::number(d->min, 'f', 0));
+        error = QStringLiteral("The value of the %1 field has to be greater than or equal to %2.").arg(fieldLabel(),QString::number(d->min, 'f', 0));
     } else if (d->type == QMetaType::Float) {
-        error = QStringLiteral("The value of the “%1” field has to be greater than or equal to %2.").arg(fieldLabel(), QString::number(d->min));
+        error = QStringLiteral("The value of the %1 field has to be greater than or equal to %2.").arg(fieldLabel(), QString::number(d->min));
     } else if (d->type == QMetaType::QString) {
-        error = QStringLiteral("The length of the “%1” field has to be greater than or equal to %2.").arg(fieldLabel(), QString::number(d->min, 'f', 0));
+        error = QStringLiteral("The length of the %1 field has to be greater than or equal to %2.").arg(fieldLabel(), QString::number(d->min, 'f', 0));
     } else {
         error = validationDataError();
     }

--- a/Cutelyst/Plugins/Utils/Validator/validatormin.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatormin.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -81,14 +81,29 @@ QString ValidatorMin::genericValidationError() const
 
     Q_D(const ValidatorMin);
 
-    if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        error = QStringLiteral("The value of the %1 field has to be greater than or equal to %2.").arg(fieldLabel(),QString::number(d->min, 'f', 0));
-    } else if (d->type == QMetaType::Float) {
-        error = QStringLiteral("The value of the %1 field has to be greater than or equal to %2.").arg(fieldLabel(), QString::number(d->min));
-    } else if (d->type == QMetaType::QString) {
-        error = QStringLiteral("The length of the %1 field has to be greater than or equal to %2.").arg(fieldLabel(), QString::number(d->min, 'f', 0));
+    QString min;
+    if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::QString) {
+        min = QString::number(d->min, 'f', 0);
     } else {
-        error = validationDataError();
+        min = QString::number(d->min);
+    }
+
+    if (label().isEmpty()) {
+        if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::Float) {
+            error = QStringLiteral("Has to be greater than or equal to %1.").arg(min);
+        } else if (d->type == QMetaType::QString) {
+            error = QStringLiteral("Has to be longer than or equal to %1.").arg(min);
+        } else {
+            error = validationDataError();
+        }
+    } else {
+        if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::Float) {
+            error = QStringLiteral("The value of the “%1” field has to be greater than or equal to %2.").arg(label(), min);
+        } else if (d->type == QMetaType::QString) {
+            error = QStringLiteral("The length of the “%1” field has to be longer than or equal to %2.").arg(label(), min);
+        } else {
+            error = validationDataError();
+        }
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatormin.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatormin.cpp
@@ -37,57 +37,61 @@ ValidatorMin::~ValidatorMin()
 
 QString ValidatorMin::validate() const
 {
-    QString v = value();
+    QString result;
 
-    if (v.isEmpty()) {
-        return QString();
+    const QString v = value();
+
+    if (!v.isEmpty()) {
+        Q_D(const ValidatorMin);
+
+        if (d->type == QMetaType::Int) {
+            qlonglong val = v.toLongLong();
+            qlonglong min = (qlonglong)d->min;
+            if (val < min) {
+                result = validationError();
+            }
+        } else if (d->type == QMetaType::UInt) {
+            qulonglong val = v.toULongLong();
+            qulonglong min = (qulonglong)d->min;
+            if (val < min) {
+                result = validationError();
+            }
+        } else if (d->type == QMetaType::Float) {
+            double val = v.toDouble();
+            if (val < d->min) {
+                result = validationError();
+            }
+        } else if (d->type == QMetaType::QString) {
+            int val = v.length();
+            int min = (int)d->min;
+            if (val < min) {
+                result = validationError();
+            }
+        } else {
+            result = validationDataError();
+        }
     }
 
-    Q_D(const ValidatorMin);
-
-    if (d->type == QMetaType::Int) {
-        qlonglong val = v.toLongLong();
-        qlonglong min = (qlonglong)d->min;
-        if (val >= min) {
-            return QString();
-        }
-    } else if (d->type == QMetaType::UInt) {
-        qulonglong val = v.toULongLong();
-        qulonglong min = (qulonglong)d->min;
-        if (val >= min) {
-            return QString();
-        }
-    } else if (d->type == QMetaType::Float) {
-        double val = v.toDouble();
-        if (val >= d->min) {
-            return QString();
-        }
-    } else if (d->type == QMetaType::QString) {
-        int val = v.length();
-        int min = (int)d->min;
-        if (val >= min) {
-            return QString();
-        }
-    } else {
-        return validationDataError();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorMin::genericValidationError() const
 {
+    QString error;
+
     Q_D(const ValidatorMin);
 
     if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        return QStringLiteral("The value of the “%1” field has to be greater than or equal to %2.").arg(fieldLabel(),QString::number(d->min, 'f', 0));
+        error = QStringLiteral("The value of the “%1” field has to be greater than or equal to %2.").arg(fieldLabel(),QString::number(d->min, 'f', 0));
     } else if (d->type == QMetaType::Float) {
-        return QStringLiteral("The value of the “%1” field has to be greater than or equal to %2.").arg(fieldLabel(), QString::number(d->min));
+        error = QStringLiteral("The value of the “%1” field has to be greater than or equal to %2.").arg(fieldLabel(), QString::number(d->min));
     } else if (d->type == QMetaType::QString) {
-        return QStringLiteral("The length of the “%1” field has to be greater than or equal to %2.").arg(fieldLabel(), QString::number(d->min, 'f', 0));
+        error = QStringLiteral("The length of the “%1” field has to be greater than or equal to %2.").arg(fieldLabel(), QString::number(d->min, 'f', 0));
     } else {
-        return validationDataError();
+        error = validationDataError();
     }
+
+    return error;
 }
 
 void ValidatorMin::setType(QMetaType::Type type)

--- a/Cutelyst/Plugins/Utils/Validator/validatormin.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatormin.cpp
@@ -35,63 +35,58 @@ ValidatorMin::~ValidatorMin()
 {
 }
 
-bool ValidatorMin::validate()
+QString ValidatorMin::validate() const
 {
     QString v = value();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    Q_D(ValidatorMin);
+    Q_D(const ValidatorMin);
 
     if (d->type == QMetaType::Int) {
         qlonglong val = v.toLongLong();
         qlonglong min = (qlonglong)d->min;
         if (val >= min) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else if (d->type == QMetaType::UInt) {
         qulonglong val = v.toULongLong();
         qulonglong min = (qulonglong)d->min;
         if (val >= min) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else if (d->type == QMetaType::Float) {
         double val = v.toDouble();
         if (val >= d->min) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else if (d->type == QMetaType::QString) {
         int val = v.length();
         int min = (int)d->min;
         if (val >= min) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else {
-        setError(ValidatorRule::ValidationDataError);
+        return validationDataError();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorMin::genericErrorMessage() const
+QString ValidatorMin::genericValidationError() const
 {
     Q_D(const ValidatorMin);
 
     if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        return QStringLiteral("The value of the “%1” field has to be greater than or equal to %2.").arg(genericFieldName(),QString::number(d->min, 'f', 0));
+        return QStringLiteral("The value of the “%1” field has to be greater than or equal to %2.").arg(fieldLabel(),QString::number(d->min, 'f', 0));
     } else if (d->type == QMetaType::Float) {
-        return QStringLiteral("The value of the “%1” field has to be greater than or equal to %2.").arg(genericFieldName(), QString::number(d->min));
+        return QStringLiteral("The value of the “%1” field has to be greater than or equal to %2.").arg(fieldLabel(), QString::number(d->min));
     } else if (d->type == QMetaType::QString) {
-        return QStringLiteral("The length of the “%1” field has to be greater than or equal to %2.").arg(genericFieldName(), QString::number(d->min, 'f', 0));
+        return QStringLiteral("The length of the “%1” field has to be greater than or equal to %2.").arg(fieldLabel(), QString::number(d->min, 'f', 0));
     } else {
-        return QString();
+        return validationDataError();
     }
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatormin.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatormin.h
@@ -67,11 +67,9 @@ public:
     ~ValidatorMin();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the type to validate.
@@ -87,7 +85,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorMin(ValidatorMinPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatornotin.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatornotin.cpp
@@ -55,7 +55,7 @@ QString ValidatorNotIn::validate() const
 
 QString ValidatorNotIn::genericValidationError() const
 {
-    return QStringLiteral("The value in the “%1“ field is not allowed.").arg(fieldLabel());
+    return QStringLiteral("The value in the %1 field is not allowed.").arg(fieldLabel());
 }
 
 void ValidatorNotIn::setValues(const QStringList &values)

--- a/Cutelyst/Plugins/Utils/Validator/validatornotin.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatornotin.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -55,7 +55,13 @@ QString ValidatorNotIn::validate() const
 
 QString ValidatorNotIn::genericValidationError() const
 {
-    return QStringLiteral("The value in the %1 field is not allowed.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Value is not allowed.");
+    } else {
+        error = QStringLiteral("The value in the “%1” field is not allowed.").arg(label());
+    }
+    return error;
 }
 
 void ValidatorNotIn::setValues(const QStringList &values)

--- a/Cutelyst/Plugins/Utils/Validator/validatornotin.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatornotin.cpp
@@ -37,23 +37,20 @@ ValidatorNotIn::~ValidatorNotIn()
 
 QString ValidatorNotIn::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorNotIn);
 
-    if (d->values.isEmpty()) {
-        return validationDataError();
+    if (d->values.empty()) {
+        result = validationDataError();
+    } else {
+        const QString v = value();
+        if (!v.isEmpty() && d->values.contains(v)) {
+            result = validationError();
+        }
     }
 
-    QString v = value();
-
-    if (v.isEmpty()) {
-        return QString();
-    }
-
-    if (!d->values.contains(v)) {
-        return QString();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorNotIn::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatornotin.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatornotin.cpp
@@ -35,33 +35,30 @@ ValidatorNotIn::~ValidatorNotIn()
 {
 }
 
-bool ValidatorNotIn::validate()
+QString ValidatorNotIn::validate() const
 {
-    Q_D(ValidatorNotIn);
+    Q_D(const ValidatorNotIn);
 
     if (d->values.isEmpty()) {
-        setError(ValidatorRule::ValidationDataError);
-        return false;
+        return validationDataError();
     }
 
     QString v = value();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     if (!d->values.contains(v)) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorNotIn::genericErrorMessage() const
+QString ValidatorNotIn::genericValidationError() const
 {
-    return QStringLiteral("The value in the “%1“ field is not allowed.").arg(genericFieldName());
+    return QStringLiteral("The value in the “%1“ field is not allowed.").arg(fieldLabel());
 }
 
 void ValidatorNotIn::setValues(const QStringList &values)

--- a/Cutelyst/Plugins/Utils/Validator/validatornotin.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatornotin.h
@@ -59,11 +59,9 @@ public:
     ~ValidatorNotIn();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the values to compare against.
@@ -74,7 +72,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorNotIn(ValidatorNotInPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatornumeric.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatornumeric.cpp
@@ -38,15 +38,13 @@ ValidatorNumeric::~ValidatorNumeric()
 
 QString ValidatorNumeric::validate() const
 {
-    if (value().isEmpty()) {
-        return QString();
+    QString result;
+
+    if (!value().isEmpty() && !value().contains(QRegularExpression(QStringLiteral("^-?\\d+(\\.|,)?\\d*(e|E)?\\d+$")))) {
+        result = validationError();
     }
 
-    if (value().contains(QRegularExpression(QStringLiteral("^-?\\d+(\\.|,)?\\d*(e|E)?\\d+$")))) {
-        return QString();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorNumeric::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatornumeric.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatornumeric.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -49,5 +49,11 @@ QString ValidatorNumeric::validate() const
 
 QString ValidatorNumeric::genericValidationError() const
 {
-    return QStringLiteral("You have to enter a numeric value into the %1 field, like 1, -2.5 or 3.454e3").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Must be numeric, like 1, -2.5 or 3.454e3.");
+    } else {
+        error = QStringLiteral("You have to enter a numeric value into the “%1” field, like 1, -2.5 or 3.454e3").arg(label());
+    }
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatornumeric.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatornumeric.cpp
@@ -36,22 +36,20 @@ ValidatorNumeric::~ValidatorNumeric()
 {
 }
 
-bool ValidatorNumeric::validate()
+QString ValidatorNumeric::validate() const
 {
     if (value().isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     if (value().contains(QRegularExpression(QStringLiteral("^-?\\d+(\\.|,)?\\d*(e|E)?\\d+$")))) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorNumeric::genericErrorMessage() const
+QString ValidatorNumeric::genericValidationError() const
 {
-    return QStringLiteral("You have to enter a numeric value into the “%1” field, like 1, -2.5 or 3.454e3").arg(genericFieldName());
+    return QStringLiteral("You have to enter a numeric value into the “%1” field, like 1, -2.5 or 3.454e3").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatornumeric.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatornumeric.cpp
@@ -49,5 +49,5 @@ QString ValidatorNumeric::validate() const
 
 QString ValidatorNumeric::genericValidationError() const
 {
-    return QStringLiteral("You have to enter a numeric value into the “%1” field, like 1, -2.5 or 3.454e3").arg(fieldLabel());
+    return QStringLiteral("You have to enter a numeric value into the %1 field, like 1, -2.5 or 3.454e3").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatornumeric.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatornumeric.h
@@ -58,17 +58,15 @@ public:
     ~ValidatorNumeric();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
     
 protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorNumeric(ValidatorNumericPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorpresent.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpresent.cpp
@@ -48,5 +48,5 @@ QString ValidatorPresent::validate() const
 
 QString ValidatorPresent::genericValidationError() const
 {
-    return QStringLiteral("The “%1“ field was not found in the input data.").arg(fieldLabel());
+    return QStringLiteral("The %1 field was not found in the input data.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorpresent.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpresent.cpp
@@ -37,11 +37,13 @@ ValidatorPresent::~ValidatorPresent()
 
 QString ValidatorPresent::validate() const
 {
-    if (parameters().contains(field())) {
-        return QString();
+    QString result;
+
+    if (!parameters().contains(field())) {
+        result = validationError();
     }
 
-    return validationError();
+    return result;
 }
 
 QString ValidatorPresent::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorpresent.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpresent.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -48,5 +48,11 @@ QString ValidatorPresent::validate() const
 
 QString ValidatorPresent::genericValidationError() const
 {
-    return QStringLiteral("The %1 field was not found in the input data.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Has to be present in input data.");
+    } else {
+        error = QStringLiteral("The “%1” field was not found in the input data.").arg(label());
+    }
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorpresent.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpresent.h
@@ -53,17 +53,15 @@ public:
     ~ValidatorPresent();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
     
 protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorPresent(ValidatorPresentPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.cpp
@@ -50,7 +50,7 @@ QString ValidatorRegularExpression::validate() const
 
 QString ValidatorRegularExpression::genericValidationError() const
 {
-    return QStringLiteral("The “%1” field does not match the desired format.").arg(fieldLabel());
+    return QStringLiteral("The %1 field does not match the desired format.").arg(fieldLabel());
 }
 
 void ValidatorRegularExpression::setRegex(const QRegularExpression &regex)

--- a/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.cpp
@@ -35,26 +35,24 @@ ValidatorRegularExpression::~ValidatorRegularExpression()
 {
 }
 
-bool ValidatorRegularExpression::validate()
+QString ValidatorRegularExpression::validate() const
 {
     if (value().isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    Q_D(ValidatorRegularExpression);
+    Q_D(const ValidatorRegularExpression);
 
     if (value().contains(d->regex)) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorRegularExpression::genericErrorMessage() const
+QString ValidatorRegularExpression::genericValidationError() const
 {
-    return QStringLiteral("The “%1” field does not match the desired format.").arg(genericFieldName());
+    return QStringLiteral("The “%1” field does not match the desired format.").arg(fieldLabel());
 }
 
 void ValidatorRegularExpression::setRegex(const QRegularExpression &regex)

--- a/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.cpp
@@ -37,17 +37,15 @@ ValidatorRegularExpression::~ValidatorRegularExpression()
 
 QString ValidatorRegularExpression::validate() const
 {
-    if (value().isEmpty()) {
-        return QString();
-    }
+    QString result;
 
     Q_D(const ValidatorRegularExpression);
 
-    if (value().contains(d->regex)) {
-        return QString();
+    if (!value().isEmpty() && !value().contains(d->regex)) {
+        result = validationError();
     }
 
-    return validationError();
+    return result;
 }
 
 QString ValidatorRegularExpression::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -50,7 +50,13 @@ QString ValidatorRegularExpression::validate() const
 
 QString ValidatorRegularExpression::genericValidationError() const
 {
-    return QStringLiteral("The %1 field does not match the desired format.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Does not match desired format.");
+    } else {
+        error = QStringLiteral("The “%1” field does not match the desired format.").arg(label());
+    }
+    return error;
 }
 
 void ValidatorRegularExpression::setRegex(const QRegularExpression &regex)

--- a/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.h
@@ -57,11 +57,9 @@ public:
     ~ValidatorRegularExpression();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the regular expression to check.
@@ -72,7 +70,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorRegularExpression(ValidatorRegularExpressionPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequired.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequired.cpp
@@ -35,17 +35,16 @@ ValidatorRequired::~ValidatorRequired()
 {
 }
 
-bool ValidatorRequired::validate()
+QString ValidatorRequired::validate() const
 {
     if (!value().isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     } else {
-        return false;
+        return validationError();
     }
 }
 
-QString ValidatorRequired::genericErrorMessage() const
+QString ValidatorRequired::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(genericFieldName());
+    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequired.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequired.cpp
@@ -48,5 +48,5 @@ QString ValidatorRequired::validate() const
 
 QString ValidatorRequired::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
+    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequired.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequired.cpp
@@ -37,11 +37,13 @@ ValidatorRequired::~ValidatorRequired()
 
 QString ValidatorRequired::validate() const
 {
-    if (!value().isEmpty()) {
-        return QString();
-    } else {
-        return validationError();
+    QString result;
+
+    if (value().isEmpty()) {
+        result = validationError();
     }
+
+    return result;
 }
 
 QString ValidatorRequired::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequired.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequired.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -48,5 +48,11 @@ QString ValidatorRequired::validate() const
 
 QString ValidatorRequired::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("This is required.");
+    } else {
+        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+    }
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequired.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequired.h
@@ -56,17 +56,15 @@ public:
     ~ValidatorRequired();
 
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
 protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
 
     ValidatorRequired(ValidatorRequiredPrivate &dd);
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.cpp
@@ -35,38 +35,34 @@ ValidatorRequiredIf::~ValidatorRequiredIf()
 {
 }
 
-bool ValidatorRequiredIf::validate()
+QString ValidatorRequiredIf::validate() const
 {
-    Q_D(ValidatorRequiredIf);
+    Q_D(const ValidatorRequiredIf);
 
     if (d->otherField.isEmpty()) {
-        setError(ValidatorRule::ValidationDataError);
-        return false;
+        return validationDataError();
     }
 
     if (d->otherValues.isEmpty()) {
-        setError(ValidatorRule::ValidationDataError);
-        return false;
+        return validationDataError();
     }
 
     if (d->otherValues.contains(d->parameters.value(d->otherField))) {
 
         if (!value().isEmpty()) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
 
     } else {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorRequiredIf::genericErrorMessage() const
+QString ValidatorRequiredIf::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(genericFieldName());
+    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
 }
 
 void ValidatorRequiredIf::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.cpp
@@ -52,7 +52,7 @@ QString ValidatorRequiredIf::validate() const
 
 QString ValidatorRequiredIf::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
+    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
 }
 
 void ValidatorRequiredIf::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -52,7 +52,13 @@ QString ValidatorRequiredIf::validate() const
 
 QString ValidatorRequiredIf::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("This is required.");
+    } else {
+        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+    }
+    return error;
 }
 
 void ValidatorRequiredIf::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.cpp
@@ -37,27 +37,17 @@ ValidatorRequiredIf::~ValidatorRequiredIf()
 
 QString ValidatorRequiredIf::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorRequiredIf);
 
-    if (d->otherField.isEmpty()) {
-        return validationDataError();
+    if (d->otherField.isEmpty() || d->otherValues.empty()) {
+        result = validationDataError();
+    } else if (d->otherValues.contains(d->parameters.value(d->otherField)) && value().isEmpty()) {
+        result = validationError();
     }
 
-    if (d->otherValues.isEmpty()) {
-        return validationDataError();
-    }
-
-    if (d->otherValues.contains(d->parameters.value(d->otherField))) {
-
-        if (!value().isEmpty()) {
-            return QString();
-        }
-
-    } else {
-        return QString();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorRequiredIf::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.h
@@ -60,11 +60,9 @@ public:
     ~ValidatorRequiredIf();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the name of the other field.
@@ -81,7 +79,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorRequiredIf(ValidatorRequiredIfPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless.cpp
@@ -52,7 +52,7 @@ QString ValidatorRequiredUnless::validate() const
 
 QString ValidatorRequiredUnless::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
+    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
 }
 
 void ValidatorRequiredUnless::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -52,7 +52,13 @@ QString ValidatorRequiredUnless::validate() const
 
 QString ValidatorRequiredUnless::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("This is required.");
+    } else {
+        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+    }
+    return error;
 }
 
 void ValidatorRequiredUnless::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless.cpp
@@ -37,27 +37,17 @@ ValidatorRequiredUnless::~ValidatorRequiredUnless()
 
 QString ValidatorRequiredUnless::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorRequiredUnless);
 
-    if (d->otherField.isEmpty()) {
-        return validationDataError();
+    if (d->otherField.isEmpty() || d->otherValues.empty()) {
+        result = validationDataError();
+    } else if (!d->otherValues.contains(d->parameters.value(d->otherField)) && value().isEmpty()) {
+        result = validationError();
     }
 
-    if (d->otherValues.isEmpty()) {
-        return validationDataError();
-    }
-
-    if (!d->otherValues.contains(d->parameters.value(d->otherField))) {
-
-        if (!value().isEmpty()) {
-            return QString();
-        }
-
-    } else {
-        return QString();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorRequiredUnless::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless.cpp
@@ -35,38 +35,34 @@ ValidatorRequiredUnless::~ValidatorRequiredUnless()
 {
 }
 
-bool ValidatorRequiredUnless::validate()
+QString ValidatorRequiredUnless::validate() const
 {
-    Q_D(ValidatorRequiredUnless);
+    Q_D(const ValidatorRequiredUnless);
 
     if (d->otherField.isEmpty()) {
-        setError(ValidatorRule::ValidationDataError);
-        return false;
+        return validationDataError();
     }
 
     if (d->otherValues.isEmpty()) {
-        setError(ValidatorRule::ValidationDataError);
-        return false;
+        return validationDataError();
     }
 
     if (!d->otherValues.contains(d->parameters.value(d->otherField))) {
 
         if (!value().isEmpty()) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
 
     } else {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorRequiredUnless::genericErrorMessage() const
+QString ValidatorRequiredUnless::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(genericFieldName());
+    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
 }
 
 void ValidatorRequiredUnless::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless.h
@@ -59,11 +59,9 @@ public:
     ~ValidatorRequiredUnless();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the name of the other field.
@@ -79,7 +77,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorRequiredUnless(ValidatorRequiredUnlessPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -65,7 +65,13 @@ QString ValidatorRequiredWith::validate() const
 
 QString ValidatorRequiredWith::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("This is required.");
+    } else {
+        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+    }
+    return error;
 }
 
 void ValidatorRequiredWith::setOtherFields(const QStringList &otherFields)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.cpp
@@ -35,13 +35,12 @@ ValidatorRequiredWith::~ValidatorRequiredWith()
 {
 }
 
-bool ValidatorRequiredWith::validate()
+QString ValidatorRequiredWith::validate() const
 {
-    Q_D(ValidatorRequiredWith);
+    Q_D(const ValidatorRequiredWith);
 
     if (d->otherFields.isEmpty()) {
-        setError(ValidatorRule::ValidationDataError);
-        return false;
+        return validationDataError();
     }
 
     bool containsOther = false;
@@ -57,22 +56,20 @@ bool ValidatorRequiredWith::validate()
 
     if (containsOther) {
         if (!value().isEmpty()) {
-            setError(ValidatorRule::NoError);
-            return true;
+           return QString();
         } else {
-            return false;
+            return validationError();
         }
     } else {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorRequiredWith::genericErrorMessage() const
+QString ValidatorRequiredWith::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(genericFieldName());
+    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
 }
 
 void ValidatorRequiredWith::setOtherFields(const QStringList &otherFields)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.cpp
@@ -37,34 +37,30 @@ ValidatorRequiredWith::~ValidatorRequiredWith()
 
 QString ValidatorRequiredWith::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorRequiredWith);
 
-    if (d->otherFields.isEmpty()) {
-        return validationDataError();
-    }
-
-    bool containsOther = false;
-
-    const QStringList ofc = d->otherFields;
-
-    for (const QString &other : ofc)  {
-        if (parameters().contains(other)) {
-            containsOther = true;
-            break;
-        }
-    }
-
-    if (containsOther) {
-        if (!value().isEmpty()) {
-           return QString();
-        } else {
-            return validationError();
-        }
+    if (d->otherFields.empty()) {
+        result = validationDataError();
     } else {
-        return QString();
+        bool containsOther = false;
+
+        const QStringList ofc = d->otherFields;
+
+        for (const QString &other : ofc)  {
+            if (parameters().contains(other)) {
+                containsOther = true;
+                break;
+            }
+        }
+
+        if (containsOther && value().isEmpty()) {
+            result = validationError();
+        }
     }
 
-    return validationError();
+    return result;
 }
 
 QString ValidatorRequiredWith::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.cpp
@@ -65,7 +65,7 @@ QString ValidatorRequiredWith::validate() const
 
 QString ValidatorRequiredWith::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
+    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
 }
 
 void ValidatorRequiredWith::setOtherFields(const QStringList &otherFields)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.h
@@ -60,11 +60,9 @@ public:
     ~ValidatorRequiredWith();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the list of other fields.
@@ -75,7 +73,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorRequiredWith(ValidatorRequiredWithPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall.cpp
@@ -66,7 +66,7 @@ QString ValidatorRequiredWithAll::validate() const
 
 QString ValidatorRequiredWithAll::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
+    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
 }
 
 void ValidatorRequiredWithAll::setOtherFields(const QStringList &otherFields)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall.cpp
@@ -35,13 +35,12 @@ ValidatorRequiredWithAll::~ValidatorRequiredWithAll()
 {
 }
 
-bool ValidatorRequiredWithAll::validate()
+QString ValidatorRequiredWithAll::validate() const
 {
-    Q_D(ValidatorRequiredWithAll);
+    Q_D(const ValidatorRequiredWithAll);
 
     if (d->otherFields.isEmpty()) {
-        setError(ValidatorRule::ValidationDataError);
-        return false;
+        return validationDataError();
     }
 
     bool containsAll = true;
@@ -58,23 +57,21 @@ bool ValidatorRequiredWithAll::validate()
     if (containsAll) {
 
         if (!value().isEmpty()) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         } else {
-            return false;
+            return validationError();
         }
 
     } else {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorRequiredWithAll::genericErrorMessage() const
+QString ValidatorRequiredWithAll::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(genericFieldName());
+    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
 }
 
 void ValidatorRequiredWithAll::setOtherFields(const QStringList &otherFields)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall.cpp
@@ -37,36 +37,31 @@ ValidatorRequiredWithAll::~ValidatorRequiredWithAll()
 
 QString ValidatorRequiredWithAll::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorRequiredWithAll);
 
-    if (d->otherFields.isEmpty()) {
-        return validationDataError();
-    }
-
-    bool containsAll = true;
-
-    const QStringList ofc = d->otherFields;
-
-    for (const QString &other : ofc) {
-        if (!parameters().contains(other)) {
-            containsAll = false;
-            break;
-        }
-    }
-
-    if (containsAll) {
-
-        if (!value().isEmpty()) {
-            return QString();
-        } else {
-            return validationError();
-        }
-
+    if (d->otherFields.empty()) {
+        result = validationDataError();
     } else {
-        return QString();
+
+        bool containsAll = true;
+
+        const QStringList ofc = d->otherFields;
+
+        for (const QString &other : ofc) {
+            if (!parameters().contains(other)) {
+                containsAll = false;
+                break;
+            }
+        }
+
+        if (containsAll && value().isEmpty()) {
+            result = validationError();
+        }
     }
 
-    return validationError();
+    return result;
 }
 
 QString ValidatorRequiredWithAll::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -66,7 +66,13 @@ QString ValidatorRequiredWithAll::validate() const
 
 QString ValidatorRequiredWithAll::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("This is required.");
+    } else {
+        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+    }
+    return error;
 }
 
 void ValidatorRequiredWithAll::setOtherFields(const QStringList &otherFields)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall.h
@@ -59,11 +59,9 @@ public:
     ~ValidatorRequiredWithAll();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the list of other fields.
@@ -74,7 +72,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorRequiredWithAll(ValidatorRequiredWithAllPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -66,7 +66,13 @@ QString ValidatorRequiredWithout::validate() const
 
 QString ValidatorRequiredWithout::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("This is required.");
+    } else {
+        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+    }
+    return error;
 }
 
 void ValidatorRequiredWithout::setOtherFields(const QStringList &otherFields)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.cpp
@@ -37,34 +37,31 @@ ValidatorRequiredWithout::~ValidatorRequiredWithout()
 
 QString ValidatorRequiredWithout::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorRequiredWithout);
 
     if (d->otherFields.isEmpty()) {
-        return validationDataError();
-    }
-
-    bool otherMissing = false;
-
-    const QStringList ofc = d->otherFields;
-
-    for (const QString &other : ofc) {
-        if (!d->parameters.contains(other)) {
-            otherMissing = true;
-            break;
-        }
-    }
-
-    if (otherMissing) {
-        if (!value().isEmpty()) {
-            return QString();
-        } else {
-            return validationError();
-        }
+        result = validationDataError();
     } else {
-        return QString();
+
+        bool otherMissing = false;
+
+        const QStringList ofc = d->otherFields;
+
+        for (const QString &other : ofc) {
+            if (!d->parameters.contains(other)) {
+                otherMissing = true;
+                break;
+            }
+        }
+
+        if (otherMissing && value().isEmpty()) {
+            result = validationError();
+        }
     }
 
-    return validationError();
+    return result;
 }
 
 QString ValidatorRequiredWithout::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.cpp
@@ -35,13 +35,12 @@ ValidatorRequiredWithout::~ValidatorRequiredWithout()
 {
 }
 
-bool ValidatorRequiredWithout::validate()
+QString ValidatorRequiredWithout::validate() const
 {
-    Q_D(ValidatorRequiredWithout);
+    Q_D(const ValidatorRequiredWithout);
 
     if (d->otherFields.isEmpty()) {
-        setError(ValidatorRule::ValidationDataError);
-        return false;
+        return validationDataError();
     }
 
     bool otherMissing = false;
@@ -57,22 +56,20 @@ bool ValidatorRequiredWithout::validate()
 
     if (otherMissing) {
         if (!value().isEmpty()) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         } else {
-            return false;
+            return validationError();
         }
     } else {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorRequiredWithout::genericErrorMessage() const
+QString ValidatorRequiredWithout::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(genericFieldName());
+    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
 }
 
 void ValidatorRequiredWithout::setOtherFields(const QStringList &otherFields)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.cpp
@@ -66,7 +66,7 @@ QString ValidatorRequiredWithout::validate() const
 
 QString ValidatorRequiredWithout::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
+    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
 }
 
 void ValidatorRequiredWithout::setOtherFields(const QStringList &otherFields)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.h
@@ -59,11 +59,9 @@ public:
     ~ValidatorRequiredWithout();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the list of other fields.
@@ -74,7 +72,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorRequiredWithout(ValidatorRequiredWithoutPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -66,7 +66,13 @@ QString ValidatorRequiredWithoutAll::validate() const
 
 QString ValidatorRequiredWithoutAll::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("This is required.");
+    } else {
+        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+    }
+    return error;
 }
 
 void ValidatorRequiredWithoutAll::setOtherFields(const QStringList &otherFields)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.cpp
@@ -35,13 +35,12 @@ ValidatorRequiredWithoutAll::~ValidatorRequiredWithoutAll()
 {
 }
 
-bool ValidatorRequiredWithoutAll::validate()
+QString ValidatorRequiredWithoutAll::validate() const
 {
-    Q_D(ValidatorRequiredWithoutAll);
+    Q_D(const ValidatorRequiredWithoutAll);
 
     if (d->otherFields.isEmpty()) {
-        setError(ValidatorRule::ValidationDataError);
-        return false;
+        return validationDataError();
     }
 
     const QStringList ofc = d->otherFields;
@@ -57,22 +56,20 @@ bool ValidatorRequiredWithoutAll::validate()
 
     if (withoutAll) {
         if (!value().isEmpty()) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         } else {
-            return false;
+            return validationError();
         }
     } else {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorRequiredWithoutAll::genericErrorMessage() const
+QString ValidatorRequiredWithoutAll::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(genericFieldName());
+    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
 }
 
 void ValidatorRequiredWithoutAll::setOtherFields(const QStringList &otherFields)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.cpp
@@ -66,7 +66,7 @@ QString ValidatorRequiredWithoutAll::validate() const
 
 QString ValidatorRequiredWithoutAll::genericValidationError() const
 {
-    return QStringLiteral("You must fill in the “%1” field.").arg(fieldLabel());
+    return QStringLiteral("You must fill in the %1 field.").arg(fieldLabel());
 }
 
 void ValidatorRequiredWithoutAll::setOtherFields(const QStringList &otherFields)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.cpp
@@ -37,34 +37,31 @@ ValidatorRequiredWithoutAll::~ValidatorRequiredWithoutAll()
 
 QString ValidatorRequiredWithoutAll::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorRequiredWithoutAll);
 
-    if (d->otherFields.isEmpty()) {
-        return validationDataError();
-    }
-
-    const QStringList ofc = d->otherFields;
-
-    bool withoutAll = true;
-
-    for (const QString &other : ofc) {
-        if (d->parameters.contains(other)) {
-            withoutAll = false;
-            break;
-        }
-    }
-
-    if (withoutAll) {
-        if (!value().isEmpty()) {
-            return QString();
-        } else {
-            return validationError();
-        }
+    if (d->otherFields.empty()) {
+        result = validationDataError();
     } else {
-        return QString();
+
+        const QStringList ofc = d->otherFields;
+
+        bool withoutAll = true;
+
+        for (const QString &other : ofc) {
+            if (d->parameters.contains(other)) {
+                withoutAll = false;
+                break;
+            }
+        }
+
+        if (withoutAll && value().isEmpty()) {
+            result = validationError();
+        }
     }
 
-    return validationError();
+    return result;
 }
 
 QString ValidatorRequiredWithoutAll::genericValidationError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.h
@@ -59,11 +59,9 @@ public:
     ~ValidatorRequiredWithoutAll();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the list of other fields.
@@ -74,7 +72,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorRequiredWithoutAll(ValidatorRequiredWithoutAllPrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
@@ -43,21 +43,23 @@ ValidatorResult::~ValidatorResult()
 
 bool ValidatorResult::isValid() const
 {
-    return d->errorFields.isEmpty();
+    return d->errors.empty();
 }
 
 void ValidatorResult::addError(const QString &field, const QString &message)
 {
-    d->errorFields.append(field);
     d->errorStrings.append(message);
-}
-
-QStringList ValidatorResult::errorFields() const
-{
-    return d->errorFields;
+    QStringList fieldErrors = d->errors.value(field);
+    fieldErrors.append(message);
+    d->errors.insert(field, fieldErrors);
 }
 
 QStringList ValidatorResult::errorStrings() const
 {
     return d->errorStrings;
+}
+
+QHash<QString, QStringList> ValidatorResult::errors() const
+{
+    return d->errors;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
@@ -17,44 +17,41 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include "validatorjson_p.h"
-#include <QJsonDocument>
+#include "validatorresult_p.h"
 
 using namespace Cutelyst;
 
-ValidatorJson::ValidatorJson(const QString &field, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorJsonPrivate(field, label, customError))
+ValidatorResult::ValidatorResult() :
+    d(new ValidatorResultPrivate)
 {
 }
 
-ValidatorJson::ValidatorJson(ValidatorJsonPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorResult::ValidatorResult(const ValidatorResult &other) :
+    d(other.d)
 {
 }
 
-ValidatorJson::~ValidatorJson()
+ValidatorResult::~ValidatorResult()
 {
 }
 
-QString ValidatorJson::validate() const
+bool ValidatorResult::isValid() const
 {
-    Q_D(const ValidatorJson);
-
-    QString v = value();
-
-    if (v.isEmpty()) {
-        return QString();
-    }
-
-    QJsonDocument json = QJsonDocument::fromJson(v.toUtf8());
-    if (!json.isEmpty() && !json.isNull()) {
-        return QString();
-    }
-
-    return validationError();
+    return d->errorFields.isEmpty();
 }
 
-QString ValidatorJson::genericValidationError() const
+void ValidatorResult::addError(const QString &field, const QString &message)
 {
-    return QStringLiteral("The data entered in the “%1” field is not valid JSON.").arg(fieldLabel());
+    d->errorFields.append(field);
+    d->errorStrings.append(message);
+}
+
+QStringList ValidatorResult::errorFields() const
+{
+    return d->errorFields;
+}
+
+QStringList ValidatorResult::errorStrings() const
+{
+    return d->errorStrings;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or

--- a/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
@@ -31,6 +31,12 @@ ValidatorResult::ValidatorResult(const ValidatorResult &other) :
 {
 }
 
+ValidatorResult& ValidatorResult::operator =(const ValidatorResult &other)
+{
+    d = other.d;
+    return *this;
+}
+
 ValidatorResult::~ValidatorResult()
 {
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorresult.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult.h
@@ -48,7 +48,7 @@ class ValidatorResultPrivate;
  * }
  *
  *
- * // you can also comapre the boolen value of the result directly
+ * // you can also compare the boolen value of the result directly
  * // for example together with the Validator::FillStashOnError flag
  * // to automatically fill the stash with error information and input values
  * if (v.validate(Validator::FillStashOnError)) {
@@ -69,9 +69,14 @@ public:
     ValidatorResult();
 
     /*!
-     * \brief Creates a copy of \a other.
+     * \brief Constructs a copy of \a other.
      */
     ValidatorResult(const ValidatorResult &other);
+
+    /*!
+     * \brief Assigns \a other to this object.
+     */
+    ValidatorResult& operator =(const ValidatorResult &other);
 
     /*!
      * \brief Deconstructs the ValidatorResult.

--- a/Cutelyst/Plugins/Utils/Validator/validatorresult.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB. If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+#ifndef CUTELYSTVALIDATORRESULT_H
+#define CUTELYSTVALIDATORRESULT_H
+
+#include <Cutelyst/cutelyst_global.h>
+#include <QString>
+#include <QStringList>
+#include <QSharedDataPointer>
+
+namespace Cutelyst {
+
+class ValidatorResultPrivate;
+
+/*!
+ * \brief Contains the result of Validator.
+ *
+ * ValidatorResult will be returned by Validator when calling Validator::validate(). It contains information
+ * about occured validation errors, like the error strings of each failed validator and a list of fields where
+ * validation failed.
+ *
+ * Beside the isValid() function, that returns \c true if the complete validation process was successful and \c false
+ * if any of the validators failed, it provides a bool operator that makes it usable in \c if statements.
+ *
+ * \code{.cpp}
+ * static Validator v(c, {new ValidatorRequired(QStringLiteral("required_field")});
+ * ValidatorResult r = v.validate();
+ * if (r) {
+ *      // do stuff if validation was successful
+ * } else {
+ *      // do other stuff if validation failed
+ * }
+ *
+ *
+ * // you can also comapre the boolen value of the result directly
+ * // for example together with the Validator::FillStashOnError flag
+ * // to automatically fill the stash with error information and input values
+ * if (v.validate(Validator::FillStashOnError)) {
+ *      // do stuff if validation was successful
+ * }
+ * \endcode
+ *
+ * Validity is simply determined by the fact, that it does not contain any error information.
+ */
+class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorResult {
+public:
+    /*!
+     * \brief Constructs a new ValidatorResult.
+     *
+     * A newly constructed ValidatorResult willl be valid by default, because it
+     * does not cotain any error information.
+     */
+    ValidatorResult();
+
+    /*!
+     * \brief Creates a copy of \a other.
+     */
+    ValidatorResult(const ValidatorResult &other);
+
+    /*!
+     * \brief Deconstructs the ValidatorResult.
+     */
+    ~ValidatorResult();
+
+    /*!
+     * \brief Returns \c true if the validation was successful.
+     *
+     * \note A newly constructed ValidatorResult will be valid by default.
+     */
+    bool isValid() const;
+
+    /*!
+     * \brief Adds new error information to the
+     * \param field     Name of the input field that has input errors.
+     * \param message   Error message shown to the user.
+     */
+    void addError(const QString &field, const QString &message);
+
+    /*!
+     * \brief Returns a list of error messages.
+     *
+     * Returns a list of all error messages from every failed ValidatorRule.
+     */
+    QStringList errorStrings() const;
+
+    /*!
+     * \brief Returns a list of field names with errors.
+     *
+     * Returns a list of all field names for that a ValidatorRule failed.
+     */
+    QStringList errorFields() const;
+
+    /*!
+     * \brief Returns \c true if the validation was successful.
+     *
+     * \note A newly constructed ValidatorResult will be valid by default.
+     */
+    explicit operator bool() const {
+        return isValid();
+    }
+
+private:
+    QSharedDataPointer<ValidatorResultPrivate> d;
+};
+
+}
+
+#endif // CUTELYSTVALIDATORRESULT_H

--- a/Cutelyst/Plugins/Utils/Validator/validatorresult.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult.h
@@ -23,6 +23,7 @@
 #include <QString>
 #include <QStringList>
 #include <QSharedDataPointer>
+#include <QVariantHash>
 
 namespace Cutelyst {
 
@@ -105,11 +106,13 @@ public:
     QStringList errorStrings() const;
 
     /*!
-     * \brief Returns a list of field names with errors.
+     * \brief Returns a dictionary containing fields with errors.
      *
-     * Returns a list of all field names for that a ValidatorRule failed.
+     * Returns a dictionary that contains the fields that have validation errors
+     * together with the errors strings. The \a key will be the field name, the \a value
+     * will be the list of errors for that field.
      */
-    QStringList errorFields() const;
+    QHash<QString,QStringList> errors() const;
 
     /*!
      * \brief Returns \c true if the validation was successful.

--- a/Cutelyst/Plugins/Utils/Validator/validatorresult_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult_p.h
@@ -32,13 +32,13 @@ public:
     ValidatorResultPrivate(const ValidatorResultPrivate &other) :
         QSharedData(other),
         errorStrings(other.errorStrings),
-        errorFields(other.errorFields)
+        errors(other.errors)
     {}
 
     ~ValidatorResultPrivate() {}
 
     QStringList errorStrings;
-    QStringList errorFields;
+    QHash<QString,QStringList> errors;
 };
 
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorresult_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult_p.h
@@ -16,35 +16,31 @@
  * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA 02110-1301, USA.
  */
+#ifndef CUTELYSTVALIDATORRESULT_P_H
+#define CUTELYSTVALIDATORRESULT_P_H
 
-#include "validatorpresent_p.h"
+#include "validatorresult.h"
+#include <QSharedData>
 
-using namespace Cutelyst;
+namespace Cutelyst {
 
-ValidatorPresent::ValidatorPresent(const QString &field, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorPresentPrivate(field, label, customError))
+class ValidatorResultPrivate : public QSharedData
 {
+public:
+    ValidatorResultPrivate() {}
+
+    ValidatorResultPrivate(const ValidatorResultPrivate &other) :
+        QSharedData(other),
+        errorStrings(other.errorStrings),
+        errorFields(other.errorFields)
+    {}
+
+    ~ValidatorResultPrivate() {}
+
+    QStringList errorStrings;
+    QStringList errorFields;
+};
+
 }
 
-ValidatorPresent::ValidatorPresent(ValidatorPresentPrivate &dd) :
-    ValidatorRule(dd)
-{
-}
-
-ValidatorPresent::~ValidatorPresent()
-{
-}
-
-QString ValidatorPresent::validate() const
-{
-    if (parameters().contains(field())) {
-        return QString();
-    }
-
-    return validationError();
-}
-
-QString ValidatorPresent::genericValidationError() const
-{
-    return QStringLiteral("The “%1“ field was not found in the input data.").arg(fieldLabel());
-}
+#endif // CUTELYSTVALIDATORRESULT_P_H

--- a/Cutelyst/Plugins/Utils/Validator/validatorrule.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrule.cpp
@@ -53,16 +53,19 @@ void ValidatorRule::setLabel(const QString &label)
 
 QString ValidatorRule::value() const
 {
+    QString v;
+
     Q_D(const ValidatorRule);
+
     if (!field().isEmpty() && !d->parameters.isEmpty()) {
         if (trimBefore()) {
-            return d->parameters.value(field()).trimmed();
+            v = d->parameters.value(field()).trimmed();
         } else {
-            return d->parameters.value(field());
+            v = d->parameters.value(field());
         }
-    } else {
-        return QString();
     }
+
+    return v;
 }
 
 ParamsMultiMap ValidatorRule::parameters() const { Q_D(const ValidatorRule); return d->parameters; }
@@ -80,12 +83,14 @@ QString ValidatorRule::fieldLabel() const
 
 QString ValidatorRule::validationError() const
 {
+    QString error;
     Q_D(const ValidatorRule);
     if (d->customError.isEmpty()) {
-        return genericValidationError();
+        error = genericValidationError();
     } else {
-        return d->customError;
+        error = d->customError;
     }
+    return error;
 }
 
 QString ValidatorRule::genericValidationError() const
@@ -95,12 +100,14 @@ QString ValidatorRule::genericValidationError() const
 
 QString ValidatorRule::parsingError() const
 {
+    QString error;
     Q_D(const ValidatorRule);
     if (d->customParsingError.isEmpty()) {
-        return genericParsingError();
+        error = genericParsingError();
     } else {
-        return d->customParsingError;
+        error = d->customParsingError;
     }
+    return error;
 }
 
 QString ValidatorRule::genericParsingError() const
@@ -110,12 +117,14 @@ QString ValidatorRule::genericParsingError() const
 
 QString ValidatorRule::validationDataError() const
 {
+    QString error;
     Q_D(const ValidatorRule);
     if (d->customValidationDataError.isEmpty()) {
-        return genericValidationDataError();
+        error = genericValidationDataError();
     } else {
-        return d->customValidationDataError;
+        error = d->customValidationDataError;
     }
+    return error;
 }
 
 QString ValidatorRule::genericValidationDataError() const

--- a/Cutelyst/Plugins/Utils/Validator/validatorrule.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrule.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -76,11 +76,6 @@ void ValidatorRule::setParameters(const ParamsMultiMap &params)
     d->parameters = params;
 }
 
-QString ValidatorRule::fieldLabel() const
-{
-    return !label().isEmpty() ? label() : field();
-}
-
 QString ValidatorRule::validationError() const
 {
     QString error;
@@ -95,7 +90,13 @@ QString ValidatorRule::validationError() const
 
 QString ValidatorRule::genericValidationError() const
 {
-    return QStringLiteral("The input data in the %1 field is not valid.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Input value is not acceptable.");
+    } else {
+        error = QStringLiteral("The input data in the “%1” field is not valid.").arg(label());
+    }
+    return error;
 }
 
 QString ValidatorRule::parsingError() const
@@ -112,7 +113,13 @@ QString ValidatorRule::parsingError() const
 
 QString ValidatorRule::genericParsingError() const
 {
-    return QStringLiteral("Failed to parse the input data of the %1 field.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Failed to parse input data.");
+    } else {
+        error = QStringLiteral("Failed to parse the input data of the “%1” field.").arg(label());
+    }
+    return error;
 }
 
 QString ValidatorRule::validationDataError() const
@@ -129,7 +136,13 @@ QString ValidatorRule::validationDataError() const
 
 QString ValidatorRule::genericValidationDataError() const
 {
-    return QStringLiteral("Missing or unusable validation data for the %1 field.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Missing or unusable validation data.");
+    } else {
+        error = QStringLiteral("Missing or unusable validation data for the “%1” field.").arg(label());
+    }
+    return error;
 }
 
 void ValidatorRule::setCustomError(const QString &customError)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrule.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrule.cpp
@@ -35,26 +35,6 @@ ValidatorRule::~ValidatorRule()
 {
 }
 
-QString ValidatorRule::errorMessage() const
-{
-    Q_D(const ValidatorRule);
-    switch(d->errorType) {
-    case ValidationFailed:
-        if (!d->customError.isEmpty()) {
-            return d->customError;
-        } else {
-            return genericErrorMessage();
-        }
-    case ParsingError:
-        return parsingErrorMessage();
-    case ValidationDataError:
-        return validationDataErrorMessage();
-    case NoError:
-    default:
-        return QString();
-    }
-}
-
 QString ValidatorRule::field() const { Q_D(const ValidatorRule); return d->field; }
 
 void ValidatorRule::setField(const QString &field)
@@ -85,15 +65,7 @@ QString ValidatorRule::value() const
     }
 }
 
-QString ValidatorRule::customError() const { Q_D(const ValidatorRule); return d->customError; }
-
-void ValidatorRule::setCustomError(const QString &customError)
-{
-    Q_D(ValidatorRule);
-    d->customError = customError;
-}
-
-bool ValidatorRule::isValid() const { Q_D(const ValidatorRule); return d->errorType == NoError; }
+ParamsMultiMap ValidatorRule::parameters() const { Q_D(const ValidatorRule); return d->parameters; }
 
 void ValidatorRule::setParameters(const ParamsMultiMap &params)
 {
@@ -101,40 +73,60 @@ void ValidatorRule::setParameters(const ParamsMultiMap &params)
     d->parameters = params;
 }
 
-ParamsMultiMap ValidatorRule::parameters() const
-{
-    Q_D(const ValidatorRule);
-    return d->parameters;
-}
-
-QString ValidatorRule::genericFieldName() const
+QString ValidatorRule::fieldLabel() const
 {
     return !label().isEmpty() ? label() : field();
 }
 
-QString ValidatorRule::genericErrorMessage() const
+QString ValidatorRule::validationError() const
 {
-    return QStringLiteral("The input data in the “%1” field is not valid.").arg(genericFieldName());
+    Q_D(const ValidatorRule);
+    if (d->customError.isEmpty()) {
+        return genericValidationError();
+    } else {
+        return d->customError;
+    }
 }
 
-QString ValidatorRule::parsingErrorMessage() const
+QString ValidatorRule::genericValidationError() const
+{
+    return QStringLiteral("The input data in the “%1” field is not valid.").arg(fieldLabel());
+}
+
+QString ValidatorRule::parsingError() const
 {
     Q_D(const ValidatorRule);
     if (d->customParsingError.isEmpty()) {
-        return QStringLiteral("Failed to parse the input data of the “%1” field.").arg(genericFieldName());
+        return genericParsingError();
     } else {
         return d->customParsingError;
     }
 }
 
-QString ValidatorRule::validationDataErrorMessage() const
+QString ValidatorRule::genericParsingError() const
+{
+    return QStringLiteral("Failed to parse the input data of the “%1” field.").arg(fieldLabel());
+}
+
+QString ValidatorRule::validationDataError() const
 {
     Q_D(const ValidatorRule);
     if (d->customValidationDataError.isEmpty()) {
-        return QStringLiteral("Missing or unusable validation data for the “%1” field.").arg(genericFieldName());
+        return genericValidationDataError();
     } else {
         return d->customValidationDataError;
     }
+}
+
+QString ValidatorRule::genericValidationDataError() const
+{
+    return QStringLiteral("Missing or unusable validation data for the “%1” field.").arg(fieldLabel());
+}
+
+void ValidatorRule::setCustomError(const QString &customError)
+{
+    Q_D(ValidatorRule);
+    d->customError = customError;
 }
 
 void ValidatorRule::setCustomParsingError(const QString &custom)
@@ -149,26 +141,10 @@ void ValidatorRule::setCustomValidationDataError(const QString &custom)
     d->customValidationDataError = custom;
 }
 
+bool ValidatorRule::trimBefore() const { Q_D(const ValidatorRule); return d->trimBefore; }
+
 void ValidatorRule::setTrimBefore(bool trimBefore)
 {
     Q_D(ValidatorRule);
     d->trimBefore = trimBefore;
-}
-
-bool ValidatorRule::trimBefore() const
-{
-    Q_D(const ValidatorRule);
-    return d->trimBefore;
-}
-
-ValidatorRule::ValidatonErrorType ValidatorRule::error() const
-{
-    Q_D(const ValidatorRule);
-    return d->errorType;
-}
-
-void ValidatorRule::setError(ValidatonErrorType errorType)
-{
-    Q_D(ValidatorRule);
-    d->errorType = errorType;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorrule.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrule.cpp
@@ -95,7 +95,7 @@ QString ValidatorRule::validationError() const
 
 QString ValidatorRule::genericValidationError() const
 {
-    return QStringLiteral("The input data in the “%1” field is not valid.").arg(fieldLabel());
+    return QStringLiteral("The input data in the %1 field is not valid.").arg(fieldLabel());
 }
 
 QString ValidatorRule::parsingError() const
@@ -112,7 +112,7 @@ QString ValidatorRule::parsingError() const
 
 QString ValidatorRule::genericParsingError() const
 {
-    return QStringLiteral("Failed to parse the input data of the “%1” field.").arg(fieldLabel());
+    return QStringLiteral("Failed to parse the input data of the %1 field.").arg(fieldLabel());
 }
 
 QString ValidatorRule::validationDataError() const
@@ -129,7 +129,7 @@ QString ValidatorRule::validationDataError() const
 
 QString ValidatorRule::genericValidationDataError() const
 {
-    return QStringLiteral("Missing or unusable validation data for the “%1” field.").arg(fieldLabel());
+    return QStringLiteral("Missing or unusable validation data for the %1 field.").arg(fieldLabel());
 }
 
 void ValidatorRule::setCustomError(const QString &customError)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrule.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrule.h
@@ -36,18 +36,19 @@ class ValidatorRulePrivate;
  *
  * \par Writing a custom validator
  *
- * If you want to implement your own validator logic to use with Valiator, you have to create a class that
+ * If you want to implement your own validator logic to use with Valiadtor, you have to create a class that
  * derives from ValidatorRule. The simplest implementation only needs a constructor an a reimplementation
- * of the validate() funciton. But for more comfort and usability, you should also reimplement genericErrorMessage().
+ * of the validate() funciton. But for more comfort and usability, you should also reimplement validationError().
  * If your validator parses the input into a specific type to validate it and/or if you are using additional parameters,
- * you may also want to reimplement parsingErrorMessage() and validationDataErrorMessage().
+ * you may also want to reimplement parsingError() and validationDataError() to return more appropriate generic error
+ * messages.
  *
- * The most important parameter for every validator is the name of the field to validate. So your own validator should
+ * The most important parameter for every validator is the name of the \a field to validate. So your own validator should
  * require that field in the constructor. For better error messages you should also add an optional paramter to set
- * a label and maybe a custom error message.
+ * a \a label and maybe a \a customError message if validation fails.
  *
- * In the validation logic you have to set setValid() to \c true if validation succeedes (it is set to \c false by default)
- * and return \c true.
+ * In the validation logic you have to return an empty QString if validation succeeded. Everything else will be treeted
+ * as an error message and that the validation has been failed.
  *
  * So lets implement a custom validator that can check for a specific value to be set. (Maybe not a realistic example, but
  * it should be enough for demonstration.)
@@ -61,19 +62,18 @@ class ValidatorRulePrivate;
  * public:
  *     // field: name of the input field
  *     // compareValue: our custom value we want compare
- *     // label: an optional human readable label for the generic error message
- *     // customError: a custom error message that is shown if validation fails
- *     // parent: you should add a parent, so that Validator can control the destruction
- *     MyValidator::MyValidator(const QString &field, const QString &compareValue, const QString &label = QString(), const QString &customError = QString(), QObject *parent = nullptr)
+ *     // label: an optional human readable label for generic error messages
+ *     // customError: a custom error message that is shown if validation fails instead of genericValidationError()
+ *     MyValidator::MyValidator(const QString &field, const QString &compareValue, const QString &label = QString(), const QString &customError = QString())
  *
  *     ~MyValidator();
  *
  *     // this will contain the validation logic
- *     bool validate() override;
+ *     QString validate() const override;
  *
  * protected:
  *     // we want to have a generic error message
- *     QString genericErrorMessage() const override;
+ *     QString validationError() const override;
  *
  * private:
  *     // storing our comparison value
@@ -81,48 +81,49 @@ class ValidatorRulePrivate;
  * }
  *
  *
- * MyValidator::MyValidator(const QString &field, const QString &compareValue, const QString &label, const QString &customError, QObject *parent) :
- *     Cutelyst::ValidatorRule(field, label, customError, parent)
+ * MyValidator::MyValidator(const QString &field, const QString &compareValue, const QString &label, const QString &customError) :
+ *     Cutelyst::ValidatorRule(field, label, customError), m_compareValue(compareValue)
  * {
- *     m_compareValue;
  * }
  *
  * MyValidator::~MyValidator()
  * {
  * }
  *
- * bool MyValidator::validate()
+ * // when reimplementing the validate function, keep in mind, that
+ * // an empty returned string is seen as successful validation, everything
+ * // else will be seen as an error
+ * QString MyValidator::validate() const
  * {
  *     // lets get the field value
- *     QString v = value();
+ *     const QString v = value();
  *
  *     // if the value is empty or the field is missing, the validation should succeed,
  *     // because we already have the required validators for that purpose
- *     if (v.isEmpts()) {
- *         setError(ValidatorRule::NoError);
- *         return true;
+ *     if (v.isEmpty()) {
+ *         return QString();
  *     }
  *
- *     // if our comparision value is empty, the validation should fail and we will
- *     // set setValidationDataError() to true to return the appropriate error message
+ *     // if our comparision value is empty, the validation should fail and we want
+ *     // to return an error message according to this situation
  *     if (m_compareValue.isEmpty()) {
- *         setError(ValidatorRule::ValidationDataError);
- *         return false;
+ *         return validationDataError();
  *     }
  *
- *     // now lets compare our values
+ *     // now lets compare our values and if they are the same
+ *     // we will return an empty QString
  *     if (m_compareValue == value()) {
- *         setError(ValidatorRule::NoError);
- *         return true;
+ *         return QString();
  *     }
  *
- *     return false;
+ *     // if we are at this point, validation failed and we are returning the validation error message
+ *     return validationError();
  * }
  *
  *
- * QString MyValidator::genericErrorMessage() const
+ * QString MyValidator::genericValidationError() const
  * {
- *     return tr("The “%1” field must constain the following value: %2").arg(genericFieldName(), m_compareValue);
+ *     return tr("The “%1” field must constain the following value: %2").arg(fieldLabel(), m_compareValue);
  * }
  * \endcode
  *
@@ -131,16 +132,6 @@ class ValidatorRulePrivate;
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorRule
 {
 public:
-    /*!
-     * \brief Defines the validation status.
-     */
-    enum ValidatonErrorType {
-        NoError             = 0,    /**< The validation succeeded and the input data is valid. */
-        ValidationFailed    = 1,    /**< Validation failed and data is not valid. */
-        ParsingError        = 2,    /**< The input data could not be parsed into a comparable type. Validation failed. */
-        ValidationDataError = 3     /**< The data to validate against is missing or unusable. Validation failed. */
-    };
-
     /*!
      * \brief Constructs a new ValidatorRule with given parameters and \a parent.
      * \param field         Name of the field to validate.
@@ -155,30 +146,35 @@ public:
     ~ValidatorRule();
 
     /*!
-     * \brief Reimplement this in a subclass to perform the validation.
+     * \brief Returns an empty string on success, otherwise a string containing the error message.
      *
-     * When reimplementing this function, do not forget to set the status via setError().
+     * This is the main function to reimplement when writing a custom validator. When reimplementing
+     * this function in a class derived from ValidatorRule, you have to return an empty string if
+     * validation succeeded and the corresponding error if it fails. There are currently three error
+     * functions that should be used for different error cases:
+     *
+     * \li validationError() - if validation itself fails
+     * \li validationDataError() - if there is a problem with missing or invalid validation data, like comparison values
+     * \li parsingError() - if the parsing of an input data fails in a valiator that not originally checks the parsing, but the parsing result
      *
      * \par Example
      *
      * \code{.cpp}
-     * bool MyValidator::validate() const
+     * QString MyValidator::validate() const
      * {
      *      if (m_myComparisonValue.isEmpty()) {
-     *          setError(ValidatorRule::ValidationDataError);
-     *          return false;
+     *          return validationDataError();
      *      }
      *
      *      if (m_myComparisonValue == value()) {
-     *          setError(ValidatorRule::NoError)
-     *          return true;
+     *          return QString();
      *      } else {
-     *          return false;
+     *          return validationError();
      *      }
      * }
      * \endcode
      */
-    virtual bool validate() = 0;
+    virtual QString validate() const = 0;
 
     /*!
      * \brief Returns the name of the field to validate.
@@ -198,29 +194,6 @@ public:
     QString value() const;
 
     /*!
-     * \brief Returns the custom error.
-     * \sa setCustomError()
-     */
-    QString customError() const;
-
-    /*!
-     * \brief Returns \c true if the validation was successful.
-     *
-     * Returns \c true if the validation was successful and error() returns ValidatorRule::NoError.
-     */
-    bool isValid() const;
-
-    /*!
-     * \brief Returns an error message if validation fails.
-     *
-     * Use isValid() or error() to check if the validation failed. Depending on the ValidatorRule::ValidationErrorType it
-     * will return the appropriate error message, either a generic one, or if set, a custom one.
-     *
-     * \sa setCustomError(), setCustomParsingError(), setCustomValidationDataError()
-     */
-    QString errorMessage() const;
-
-    /*!
      * \brief Returns true if field value should be trimmed before validation.
      *
      * By default, this will return \c true and all input values will be trimmed before validation to
@@ -229,16 +202,6 @@ public:
      * \sa setTrimBefore()
      */
     bool trimBefore() const;
-
-    /*!
-     * \brief Returns the error type.
-     *
-     * By default this will return ValidationRule::ValidationFailed. Only if validation
-     * has been performed and was successful, it will return ValidationRule::NoError.
-     *
-     * If this returns ValidationRule::NoError, isValid() will return \c true.
-     */
-    ValidatonErrorType error() const;
 
 
 
@@ -255,12 +218,6 @@ public:
     void setLabel(const QString &label);
 
     /*!
-     * \brief Sets a cutom error returned with errorMessage()
-     * \sa customError()
-     */
-    void setCustomError(const QString &customError);
-
-    /*!
      * \brief Sets the request parameters to validate.
      * \sa parameters()
      */
@@ -273,21 +230,27 @@ public:
     ParamsMultiMap parameters() const;
 
     /*!
+     * \brief Sets a cutom error returned with errorMessage()
+     * \sa validationError()
+     */
+    void setCustomError(const QString &customError);
+
+    /*!
      * \brief Sets a custom error message that is shown if parsing of input data fails.
-     * \sa customParsingError(), parsingErrorMessage()
+     * \sa parsingError()
      */
     void setCustomParsingError(const QString &custom);
 
     /*!
      * \brief Sets a custom error message if validation data is invalid or missing.
-     * \sa customValidationDataError(), validationDataErrorMessage()
+     * \sa validationDataError()
      */
     void setCustomValidationDataError(const QString &custom);
 
     /*!
      * \brief Set to \c false to not trim input value before validation.
      *
-     * By default, this value is set to \c true and all input values will be trimmed before validation to
+     * By default, this value is set to \c true and all input values will be \link QString::trimmed() trimmed \endlink before validation to
      * remove whitespaces from the beginning and the end.
      *
      * \sa trimBefore()
@@ -299,34 +262,38 @@ protected:
     ValidatorRule(ValidatorRulePrivate &dd);
 
     /*!
-     * \brief Returns a generic error message.
+     * \brief Returns a descriptive error message if validation failed.
      *
-     * Reimplement this in your subclass to return a generic error message that will be used by the ValidatorRule::errorMessage() function.
-     *
-     * The default implementation returns a string like this: "The input data in the “Foo Bar” field is not valid.".
-     *
-     * When reimplementing this, you should the genericFieldName() function to either get a label, if any has been set, or the field name.
-     *
-     * \par Example
-     *
-     * \code{.cpp}
-     * QString MyValidator::genericErrorMessage() const
-     * {
-     *      return tr("The “%1” field has the wrong content.").arg(genericFieldName());
-     * }
-     * \endcode
+     * This will either return the custom error message set via setCustomError() or the message
+     * returned by genericValidationError(). When writing a new ValidatorRule, use this in your
+     * reimplementaion of validate() if validation failed.
      */
-    virtual QString genericErrorMessage() const;
+    QString validationError() const;
+
+    /*!
+     * \brief Returns a generic error mesage if validation failed.
+     *
+     * If you want to have a more specifc generic validation error message for your validator,
+     * reimplment this in a subclass.
+     */
+    virtual QString genericValidationError() const;
 
     /*!
      * \brief Returns an error message if an error occured while parsing input.
      *
-     * Reimplement this in your subclass to return an error message in case the input data could not be parsed
-     * into a comparative value. The default implementation returns a generic message unless a custom one is set via setCustomParsingError().
-     *
-     * When reimplementing this function take into account that there might be a custom parsing error message set by the user.
+     * This will either return the custom parsing error message set via setCustomParsingError() or
+     * the message returned by genericParsingError(). When writing a new ValidatorRule, use this
+     * in your reimplementation of validate() if parsing of input data fails.
      */
-    virtual QString parsingErrorMessage() const;
+    QString parsingError() const;
+
+    /*!
+     * \brief Returns a generic error message if an error occures while parsing input.
+     *
+     * If you want to have a more specific generic parsing error message for your validator,
+     * reimplement this in a subclass.
+     */
+    virtual QString genericParsingError() const;
 
     /*!
      * \brief Returns an error message if any validation data is missing or invalid.
@@ -336,38 +303,24 @@ protected:
      *
      * When reimplementing this function take into account that there might be a custom validation data error message set by the user.
      */
-    virtual QString validationDataErrorMessage() const;
+    QString validationDataError() const;
 
     /*!
-     * \brief Returns the name of the field for the generic error message.
+     * \brief Returns a generic error message if any validation data is missing or invalid.
      *
-     * This can be used by genericErrorMessage() to retrieve the field name.
+     * If you want to have a more specific generic validation data error message for your validator,
+     * reimplement this in a subclass.
+     */
+    virtual QString genericValidationDataError() const;
+
+    /*!
+     * \brief Returns the name of the field for generic error messages.
+     *
+     * This can be used by validationError() to retrieve the field name.
      * It will return the \link ValidatorRule::label() label() \endlink if it is set, otherwise
      * it will return the \link ValidatorRule::field() field() \endlink.
      */
-    QString genericFieldName() const;
-
-    /*!
-     * \brief Returns the custom parsing error message if any is set.
-     *
-     * \sa setCustomParsingError(), parsingErrorMessage()
-     */
-    QString customParsingError() const;
-
-    /*!
-     * \brief Returns the custom validation data error message if any is set.
-     *
-     * \sa setCustomValidationDataError(), validationDataErrorMessage()
-     */
-    QString customValidationDataError() const;
-
-    /*!
-     * \brief Sets the error type.
-     *
-     * Use this to set the result of the validation when reimplementing ValidatorRule. The default value is ValidationRule::ValidationError,
-     * if the validation succeeded, set this to ValidationRule::NoError.
-     */
-    void setError(ValidatonErrorType errorType);
+    QString fieldLabel() const;
 
 private:
     Q_DECLARE_PRIVATE(ValidatorRule)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrule.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrule.h
@@ -123,7 +123,7 @@ class ValidatorRulePrivate;
  *
  * QString MyValidator::genericValidationError() const
  * {
- *     return tr("The “%1” field must constain the following value: %2").arg(fieldLabel(), m_compareValue);
+ *     return tr("The %1 field must constain the following value: %2").arg(fieldLabel(), m_compareValue);
  * }
  * \endcode
  *

--- a/Cutelyst/Plugins/Utils/Validator/validatorrule_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrule_p.h
@@ -30,22 +30,14 @@ class ValidatorRulePrivate
 {
 public:
     ValidatorRulePrivate() :
-        valid(false),
-        parsingError(false),
-        validationDataError(false),
-        trimBefore(true),
-        errorType(ValidatorRule::ValidationFailed)
+        trimBefore(true)
     {}
 
     ValidatorRulePrivate(const QString f, const QString &l, const QString &e) :
         field(f),
         label(l),
         customError(e),
-        valid(false),
-        parsingError(false),
-        validationDataError(false),
-        trimBefore(true),
-        errorType(ValidatorRule::ValidationFailed)
+        trimBefore(true)
     {}
 
     virtual ~ValidatorRulePrivate() {}
@@ -124,14 +116,10 @@ public:
     QString field;
     QString label;
     QString customError;
-    bool valid;
     ParamsMultiMap parameters;
-    bool parsingError;
-    bool validationDataError;
     QString customParsingError;
     QString customValidationDataError;
     bool trimBefore;
-    ValidatorRule::ValidatonErrorType errorType;
 };
 
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorsame.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsame.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -52,9 +52,17 @@ QString ValidatorSame::validate() const
 
 QString ValidatorSame::genericValidationError() const
 {
+    QString error;
+
     Q_D(const ValidatorSame);
 
-    return QStringLiteral("The %1 field must have the same value as the %2 field.").arg(fieldLabel(), !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
+    if (label().isEmpty()) {
+        error = QStringLiteral("Must be the same as in the “%1” field.").arg(!d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
+    } else {
+        error = QStringLiteral("The “%1” field must have the same value as the “%2” field.").arg(label(), !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
+    }
+
+    return error;
 }
 
 void ValidatorSame::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatorsame.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsame.cpp
@@ -35,32 +35,30 @@ ValidatorSame::~ValidatorSame()
 {
 }
 
-bool ValidatorSame::validate()
+QString ValidatorSame::validate() const
 {
-    Q_D(ValidatorSame);
+    Q_D(const ValidatorSame);
 
     QString v = value();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     if (v == d->parameters.value(d->otherField)) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorSame::genericErrorMessage() const
+QString ValidatorSame::genericValidationError() const
 {
     Q_D(const ValidatorSame);
 
     QString ol = !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField;
 
-    return QStringLiteral("The “%1” field must have the same value as the “%2” field.").arg(genericFieldName(), ol);
+    return QStringLiteral("The “%1” field must have the same value as the “%2” field.").arg(fieldLabel(), ol);
 }
 
 void ValidatorSame::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatorsame.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsame.cpp
@@ -54,7 +54,7 @@ QString ValidatorSame::genericValidationError() const
 {
     Q_D(const ValidatorSame);
 
-    return QStringLiteral("The “%1” field must have the same value as the “%2” field.").arg(fieldLabel(), !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
+    return QStringLiteral("The %1 field must have the same value as the %2 field.").arg(fieldLabel(), !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
 }
 
 void ValidatorSame::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatorsame.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsame.cpp
@@ -37,28 +37,24 @@ ValidatorSame::~ValidatorSame()
 
 QString ValidatorSame::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorSame);
 
-    QString v = value();
+    const QString v = value();
 
-    if (v.isEmpty()) {
-        return QString();
+    if (!v.isEmpty() && (v != d->parameters.value(d->otherField))) {
+        result = validationError();
     }
 
-    if (v == d->parameters.value(d->otherField)) {
-        return QString();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorSame::genericValidationError() const
 {
     Q_D(const ValidatorSame);
 
-    QString ol = !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField;
-
-    return QStringLiteral("The “%1” field must have the same value as the “%2” field.").arg(fieldLabel(), ol);
+    return QStringLiteral("The “%1” field must have the same value as the “%2” field.").arg(fieldLabel(), !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
 }
 
 void ValidatorSame::setOtherField(const QString &otherField)

--- a/Cutelyst/Plugins/Utils/Validator/validatorsame.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsame.h
@@ -57,11 +57,9 @@ public:
     ~ValidatorSame();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the name of the other field.
@@ -72,7 +70,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorSame(ValidatorSamePrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorsize.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsize.cpp
@@ -35,63 +35,58 @@ ValidatorSize::~ValidatorSize()
 {
 }
 
-bool ValidatorSize::validate()
+QString ValidatorSize::validate() const
 {
     QString v = value();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    Q_D(ValidatorSize);
+    Q_D(const ValidatorSize);
 
     if (d->type == QMetaType::Int) {
         qlonglong val = v.toLongLong();
         qlonglong size = (qlonglong)d->size;
         if (val == size) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else if (d->type == QMetaType::UInt) {
         qulonglong val = v.toULongLong();
         qulonglong size = (qulonglong)d->size;
         if (val == size) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else if (d->type == QMetaType::Float) {
         double val = v.toDouble();
         if (val == d->size) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else if (d->type == QMetaType::QString) {
         int val = v.length();
         int size = (int)d->size;
         if (val == size) {
-            setError(ValidatorRule::NoError);
-            return true;
+            return QString();
         }
     } else {
-        setError(ValidatorRule::ValidationDataError);
+        return validationDataError();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorSize::genericErrorMessage() const
+QString ValidatorSize::genericValidationError() const
 {
     Q_D(const ValidatorSize);
 
     if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        return QStringLiteral("The value of the “%1” field has to be equal to %2.").arg(genericFieldName(),QString::number(d->size, 'f', 0));
+        return QStringLiteral("The value of the “%1” field has to be equal to %2.").arg(fieldLabel(),QString::number(d->size, 'f', 0));
     } else if (d->type == QMetaType::Float) {
-        return QStringLiteral("The value of the “%1” field has to be equal to %2.").arg(genericFieldName(), QString::number(d->size));
+        return QStringLiteral("The value of the “%1” field has to be equal to %2.").arg(fieldLabel(), QString::number(d->size));
     } else if (d->type == QMetaType::QString) {
-        return QStringLiteral("The length of the “%1” field has to be equal to %2.").arg(genericFieldName(), QString::number(d->size, 'f', 0));
+        return QStringLiteral("The length of the “%1” field has to be equal to %2.").arg(fieldLabel(), QString::number(d->size, 'f', 0));
     } else {
-        return QString();
+        return validationDataError();
     }
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorsize.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsize.cpp
@@ -83,11 +83,11 @@ QString ValidatorSize::genericValidationError() const
     Q_D(const ValidatorSize);
 
     if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        error = QStringLiteral("The value of the “%1” field has to be equal to %2.").arg(fieldLabel(),QString::number(d->size, 'f', 0));
+        error = QStringLiteral("The value of the %1 field has to be equal to %2.").arg(fieldLabel(),QString::number(d->size, 'f', 0));
     } else if (d->type == QMetaType::Float) {
-        error =  QStringLiteral("The value of the “%1” field has to be equal to %2.").arg(fieldLabel(), QString::number(d->size));
+        error =  QStringLiteral("The value of the %1 field has to be equal to %2.").arg(fieldLabel(), QString::number(d->size));
     } else if (d->type == QMetaType::QString) {
-        error =  QStringLiteral("The length of the “%1” field has to be equal to %2.").arg(fieldLabel(), QString::number(d->size, 'f', 0));
+        error =  QStringLiteral("The length of the %1 field has to be equal to %2.").arg(fieldLabel(), QString::number(d->size, 'f', 0));
     } else {
         error =  validationDataError();
     }

--- a/Cutelyst/Plugins/Utils/Validator/validatorsize.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsize.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -82,14 +82,29 @@ QString ValidatorSize::genericValidationError() const
 
     Q_D(const ValidatorSize);
 
-    if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        error = QStringLiteral("The value of the %1 field has to be equal to %2.").arg(fieldLabel(),QString::number(d->size, 'f', 0));
-    } else if (d->type == QMetaType::Float) {
-        error =  QStringLiteral("The value of the %1 field has to be equal to %2.").arg(fieldLabel(), QString::number(d->size));
-    } else if (d->type == QMetaType::QString) {
-        error =  QStringLiteral("The length of the %1 field has to be equal to %2.").arg(fieldLabel(), QString::number(d->size, 'f', 0));
+    QString size;
+    if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::QString) {
+        size = QString::number(d->size, 'f', 0);
     } else {
-        error =  validationDataError();
+        size = QString::number(d->size);
+    }
+
+    if (label().isEmpty()) {
+        if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::Float) {
+            error = QStringLiteral("Value has to be equal to %1.").arg(size);
+        } else if (d->type == QMetaType::QString) {
+            error = QStringLiteral("Length has to be equal to %1.").arg(size);
+        } else {
+            error = validationDataError();
+        }
+    } else {
+        if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::Float) {
+            error = QStringLiteral("The value of the “%1” field has to be equal to %2.").arg(label(), size);
+        } else if (d->type == QMetaType::QString) {
+            error = QStringLiteral("The length of the “%1” field has to be equal to %2.").arg(label(), size);
+        } else {
+            error = validationDataError();
+        }
     }
 
     return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatorsize.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsize.cpp
@@ -37,57 +37,62 @@ ValidatorSize::~ValidatorSize()
 
 QString ValidatorSize::validate() const
 {
-    QString v = value();
+    QString result;
 
-    if (v.isEmpty()) {
-        return QString();
+    const QString v = value();
+
+    if (!v.isEmpty()) {
+
+        Q_D(const ValidatorSize);
+
+        if (d->type == QMetaType::Int) {
+            qlonglong val = v.toLongLong();
+            qlonglong size = (qlonglong)d->size;
+            if (val != size) {
+                result = validationError();
+            }
+        } else if (d->type == QMetaType::UInt) {
+            qulonglong val = v.toULongLong();
+            qulonglong size = (qulonglong)d->size;
+            if (val != size) {
+                result = validationError();
+            }
+        } else if (d->type == QMetaType::Float) {
+            double val = v.toDouble();
+            if (val != d->size) {
+                result = validationError();
+            }
+        } else if (d->type == QMetaType::QString) {
+            int val = v.length();
+            int size = (int)d->size;
+            if (val != size) {
+                result = validationError();
+            }
+        } else {
+            result = validationDataError();
+        }
     }
 
-    Q_D(const ValidatorSize);
-
-    if (d->type == QMetaType::Int) {
-        qlonglong val = v.toLongLong();
-        qlonglong size = (qlonglong)d->size;
-        if (val == size) {
-            return QString();
-        }
-    } else if (d->type == QMetaType::UInt) {
-        qulonglong val = v.toULongLong();
-        qulonglong size = (qulonglong)d->size;
-        if (val == size) {
-            return QString();
-        }
-    } else if (d->type == QMetaType::Float) {
-        double val = v.toDouble();
-        if (val == d->size) {
-            return QString();
-        }
-    } else if (d->type == QMetaType::QString) {
-        int val = v.length();
-        int size = (int)d->size;
-        if (val == size) {
-            return QString();
-        }
-    } else {
-        return validationDataError();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorSize::genericValidationError() const
 {
+    QString error;
+
     Q_D(const ValidatorSize);
 
     if (d->type == QMetaType::Int || d->type == QMetaType::UInt) {
-        return QStringLiteral("The value of the “%1” field has to be equal to %2.").arg(fieldLabel(),QString::number(d->size, 'f', 0));
+        error = QStringLiteral("The value of the “%1” field has to be equal to %2.").arg(fieldLabel(),QString::number(d->size, 'f', 0));
     } else if (d->type == QMetaType::Float) {
-        return QStringLiteral("The value of the “%1” field has to be equal to %2.").arg(fieldLabel(), QString::number(d->size));
+        error =  QStringLiteral("The value of the “%1” field has to be equal to %2.").arg(fieldLabel(), QString::number(d->size));
     } else if (d->type == QMetaType::QString) {
-        return QStringLiteral("The length of the “%1” field has to be equal to %2.").arg(fieldLabel(), QString::number(d->size, 'f', 0));
+        error =  QStringLiteral("The length of the “%1” field has to be equal to %2.").arg(fieldLabel(), QString::number(d->size, 'f', 0));
     } else {
-        return validationDataError();
+        error =  validationDataError();
     }
+
+    return error;
 }
 
 void ValidatorSize::setType(QMetaType::Type type)

--- a/Cutelyst/Plugins/Utils/Validator/validatorsize.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsize.h
@@ -69,11 +69,9 @@ public:
     ~ValidatorSize();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets the type to validate.
@@ -89,7 +87,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorSize(ValidatorSizePrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatortime.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatortime.cpp
@@ -36,35 +36,33 @@ ValidatorTime::~ValidatorTime()
 {
 }
 
-bool ValidatorTime::validate()
+QString ValidatorTime::validate() const
 {
-    Q_D(ValidatorTime);
+    Q_D(const ValidatorTime);
 
     QString v = value();
 
     if (v.isEmpty()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
     QTime date = d->extractTime(v, d->format);
 
     if (date.isValid()) {
-        setError(ValidatorRule::NoError);
-        return true;
+        return QString();
     }
 
-    return false;
+    return validationError();
 }
 
-QString ValidatorTime::genericErrorMessage() const
+QString ValidatorTime::genericValidationError() const
 {
     Q_D(const ValidatorTime);
 
    if (!d->format.isEmpty()) {
-       return QStringLiteral("The data in the “%1” field can not be interpreted as time of this schema: %2").arg(genericFieldName(), d->format);
+       return QStringLiteral("The data in the “%1” field can not be interpreted as time of this schema: %2").arg(fieldLabel(), d->format);
    } else {
-       return QStringLiteral("The data in the “%1” field can not be interpreted as time.").arg(genericFieldName());
+       return QStringLiteral("The data in the “%1” field can not be interpreted as time.").arg(fieldLabel());
    }
 }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatortime.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatortime.cpp
@@ -61,9 +61,9 @@ QString ValidatorTime::genericValidationError() const
     Q_D(const ValidatorTime);
 
    if (!d->format.isEmpty()) {
-       error = QStringLiteral("The data in the “%1” field can not be interpreted as time of this schema: %2").arg(fieldLabel(), d->format);
+       error = QStringLiteral("The data in the %1 field can not be interpreted as time of this schema: %2").arg(fieldLabel(), d->format);
    } else {
-       error = QStringLiteral("The data in the “%1” field can not be interpreted as time.").arg(fieldLabel());
+       error = QStringLiteral("The data in the %1 field can not be interpreted as time.").arg(fieldLabel());
    }
 
    return error;

--- a/Cutelyst/Plugins/Utils/Validator/validatortime.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatortime.cpp
@@ -38,32 +38,35 @@ ValidatorTime::~ValidatorTime()
 
 QString ValidatorTime::validate() const
 {
+    QString result;
+
     Q_D(const ValidatorTime);
 
-    QString v = value();
+    const QString v = value();
 
-    if (v.isEmpty()) {
-        return QString();
+    if (!v.isEmpty()) {
+        const QTime date = d->extractTime(v, d->format);
+        if (!date.isValid()) {
+            result = validationError();
+        }
     }
 
-    QTime date = d->extractTime(v, d->format);
-
-    if (date.isValid()) {
-        return QString();
-    }
-
-    return validationError();
+    return result;
 }
 
 QString ValidatorTime::genericValidationError() const
 {
+    QString error;
+
     Q_D(const ValidatorTime);
 
    if (!d->format.isEmpty()) {
-       return QStringLiteral("The data in the “%1” field can not be interpreted as time of this schema: %2").arg(fieldLabel(), d->format);
+       error = QStringLiteral("The data in the “%1” field can not be interpreted as time of this schema: %2").arg(fieldLabel(), d->format);
    } else {
-       return QStringLiteral("The data in the “%1” field can not be interpreted as time.").arg(fieldLabel());
+       error = QStringLiteral("The data in the “%1” field can not be interpreted as time.").arg(fieldLabel());
    }
+
+   return error;
 }
 
 void ValidatorTime::setFormat(const QString &format)

--- a/Cutelyst/Plugins/Utils/Validator/validatortime.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatortime.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -60,11 +60,15 @@ QString ValidatorTime::genericValidationError() const
 
     Q_D(const ValidatorTime);
 
-   if (!d->format.isEmpty()) {
-       error = QStringLiteral("The data in the %1 field can not be interpreted as time of this schema: %2").arg(fieldLabel(), d->format);
-   } else {
-       error = QStringLiteral("The data in the %1 field can not be interpreted as time.").arg(fieldLabel());
-   }
+    if (label().isEmpty()) {
+        error = QStringLiteral("Not a valid time.");
+    } else {
+        if (!d->format.isEmpty()) {
+            error = QStringLiteral("The data in the “%1” field can not be interpreted as time of this schema: “%2”").arg(label(), d->format);
+        } else {
+            error = QStringLiteral("The data in the “%1” field can not be interpreted as time.").arg(label());
+        }
+    }
 
    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatortime.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatortime.h
@@ -60,11 +60,9 @@ public:
     ~ValidatorTime();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets an optional date format.
@@ -75,7 +73,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorTime(ValidatorTimePrivate &dd);
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorurl.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorurl.cpp
@@ -106,7 +106,7 @@ QString ValidatorUrl::validate() const
 
 QString ValidatorUrl::genericValidationError() const
 {
-    return QStringLiteral("The value in the “%1” field is not a valid URL.").arg(fieldLabel());
+    return QStringLiteral("The value in the %1 field is not a valid URL.").arg(fieldLabel());
 }
 
 void ValidatorUrl::setConstraints(Constraints constraints)

--- a/Cutelyst/Plugins/Utils/Validator/validatorurl.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorurl.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
@@ -106,7 +106,13 @@ QString ValidatorUrl::validate() const
 
 QString ValidatorUrl::genericValidationError() const
 {
-    return QStringLiteral("The value in the %1 field is not a valid URL.").arg(fieldLabel());
+    QString error;
+    if (label().isEmpty()) {
+        error = QStringLiteral("Not a valid URL.");
+    } else {
+        error = QStringLiteral("The value in the “%1” field is not a valid URL.").arg(label());
+    }
+    return error;
 }
 
 void ValidatorUrl::setConstraints(Constraints constraints)

--- a/Cutelyst/Plugins/Utils/Validator/validatorurl.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorurl.h
@@ -69,11 +69,9 @@ public:
     ~ValidatorUrl();
     
     /*!
-     * \brief Performs the validation.
-     *
-     * Returns \c true on success.
+     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
      */
-    bool validate() override;
+    QString validate() const override;
 
     /*!
      * \brief Sets optional validation contraints.
@@ -89,7 +87,7 @@ protected:
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericErrorMessage() const override;
+    QString genericValidationError() const override;
     
     ValidatorUrl(ValidatorUrlPrivate &dd);
     

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -22,6 +22,7 @@
 #include <Cutelyst/upload.h>
 #include <Cutelyst/Plugins/Utils/Validator/Validator>
 #include <Cutelyst/Plugins/Utils/Validator/Validators>
+#include <Cutelyst/Plugins/Utils/Validator/validatorresult.h>
 
 using namespace Cutelyst;
 
@@ -57,10 +58,11 @@ public:
     C_ATTR(accepted, :Local :AutoArgs)
     void accepted(Context *c) {
         Validator v({new ValidatorAccepted(QStringLiteral("accepted_field"), QString(), QStringLiteral("invalid"))});
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -72,10 +74,11 @@ public:
         va->setCustomError(QStringLiteral("invalid"));
         va->setCustomParsingError(QStringLiteral("parsingerror"));
         v.addValidator(va);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -87,10 +90,11 @@ public:
         va->setCustomError(QStringLiteral("invalid"));
         va->setCustomParsingError(QStringLiteral("parsingerror"));
         v.addValidator(va);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -102,10 +106,11 @@ public:
         va->setCustomError(QStringLiteral("invalid"));
         va->setCustomParsingError(QStringLiteral("parsingerror"));
         v.addValidator(va);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -118,10 +123,11 @@ public:
         va->setCustomParsingError(QStringLiteral("parsingerror"));
         va->setInputFormat(QStringLiteral("yyyy d MM HH:mm"));
         v.addValidator(va);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -133,10 +139,11 @@ public:
         va->setCustomError(QStringLiteral("invalid"));
         va->setCustomValidationDataError(QStringLiteral("validationdataerror"));
         v.addValidator(va);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -148,10 +155,11 @@ public:
         va->setCustomError(QStringLiteral("invalid"));
         va->setCustomValidationDataError(QStringLiteral("validationdataerror"));
         v.addValidator(va);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -160,10 +168,11 @@ public:
     void alpha(Context *c) {
         Validator v;
         v.addValidator(new ValidatorAlpha(QStringLiteral("alpha_field"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -172,10 +181,11 @@ public:
     void alphaDash(Context *c) {
         Validator v;
         v.addValidator(new ValidatorAlphaDash(QStringLiteral("alphadash_field"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -184,10 +194,11 @@ public:
     void alphaNum(Context *c) {
         Validator v;
         v.addValidator(new ValidatorAlphaNum(QStringLiteral("alphanum_field"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -199,10 +210,11 @@ public:
         va->setCustomError(QStringLiteral("invalid"));
         va->setCustomParsingError(QStringLiteral("parsingerror"));
         v.addValidator(va);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -214,10 +226,11 @@ public:
         va->setCustomError(QStringLiteral("invalid"));
         va->setCustomParsingError(QStringLiteral("parsingerror"));
         v.addValidator(va);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -229,10 +242,11 @@ public:
         va->setCustomError(QStringLiteral("invalid"));
         va->setCustomParsingError(QStringLiteral("parsingerror"));
         v.addValidator(va);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -245,10 +259,11 @@ public:
         va->setCustomParsingError(QStringLiteral("parsingerror"));
         va->setInputFormat(QStringLiteral("yyyy d MM HH:mm"));
         v.addValidator(va);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -260,10 +275,11 @@ public:
         va->setCustomError(QStringLiteral("invalid"));
         va->setCustomValidationDataError(QStringLiteral("validationdataerror"));
         v.addValidator(va);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -275,10 +291,11 @@ public:
         va->setCustomError(QStringLiteral("invalid"));
         va->setCustomValidationDataError(QStringLiteral("validationdataerror"));
         v.addValidator(va);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -287,10 +304,11 @@ public:
     void betweenInt(Context *c) {
         Validator v;
         v.addValidator(new ValidatorBetween(QStringLiteral("between_field"), QMetaType::Int, -10, 10, QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -299,10 +317,11 @@ public:
     void betweenUint(Context *c) {
         Validator v;
         v.addValidator(new ValidatorBetween(QStringLiteral("between_field"), QMetaType::UInt, 10, 20, QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -311,10 +330,11 @@ public:
     void betweenFloat(Context *c) {
         Validator v;
         v.addValidator(new ValidatorBetween(QStringLiteral("between_field"), QMetaType::Float, -10.0, 10.0, QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -323,10 +343,11 @@ public:
     void betweenString(Context *c) {
         Validator v;
         v.addValidator(new ValidatorBetween(QStringLiteral("between_field"), QMetaType::QString, 5, 10, QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -335,10 +356,11 @@ public:
     void boolean(Context *c) {
         Validator v;
         v.addValidator(new ValidatorBoolean(QStringLiteral("boolean_field"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -347,10 +369,11 @@ public:
     void confirmed(Context *c) {
         Validator v;
         v.addValidator(new ValidatorConfirmed(QStringLiteral("pass"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -359,10 +382,11 @@ public:
     void date(Context *c) {
         Validator v;
         v.addValidator(new ValidatorDate(QStringLiteral("field"), QString(), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -371,10 +395,11 @@ public:
     void dateFormat(Context *c) {
         Validator v;
         v.addValidator(new ValidatorDate(QStringLiteral("field"), QStringLiteral("yyyy d MM"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -383,10 +408,11 @@ public:
     void dateTime(Context *c) {
         Validator v;
         v.addValidator(new ValidatorDateTime(QStringLiteral("field"), QString(), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -395,10 +421,11 @@ public:
     void dateTimeFormat(Context *c) {
         Validator v;
         v.addValidator(new ValidatorDateTime(QStringLiteral("field"), QStringLiteral("yyyy d MM mm:HH" ), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -407,10 +434,11 @@ public:
     void different(Context *c) {
         Validator v;
         v.addValidator(new ValidatorDifferent(QStringLiteral("field"), QStringLiteral("other"), QString(), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -419,10 +447,11 @@ public:
     void digits(Context *c) {
         Validator v;
         v.addValidator(new ValidatorDigits(QStringLiteral("field"), -1, QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -431,10 +460,11 @@ public:
     void digitsLength(Context *c) {
         Validator v;
         v.addValidator(new ValidatorDigits(QStringLiteral("field"), 10, QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -443,10 +473,11 @@ public:
     void digitsBetween(Context *c) {
         Validator v;
         v.addValidator(new ValidatorDigitsBetween(QStringLiteral("field"), 5, 10, QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -455,10 +486,11 @@ public:
     void email(Context *c) {
         Validator v;
         v.addValidator(new ValidatorEmail(QStringLiteral("field"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -467,10 +499,11 @@ public:
     void filled(Context *c) {
         Validator v;
         v.addValidator(new ValidatorFilled(QStringLiteral("field"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -479,10 +512,11 @@ public:
     void in(Context *c) {
         Validator v;
         v.addValidator(new ValidatorIn(QStringLiteral("field"), QStringList({QStringLiteral("eins"), QStringLiteral("zwei"), QStringLiteral("drei")}), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -491,10 +525,11 @@ public:
     void integer(Context *c) {
         Validator v;
         v.addValidator(new ValidatorInteger(QStringLiteral("field"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -528,10 +563,11 @@ public:
         }
 
         v.addValidator(new ValidatorIp(QStringLiteral("field"), constraints, QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -541,10 +577,11 @@ public:
     void json(Context *c) {
         Validator v;
         v.addValidator(new ValidatorJson(QStringLiteral("field"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -570,10 +607,11 @@ public:
         ValidatorMax *vm = new ValidatorMax(QStringLiteral("field"), type, 10.0, QString(), QStringLiteral("invalid"));
         vm->setCustomValidationDataError(QStringLiteral("validationdataerror"));
         v.addValidator(vm);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -598,10 +636,11 @@ public:
         ValidatorMin *vm = new ValidatorMin(QStringLiteral("field"), type, 10.0, QString(), QStringLiteral("invalid"));
         vm->setCustomValidationDataError(QStringLiteral("validationdataerror"));
         v.addValidator(vm);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -613,10 +652,11 @@ public:
         ValidatorNotIn *va = new ValidatorNotIn(QStringLiteral("field"), values, QString(), QStringLiteral("invalid"));
         va->setCustomValidationDataError(QStringLiteral("validationdataerror"));
         v.addValidator(va);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -626,10 +666,11 @@ public:
     void numeric(Context *c) {
         Validator v;
         v.addValidator(new ValidatorNumeric(QStringLiteral("field"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -639,10 +680,11 @@ public:
     void present(Context *c) {
         Validator v;
         v.addValidator(new ValidatorPresent(QStringLiteral("field"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -652,10 +694,11 @@ public:
     void regex(Context *c) {
         Validator v;
         v.addValidator(new ValidatorRegularExpression(QStringLiteral("field"), QRegularExpression(QStringLiteral("^(\\d\\d)/(\\d\\d)/(\\d\\d\\d\\d)$")), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -664,10 +707,11 @@ public:
     void required(Context *c) {
         Validator v;
         v.addValidator(new ValidatorRequired(QStringLiteral("field"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -676,10 +720,11 @@ public:
     void requiredIf(Context *c) {
         Validator v;
         v.addValidator(new ValidatorRequiredIf(QStringLiteral("field"), QStringLiteral("field2"), QStringList({QStringLiteral("eins"), QStringLiteral("zwei")}), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -688,10 +733,11 @@ public:
     void requiredUnless(Context *c) {
         Validator v;
         v.addValidator(new ValidatorRequiredUnless(QStringLiteral("field"), QStringLiteral("field2"), QStringList({QStringLiteral("eins"), QStringLiteral("zwei")}), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -700,10 +746,11 @@ public:
     void requiredWith(Context *c) {
         Validator v;
         v.addValidator(new ValidatorRequiredWith(QStringLiteral("field"), QStringList({QStringLiteral("field2"), QStringLiteral("field3")}), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -712,10 +759,11 @@ public:
     void requiredWithAll(Context *c) {
         Validator v;
         v.addValidator(new ValidatorRequiredWithAll(QStringLiteral("field"), QStringList({QStringLiteral("field2"), QStringLiteral("field3"), QStringLiteral("field4")}), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -724,10 +772,11 @@ public:
     void requiredWithout(Context *c) {
         Validator v;
         v.addValidator(new ValidatorRequiredWithout(QStringLiteral("field"), QStringList({QStringLiteral("field2"), QStringLiteral("field3")}), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -736,10 +785,11 @@ public:
     void requiredWithoutAll(Context *c) {
         Validator v;
         v.addValidator(new ValidatorRequiredWithoutAll(QStringLiteral("field"), QStringList({QStringLiteral("field2"), QStringLiteral("field3")}), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -748,10 +798,11 @@ public:
     void same(Context *c) {
         Validator v;
         v.addValidator(new ValidatorSame(QStringLiteral("field"), QStringLiteral("other"), QString(), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -776,10 +827,11 @@ public:
         ValidatorSize *vm = new ValidatorSize(QStringLiteral("field"), type, 10.0, QString(), QStringLiteral("invalid"));
         vm->setCustomValidationDataError(QStringLiteral("validationdataerror"));
         v.addValidator(vm);
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -788,10 +840,11 @@ public:
     void time(Context *c) {
         Validator v;
         v.addValidator(new ValidatorTime(QStringLiteral("field"), QString(), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -800,10 +853,11 @@ public:
     void timeFormat(Context *c) {
         Validator v;
         v.addValidator(new ValidatorTime(QStringLiteral("field"), QStringLiteral("m:hh"), QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 
@@ -838,10 +892,11 @@ public:
 
         Validator v;
         v.addValidator(new ValidatorUrl(QStringLiteral("field"), constraints, schemes, QString(), QStringLiteral("invalid")));
-        if (v.validate(c)) {
+        ValidatorResult r = v.validate(c);
+        if (r) {
             c->response()->setBody(QByteArrayLiteral("valid"));
         } else {
-            c->response()->setBody(v.errorStrings().first().toString());
+            c->response()->setBody(r.errorStrings().first());
         }
     }
 };

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -24,6 +24,8 @@
 #include <Cutelyst/Plugins/Utils/Validator/Validators>
 #include <Cutelyst/Plugins/Utils/Validator/validatorresult.h>
 
+// clazy:excludeall=detaching-temporary
+
 using namespace Cutelyst;
 
 class TestValidator : public CoverageObject


### PR DESCRIPTION
ValidatorRule::validate() is now const and will return an error string
if validation fails. If validation succeedes, an empty string will be
returned.

Validator::validate() now returns a ValidatorResult that can be used for
checking overall validation success and for further validation error
data processing.