### PR TITLE
added a new SQL Util method: queryToMap

### DIFF
--- a/Cutelyst/Plugins/Utils/Sql/sql.cpp
+++ b/Cutelyst/Plugins/Utils/Sql/sql.cpp
@@ -94,6 +94,34 @@ QVariantList Sql::queryToMapList(QSqlQuery &query)
     return ret;
 }
 
+QVariantMap Sql::queryToMap(QSqlQuery &query, const QString &key)
+{
+    QVariantMap ret;
+    QSqlRecord record = query.record();
+
+    if (!record.contains(key)) {
+      qCCritical(C_SQL) << "Field Name " << key << " not found in result set";
+      return ret;
+    }
+
+    int columns = record.count();
+    QStringList cols;
+
+    for (int i = 0; i < columns; ++i) {
+      cols.append(record.fieldName(i));
+    }
+
+    while (query.next()) {
+      QVariantHash h;
+      for (int i = 0; i < columns; ++i) {
+        h.insert(cols.at(i),query.value(i));
+      }
+      ret.insert(query.value(key).toString(), h);
+    }
+
+    return ret;
+}
+
 void Sql::bindParamsToQuery(QSqlQuery &query, const Cutelyst::ParamsMultiMap &params, bool htmlEscaped)
 {
     auto it = params.constBegin();

--- a/Cutelyst/Plugins/Utils/Sql/sql.cpp
+++ b/Cutelyst/Plugins/Utils/Sql/sql.cpp
@@ -94,29 +94,31 @@ QVariantList Sql::queryToMapList(QSqlQuery &query)
     return ret;
 }
 
-QVariantMap Sql::queryToMap(QSqlQuery &query, const QString &key)
+QVariantHash Sql::queryToIndexedHash(QSqlQuery &query, const QString &key)
 {
-    QVariantMap ret;
+    QVariantHash ret;
     QSqlRecord record = query.record();
 
     if (!record.contains(key)) {
-      qCCritical(C_SQL) << "Field Name " << key << " not found in result set";
-      return ret;
+        qCCritical(C_SQL) << "Field Name " << key <<
+                             " not found in result set";
+        return ret;
     }
 
     int columns = record.count();
     QStringList cols;
 
     for (int i = 0; i < columns; ++i) {
-      cols.append(record.fieldName(i));
+        cols.append(record.fieldName(i));
     }
 
     while (query.next()) {
-      QVariantHash h;
-      for (int i = 0; i < columns; ++i) {
-        h.insert(cols.at(i),query.value(i));
-      }
-      ret.insert(query.value(key).toString(), h);
+        QVariantHash line;
+        for (int i = 0; i < columns; ++i) {
+            line.insertMulti(cols.at(i),query.value(i));
+        }
+
+        ret.insertMulti(query.value(key).toString(), line);
     }
 
     return ret;

--- a/Cutelyst/Plugins/Utils/Sql/sql.h
+++ b/Cutelyst/Plugins/Utils/Sql/sql.h
@@ -60,6 +60,12 @@ namespace Sql
     CUTELYST_PLUGIN_UTILS_SQL_EXPORT QVariantList queryToMapList(QSqlQuery &query);
 
     /**
+     * Returns a hash of QVariantMaps where the key table field name can
+     * be specified by the key parameter
+     */
+    CUTELYST_PLUGIN_UTILS_SQL_EXPORT QVariantMap queryToMap(QSqlQuery &query, const QString &key);
+
+    /**
      * Bind params to the query, using the param name as
      * the placeholder prebended with ':', if htmlEscaped
      * is true the bound values will be the return of toHtmlEscaped()

--- a/Cutelyst/Plugins/Utils/Sql/sql.h
+++ b/Cutelyst/Plugins/Utils/Sql/sql.h
@@ -60,10 +60,11 @@ namespace Sql
     CUTELYST_PLUGIN_UTILS_SQL_EXPORT QVariantList queryToMapList(QSqlQuery &query);
 
     /**
-     * Returns a hash of QVariantMaps where the key table field name can
-     * be specified by the key parameter
+     * Returns a QVariantHash of QVariantHashes where the key parameter
+     * is the field name in the query result. This is useful when you
+     * want to access specific user by user name or user id.
      */
-    CUTELYST_PLUGIN_UTILS_SQL_EXPORT QVariantMap queryToMap(QSqlQuery &query, const QString &key);
+    CUTELYST_PLUGIN_UTILS_SQL_EXPORT QVariantHash queryToIndexedMap(QSqlQuery &query, const QString &key);
 
     /**
      * Bind params to the query, using the param name as


### PR DESCRIPTION
queryToMap(query,key) puts the query result into a QVariantMap that is
accessible directly by the table field specified as the map key in a
second parameter

This way one can pass the whole map to the template but also easily access different records by key.

What do you think? Would this helper function be of any interest?