### PR TITLE
Add cmake option to disable Doxygen footer timestamp.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set (UWSGI_PLUGINS_DIR "${CMAKE_INSTALL_PREFIX}/lib/uwsgi/plugins" CACHE PATH "O
 find_program(UWSGI_EXEC_PATH NAMES uwsgi)
 set (UWSGI_EXEC_PATH "uwsgi" CACHE FILEPATH "Path to the uWSGI executable")
 set (CUTELYST_PLUGINS_DIR "${CMAKE_INSTALL_PREFIX}/lib/cutelyst-plugins" CACHE PATH "Output directory for cutelyst plugins")
+set (DOXYGEN_TIMESTAMP "YES" CACHE STRING "Enables or disables the footer timestamp in API documentation. Allowed values: YES or NO")
 
 add_definitions("-DLOCALSTATEDIR=\"${LOCALSTATEDIR}\"")
 

--- a/cmake/modules/Doxyfile.in
+++ b/cmake/modules/Doxyfile.in
@@ -157,6 +157,7 @@ ENUM_VALUES_PER_LINE   = 4
 GENERATE_TREEVIEW      = NONE
 TREEVIEW_WIDTH         = 250
 FORMULA_FONTSIZE       = 10
+HTML_TIMESTAMP         = @DOXYGEN_TIMESTAMP@
 #---------------------------------------------------------------------------
 # configuration options related to the Qt Docs output
 #---------------------------------------------------------------------------


### PR DESCRIPTION
Some automatic package build services, like OBS, compare built packages
to determine if something has changed. If nothing has changed, the built
packages are not pushed to the repositories. Disabling the timestamp in
the doxygen generated footer helps to prevent pushing automatic rebuilds
to the repos where only the timestamp in the footer changed.