### PR TITLE
Add cmake option to set qhelpgenerator path, enable tag file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ find_program(UWSGI_EXEC_PATH NAMES uwsgi)
 set (UWSGI_EXEC_PATH "uwsgi" CACHE FILEPATH "Path to the uWSGI executable")
 set (CUTELYST_PLUGINS_DIR "${CMAKE_INSTALL_PREFIX}/lib/cutelyst-plugins" CACHE PATH "Output directory for cutelyst plugins")
 set (DOXYGEN_TIMESTAMP "YES" CACHE STRING "Enables or disables the footer timestamp in API documentation. Allowed values: YES or NO")
+set (QHG_LOCATION "qhelpgenerator" CACHE FILEPATH "Path to the qhelpgenerator executable")
 
 add_definitions("-DLOCALSTATEDIR=\"${LOCALSTATEDIR}\"")
 

--- a/cmake/modules/Doxyfile.in
+++ b/cmake/modules/Doxyfile.in
@@ -165,7 +165,7 @@ GENERATE_QHP       = @GENERATE_QHP@
 QHP_NAMESPACE      = "org.cutelyst.@CUTELYST_VERSION_MAJOR@@CUTELYST_VERSION_MINOR@@CUTELYST_VERSION_PATCH@"
 QHP_VIRTUAL_FOLDER = "cutelyst-@CUTELYST_VERSION_MAJOR@.@CUTELYST_VERSION_MINOR@"
 QCH_FILE           = @CMAKE_BINARY_DIR@/"cutelyst-@CUTELYST_VERSION_MAJOR@@CUTELYST_VERSION_MINOR@@CUTELYST_VERSION_PATCH@.qch"
-QHG_LOCATION       = "qhelpgenerator"
+QHG_LOCATION       = @QHG_LOCATION@
 #---------------------------------------------------------------------------
 # configuration options related to the LaTeX output
 #---------------------------------------------------------------------------
@@ -232,7 +232,7 @@ SKIP_FUNCTION_MACROS   = YES
 # Configuration::additions related to external references
 #---------------------------------------------------------------------------
 TAGFILES               = @TAGFILES@
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = @CMAKE_BINARY_DIR@/"cutelyst.tags"
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 PERL_PATH              = /usr/bin/perl


### PR DESCRIPTION
openSUSE and Fedora are using a different name for the
qhelpfilegenerator, so it is easier for packagers if one can change it.

Additionally I enabled the generation of a cutelyst doxygen tag file
that can be used in 3rd party api documentation.