### PR TITLE
GrantleeView: implement adding of QTranslator

### DIFF
--- a/Cutelyst/Plugins/View/Grantlee/grantleeview.cpp
+++ b/Cutelyst/Plugins/View/Grantlee/grantleeview.cpp
@@ -191,6 +191,12 @@ QByteArray GrantleeView::render(Context *c) const
     Grantlee::Context gc(stash);
 
     auto localizer = QSharedPointer<Grantlee::QtLocalizer>::create(c->locale());
+
+    auto transIt = d->translators.constFind(c->locale().name());
+    if (transIt != d->translators.constEnd()) {
+        localizer.data()->installTranslator(transIt.value(), transIt.key());
+    }
+
     gc.setLocalizer(localizer);
 
     Grantlee::Template tmpl = d->engine->loadByName(templateFile);
@@ -216,6 +222,12 @@ QByteArray GrantleeView::render(Context *c) const
 
     ret = content.toUtf8();
     return ret;
+}
+
+void GrantleeView::addTranslator(const QString &locale, QTranslator *translator)
+{
+    Q_D(GrantleeView);
+    d->translators.insert(locale, translator);
 }
 
 #include "moc_grantleeview.cpp"

--- a/Cutelyst/Plugins/View/Grantlee/grantleeview.h
+++ b/Cutelyst/Plugins/View/Grantlee/grantleeview.h
@@ -25,6 +25,8 @@
 
 #include <Cutelyst/View>
 
+class QTranslator;
+
 namespace Grantlee {
 class Engine;
 }
@@ -65,6 +67,35 @@ public:
     void preloadTemplates();
 
     QByteArray render(Context *c) const final;
+
+    /*!
+     * \brief Adds a \a translator for the specified \a locale to the list of translators.
+     *
+     * The \a locale string should be parseable by QLocale.
+     *
+     * \par Example usage
+     * \code{.cpp}
+     * bool MyCutelystApp::init()
+     * {
+     *      // ...
+     *
+     *      auto view = new GrantleeView(this);
+     *
+     *      auto deDeTrans = new QTranslator(this);
+     *      if (deDeTrans->load(QStringLiteral("de_DE"), QStringLiteral("/path/to/my/translations")) {
+     *          view->addTranslator(QStringLiteral("de_DE"), deDeTrans);
+     *      }
+     *
+     *      auto ptBrTrans = new QTranslator(this);
+     *      if (ptBrTrans->load(QStringLiteral("pt_BR"), QStringLiteral("/path/to/my/translations")) {
+     *          view->addTranslator(QStringLiteral("pt_BR"), ptBrTrans);
+     *      }
+     *
+     *      // ...
+     * }
+     * \endcode
+     */
+    void addTranslator(const QString &locale, QTranslator *translator);
 
 protected:
     GrantleeViewPrivate *d_ptr;

--- a/Cutelyst/Plugins/View/Grantlee/grantleeview_p.h
+++ b/Cutelyst/Plugins/View/Grantlee/grantleeview_p.h
@@ -38,6 +38,7 @@ public:
     Grantlee::Engine *engine;
     QSharedPointer<Grantlee::FileSystemTemplateLoader> loader;
     QSharedPointer<Grantlee::CachingLoaderDecorator> cache;
+    QHash<QString, QTranslator*> translators;
 };
 
 }


### PR DESCRIPTION
Without a QTranslator set for the selected locale, Grantlee::QtLocalizer
will use QCoreApplication::translate() to translate strings. This does
not work together with the current implementation where only a
Grantlee::QtLocalizer with a QLocale is set.

GrantleeView::addTranslator() will add a new QTranslator object for a
specified locale to an internal map of QTranslator object pointers. In
GrantleeView::render() it will set the appropriate QTranslator to the
Grantlee::QtLocalizert object.