### PR TITLE
Context translation support

### DIFF
--- a/Cutelyst/Plugins/View/Grantlee/grantleeview.cpp
+++ b/Cutelyst/Plugins/View/Grantlee/grantleeview.cpp
@@ -192,9 +192,9 @@ QByteArray GrantleeView::render(Context *c) const
 
     auto localizer = QSharedPointer<Grantlee::QtLocalizer>::create(c->locale());
 
-    auto transIt = d->translators.constFind(c->locale().name());
+    auto transIt = d->translators.constFind(c->locale());
     if (transIt != d->translators.constEnd()) {
-        localizer.data()->installTranslator(transIt.value(), transIt.key());
+        localizer.data()->installTranslator(transIt.value(), transIt.key().name());
     }
 
     gc.setLocalizer(localizer);
@@ -224,10 +224,16 @@ QByteArray GrantleeView::render(Context *c) const
     return ret;
 }
 
-void GrantleeView::addTranslator(const QString &locale, QTranslator *translator)
+void GrantleeView::addTranslator(const QLocale &locale, QTranslator *translator)
 {
     Q_D(GrantleeView);
+    Q_ASSERT_X(translator, "add translator to GrantleeView", "invalid QTranslator object");
     d->translators.insert(locale, translator);
+}
+
+void GrantleeView::addTranslator(const QString &locale, QTranslator *translator)
+{
+    addTranslator(QLocale(locale), translator);
 }
 
 #include "moc_grantleeview.cpp"

--- a/Cutelyst/Plugins/View/Grantlee/grantleeview.cpp
+++ b/Cutelyst/Plugins/View/Grantlee/grantleeview.cpp
@@ -197,6 +197,12 @@ QByteArray GrantleeView::render(Context *c) const
         localizer.data()->installTranslator(transIt.value(), transIt.key().name());
     }
 
+    auto catalogIt = d->translationCatalogs.constBegin();
+    while (catalogIt != d->translationCatalogs.constEnd()) {
+        localizer.data()->loadCatalog(catalogIt.value(), catalogIt.key());
+        ++it;
+    }
+
     gc.setLocalizer(localizer);
 
     Grantlee::Template tmpl = d->engine->loadByName(templateFile);
@@ -234,6 +240,21 @@ void GrantleeView::addTranslator(const QLocale &locale, QTranslator *translator)
 void GrantleeView::addTranslator(const QString &locale, QTranslator *translator)
 {
     addTranslator(QLocale(locale), translator);
+}
+
+void GrantleeView::addTranslationCatalog(const QString &path, const QString &catalog)
+{
+    Q_D(GrantleeView);
+    Q_ASSERT_X(!path.isEmpty(), "add translation catalog to GrantleeView", "empty path");
+    Q_ASSERT_X(!catalog.isEmpty(), "add translation catalog to GrantleeView", "empty catalog name");
+    d->translationCatalogs.insert(catalog, path);
+}
+
+void GrantleeView::addTranslationCatalogs(const QHash<QString, QString> &catalogs)
+{
+    Q_D(GrantleeView);
+    Q_ASSERT_X(!catalogs.empty(), "add translation catalogs to GranteleeView", "empty QHash");
+    d->translationCatalogs.unite(catalogs);
 }
 
 #include "moc_grantleeview.cpp"

--- a/Cutelyst/Plugins/View/Grantlee/grantleeview.h
+++ b/Cutelyst/Plugins/View/Grantlee/grantleeview.h
@@ -109,6 +109,46 @@ public:
      */
     void addTranslator(const QString &locale, QTranslator *translator);
 
+    /*!
+     * \brief Dynamically adds translation \a catalog at \a path to the translator.
+     *
+     * Translation catalogs can be used to dynamically integrate translations into the
+     * GrantleeView, for example for plugins and themes. The \a catalog could be the name
+     * of an extension for example that is loaded from a locale specifc directory under \a path.
+     *
+     * The catalog will be loaded in the following way: /path/locale/catalog, for example
+     * \c /usr/share/mycutelystapp/l10n/de_DE/fancytheme.qm. The current locale is defined by
+     * Context::locale() when rendering the theme. The \a path \c /usr/share/myapp/l10n would
+     * then contain locale specific subdirectories like de_DE, pt_BR, etc. that contain the
+     * translation files named by \a catalog.
+     *
+     * \par Usage example:
+     * \code{.cpp}
+     * bool MyCutelystApp::init()
+     * {
+     *      // ...
+     *
+     *      auto view = new GrantleeView(this);
+     *      view->addTranslationCatalog(QStringLiteral("/usr/share/mycutelystapp/l10n"), QStringLiteral("fancytheme"));
+     *
+     *      // ...
+     * }
+     * \endcode
+     *
+     * \since Cutelyst 1.5.0
+     */
+    void addTranslationCatalog(const QString &path, const QString &catalog);
+
+    /*!
+     * \brief Adds a dictionary of translation catalogs and paths to the translator.
+     *
+     * The \a key of the QHash is the name of the catalog, the \a value is the path.
+     * See addTranslationCatalog() for more information about translation catalogs.
+     *
+     * \since Cutelyst 1.5.0
+     */
+    void addTranslationCatalogs(const QHash<QString, QString> &catalogs);
+
 protected:
     GrantleeViewPrivate *d_ptr;
 };

--- a/Cutelyst/Plugins/View/Grantlee/grantleeview.h
+++ b/Cutelyst/Plugins/View/Grantlee/grantleeview.h
@@ -69,8 +69,8 @@ public:
 
     QByteArray render(Context *c) const final;
 
-    /*!
-     * \brief Adds a \a translator for the specified \a locale to the list of translators.
+    /**
+     * Adds a \a translator for the specified \a locale to the list of translators.
      *
      * \par Example usage
      * \code{.cpp}
@@ -98,8 +98,8 @@ public:
      */
     void addTranslator(const QLocale &locale, QTranslator *translator);
 
-    /*!
-     * \brief Adds a \a translator for the specified \a locale to the list of translators.
+    /**
+     * Adds a \a translator for the specified \a locale to the list of translators.
      *
      * The \a locale string should be parseable by QLocale.
      *
@@ -109,8 +109,8 @@ public:
      */
     void addTranslator(const QString &locale, QTranslator *translator);
 
-    /*!
-     * \brief Dynamically adds translation \a catalog at \a path to the translator.
+    /**
+     * Dynamically adds translation \a catalog at \a path to the translator.
      *
      * Translation catalogs can be used to dynamically integrate translations into the
      * GrantleeView, for example for plugins and themes. The \a catalog could be the name
@@ -139,8 +139,8 @@ public:
      */
     void addTranslationCatalog(const QString &path, const QString &catalog);
 
-    /*!
-     * \brief Adds a dictionary of translation catalogs and paths to the translator.
+    /**
+     * Adds a dictionary of translation catalogs and paths to the translator.
      *
      * The \a key of the QHash is the name of the catalog, the \a value is the path.
      * See addTranslationCatalog() for more information about translation catalogs.

--- a/Cutelyst/Plugins/View/Grantlee/grantleeview.h
+++ b/Cutelyst/Plugins/View/Grantlee/grantleeview.h
@@ -22,6 +22,7 @@
 
 #include <QObject>
 #include <QStringList>
+#include <QLocale>
 
 #include <Cutelyst/View>
 
@@ -71,8 +72,6 @@ public:
     /*!
      * \brief Adds a \a translator for the specified \a locale to the list of translators.
      *
-     * The \a locale string should be parseable by QLocale.
-     *
      * \par Example usage
      * \code{.cpp}
      * bool MyCutelystApp::init()
@@ -83,17 +82,30 @@ public:
      *
      *      auto deDeTrans = new QTranslator(this);
      *      if (deDeTrans->load(QStringLiteral("de_DE"), QStringLiteral("/path/to/my/translations")) {
-     *          view->addTranslator(QStringLiteral("de_DE"), deDeTrans);
+     *          view->addTranslator(QLocale("de_DE"), deDeTrans);
      *      }
      *
      *      auto ptBrTrans = new QTranslator(this);
      *      if (ptBrTrans->load(QStringLiteral("pt_BR"), QStringLiteral("/path/to/my/translations")) {
-     *          view->addTranslator(QStringLiteral("pt_BR"), ptBrTrans);
+     *          view->addTranslator(QLocale("pt_BR"), ptBrTrans);
      *      }
      *
      *      // ...
      * }
      * \endcode
+     *
+     * \since Cutelyst 1.5.0
+     */
+    void addTranslator(const QLocale &locale, QTranslator *translator);
+
+    /*!
+     * \brief Adds a \a translator for the specified \a locale to the list of translators.
+     *
+     * The \a locale string should be parseable by QLocale.
+     *
+     * \overload
+     *
+     * \since Cutelyst 1.4.0
      */
     void addTranslator(const QString &locale, QTranslator *translator);
 

--- a/Cutelyst/Plugins/View/Grantlee/grantleeview_p.h
+++ b/Cutelyst/Plugins/View/Grantlee/grantleeview_p.h
@@ -39,6 +39,7 @@ public:
     QSharedPointer<Grantlee::FileSystemTemplateLoader> loader;
     QSharedPointer<Grantlee::CachingLoaderDecorator> cache;
     QHash<QLocale, QTranslator*> translators;
+    QHash<QString, QString> translationCatalogs;
 };
 
 }

--- a/Cutelyst/Plugins/View/Grantlee/grantleeview_p.h
+++ b/Cutelyst/Plugins/View/Grantlee/grantleeview_p.h
@@ -38,7 +38,7 @@ public:
     Grantlee::Engine *engine;
     QSharedPointer<Grantlee::FileSystemTemplateLoader> loader;
     QSharedPointer<Grantlee::CachingLoaderDecorator> cache;
-    QHash<QString, QTranslator*> translators;
+    QHash<QLocale, QTranslator*> translators;
 };
 
 }

--- a/Cutelyst/application.cpp
+++ b/Cutelyst/application.cpp
@@ -475,27 +475,26 @@ void Application::addTranslators(const QLocale &locale, const QVector<QTranslato
 
 static void replacePercentN(QString *result, int n)
 {
-  if (n >= 0) {
-    auto percentPos = 0;
-    auto len = 0;
-    while ((percentPos = result->indexOf(QLatin1Char('%'), percentPos + len))
-           != -1) {
-      len = 1;
-      QString fmt;
-      if (result->at(percentPos + len) == QLatin1Char('L')) {
-        ++len;
-        fmt = QStringLiteral("%L1");
-      } else {
-        fmt = QStringLiteral("%1");
-      }
-      if (result->at(percentPos + len) == QLatin1Char('n')) {
-        fmt = fmt.arg(n);
-        ++len;
-        result->replace(percentPos, len, fmt);
-        len = fmt.length();
-      }
+    if (n >= 0) {
+        auto percentPos = 0;
+        auto len = 0;
+        while ((percentPos = result->indexOf(QLatin1Char('%'), percentPos + len)) != -1) {
+            len = 1;
+            QString fmt;
+            if (result->at(percentPos + len) == QLatin1Char('L')) {
+                ++len;
+                fmt = QStringLiteral("%L1");
+            } else {
+                fmt = QStringLiteral("%1");
+            }
+            if (result->at(percentPos + len) == QLatin1Char('n')) {
+                fmt = fmt.arg(n);
+                ++len;
+                result->replace(percentPos, len, fmt);
+                len = fmt.length();
+            }
+        }
     }
-  }
 }
 
 QString Application::translate(const QLocale &locale, const char *context, const char *sourceText, const char *disambiguation, int n) const

--- a/Cutelyst/application.cpp
+++ b/Cutelyst/application.cpp
@@ -446,10 +446,9 @@ void Application::addTranslator(const QLocale &locale, QTranslator *translator)
 {
     Q_D(Application);
     Q_ASSERT_X(translator, "add translator to application", "invalid QTranslator object");
-    if (d->translators.contains(locale)) {
-        QVector<QTranslator*> trs = d->translators.value(locale);
-        trs.prepend(translator);
-        d->translators.insert(locale, trs);
+    auto it = d->translators.find(locale);
+    if (it != d->translators.end()) {
+        it.value().prepend(translator);
     } else {
         d->translators.insert(locale, QVector<QTranslator*>(1, translator));
     }
@@ -464,12 +463,11 @@ void Application::addTranslators(const QLocale &locale, const QVector<QTranslato
 {
     Q_D(Application);
     Q_ASSERT_X(!translators.empty(), "add translators to application", "empty translators vector");
-    if (d->translators.contains(locale)) {
-        QVector<QTranslator*> trs = d->translators.value(locale);
+    auto transIt = d->translators.find(locale);
+    if (transIt != d->translators.end()) {
         for (auto it = translators.crbegin(); it != translators.crend(); ++it) {
-            trs.prepend(*it);
+            transIt.value().prepend(*it);
         }
-        d->translators.insert(locale, trs);
     } else {
         d->translators.insert(locale, translators);
     }

--- a/Cutelyst/application.h
+++ b/Cutelyst/application.h
@@ -22,8 +22,11 @@
 
 #include <QtCore/qobject.h>
 #include <QtCore/qvariant.h>
+#include <QtCore/qlocale.h>
 
 #include <Cutelyst/cutelyst_global.h>
+
+class QTranslator;
 
 namespace Cutelyst {
 
@@ -131,6 +134,67 @@ public:
      * Returns cutelyst version.
      */
     static const char *cutelystVersion();
+
+    /**
+     * Adds a @a translator for the specified @a locale.
+     *
+     * You can add multiple translators for different application parts for every supported
+     * locale. The installed translators will then be used by Context::translate() (what itself
+     * will use Application::translate()) to translate strings according to the locale set by
+     * Context::setLocale().
+     *
+     * @par Usage example:
+     * @code{.cpp}
+     * bool MyCutelystApp::init()
+     * {
+     *      // ...
+     *
+     *      auto trans = new QTranslator(this);
+     *      QLocale deDE(QLocale::German, QLocale::Germany);
+     *      if (trans->load(deDE, QStringLiteral("mycutelystapp"), QStringLiteral("."), QStringLiteral("/usr/share/mycutelystapp/l10n")) {
+     *          addTranslator(deDE, trans);
+     *      }
+     *
+     *      // ...
+     * }
+     * @endcode
+     *
+     * @since Cutelyst 1.5.0
+     */
+    void addTranslator(const QLocale &locale, QTranslator *translator);
+
+    /**
+     * Adds a @a translator for the specified @a locale.
+     *
+     * The @a locale string has to be parseable by QLocale.
+     *
+     * @overload
+     *
+     * @since Cutelyst 1.5.0
+     */
+    void addTranslator(const QString &locale, QTranslator *translator);
+
+    /**
+     * Adds multiple @a translators for the specified @a locale.
+     *
+     * @sa addTranslator()
+     *
+     * @since Cutelyst 1.5.0
+     */
+    void addTranslators(const QLocale &locale, const QVector<QTranslator *> &translators);
+
+    /**
+     * Translates the @a sourceText into the target @a locale language.
+     *
+     * This uses the installed translators for the specified @a locale to translate the @a sourceText for the
+     * given @a context into the target locale. Optionally you can use a @a disambiguation and/or the @a n parameter
+     * to translate a pluralized version.
+     *
+     * @sa Context::translate(), QTranslator::translate()
+     *
+     * @since Cutelyst 1.5.0
+     */
+    QString translate(const QLocale &locale, const char *context, const char *sourceText, const char *disambiguation = nullptr, int n = -1) const;
 
 protected:
     /**

--- a/Cutelyst/application_p.h
+++ b/Cutelyst/application_p.h
@@ -53,6 +53,7 @@ public:
     Engine *engine;
     bool useStats;
     bool init = false;
+    QHash<QLocale, QVector<QTranslator*>> translators;
 };
 
 }

--- a/Cutelyst/context.cpp
+++ b/Cutelyst/context.cpp
@@ -403,6 +403,12 @@ void *Context::engineData()
     return d->requestPtr;
 }
 
+QString Context::translate(const char *context, const char *sourceText, const char *disambiguation, int n) const
+{
+    Q_D(const Context);
+    return d->app->translate(d->locale, context, sourceText, disambiguation, n);
+}
+
 QString ContextPrivate::statsStartExecute(Component *code)
 {
     QString actionName;

--- a/Cutelyst/context.h
+++ b/Cutelyst/context.h
@@ -412,6 +412,21 @@ public:
 
     void *engineData();
 
+    /**
+     * Translates the \a sourceText for the given \a context into the language defined by locale().
+     *
+     * See Application::addTranslator() for information about installation of translators. Internally
+     * this function will use QTranslator::translate().
+     *
+     * \code{.cpp}
+     * void MyController::index(Context *c)
+     * {
+     *      c->res()->body() = c->translate("MyController", "You are on the index page.").toUtf8();
+     * }
+     * \endcode
+     */
+    QString translate(const char *context, const char *sourceText, const char *disambiguation = nullptr, int n = -1) const;
+
 protected:
     Context(ContextPrivate *priv);
 


### PR DESCRIPTION
This implements basic translation functionality into the Context and Application. QTranslator objects can be added to the main Application object (best in init() function) and are used from there by the Context to translate strings. Other stuff like numbers can be localized directly by Context::locale().

The Context now has a translate() function that takes the translation context, source string, optional disambiguation and plural. This will be used together with the current Context::locale() to get a translation from Application::translate() that iterates over all installed QTranslator objects for the given locale to return the translated string.

I used _translate()_ for the function name instead of something like ctr() because it is used like QTranslator::translate() not like QObject::tr(). The problem with tr() is that it automatically extracts the translation context from the meta object. But for a translation method bound to the Context, the Context object would be the translation context for all translations. Also this approach works automatically with lupdate without changing anything.

For sure we could also create an overloaded Context::ctr() function that invokes Context::translate(), but I think it might lead to confusion, because tr() does not need an explicitly set translation context. Maybe we can later find a solution for an automatic identification of the translation context (tr() uses the class name from the meta object, Grantlee hard codes "GR_FILENAME").