### PR TITLE
Fix authentication with multiple realms.

### DIFF
--- a/Cutelyst/Plugins/Authentication/authentication.cpp
+++ b/Cutelyst/Plugins/Authentication/authentication.cpp
@@ -57,13 +57,16 @@ void Authentication::addRealm(Cutelyst::AuthenticationRealm *realm, const QStrin
 {
     Q_D(Authentication);
     realm->setObjectName(name);
+    realm->setName(name);
     d->realms.insert(name, realm);
     d->realmsOrder.append(name);
 }
 
 void Cutelyst::Authentication::addRealm(Cutelyst::AuthenticationStore *store, Cutelyst::AuthenticationCredential *credential, const QString &name)
 {
-    addRealm(new AuthenticationRealm(store, credential, this), name);
+    AuthenticationRealm *realm = new AuthenticationRealm(store, credential, this);
+    realm->setName(name);
+    addRealm(realm, name);
 }
 
 AuthenticationRealm *Authentication::realm(const QString &name) const

--- a/Cutelyst/Plugins/Authentication/authentication.cpp
+++ b/Cutelyst/Plugins/Authentication/authentication.cpp
@@ -64,7 +64,7 @@ void Authentication::addRealm(Cutelyst::AuthenticationRealm *realm, const QStrin
 
 void Cutelyst::Authentication::addRealm(Cutelyst::AuthenticationStore *store, Cutelyst::AuthenticationCredential *credential, const QString &name)
 {
-    AuthenticationRealm *realm = new AuthenticationRealm(store, credential, this);
+    auto realm = new AuthenticationRealm(store, credential, this);
     realm->setName(name);
     addRealm(realm, name);
 }


### PR DESCRIPTION
When using multiple authentication realms and therefore
Authentication::userInRealm() instead of Authentication::userExists(),
the authentication check fails in Authentication::userInRealm() because
no realm name hase been set.