### PR TITLE
Fix build SessionStoreMemcached on Qt 5.8.

### DIFF
--- a/Cutelyst/Plugins/Session/sessionstorememcached.cpp
+++ b/Cutelyst/Plugins/Session/sessionstorememcached.cpp
@@ -108,11 +108,7 @@ QVariantHash loadMemcSessionData(Context *c, const QString &sid, const std::stri
         QVariantHash data = c->property(SESSION_STORE_MEMCD_DATA).toHash();
 
         if (data.isEmpty()) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 8, 0))
-            if (!memc.remove(sessionKey.toStdString(), QDateTime::currentDateTimeUtc().toSecsSinceEpoch()())) {
-#else
-            if (!memc.remove(sessionKey.toStdString(), QDateTime::currentDateTimeUtc().toTime_t())) {
-#endif
+            if (!memc.remove(sessionKey.toStdString()))
                 std::string errorString;
                 memc.error(errorString);
                 qCWarning(C_SESSION_MEMCACHED) << "Failed to remove session from Memcached:" << QString::fromStdString(errorString);

--- a/Cutelyst/Plugins/Session/sessionstorememcached.cpp
+++ b/Cutelyst/Plugins/Session/sessionstorememcached.cpp
@@ -108,7 +108,11 @@ QVariantHash loadMemcSessionData(Context *c, const QString &sid, const std::stri
         QVariantHash data = c->property(SESSION_STORE_MEMCD_DATA).toHash();
 
         if (data.isEmpty()) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 8, 0))
+            if (!memc.remove(sessionKey.toStdString(), QDateTime::currentDateTimeUtc().toSecsSinceEpoch()())) {
+#else
             if (!memc.remove(sessionKey.toStdString(), QDateTime::currentDateTimeUtc().toTime_t())) {
+#endif
                 std::string errorString;
                 memc.error(errorString);
                 qCWarning(C_SESSION_MEMCACHED) << "Failed to remove session from Memcached:" << QString::fromStdString(errorString);


### PR DESCRIPTION
Qt 5.8 deprecated some methods of QDateTime, especially toTime_t(). Qt
docus say deprecated at one place and obsolete at another place. At
least openSUSE packages seems not to export the deprecated method
toTime_t() anymore with Qt 5.8. So this little switch helps to build the
SessionStoreMemcached on Qt 5.8.