### PR TITLE
Install dll's in the same folder whith runtime when building with MSVC

### DIFF
--- a/Cutelyst/CMakeLists.txt
+++ b/Cutelyst/CMakeLists.txt
@@ -94,15 +94,8 @@ target_compile_features(cutelyst-qt5
 
 if (CMAKE_GENERATOR MATCHES "Visual Studio")
   set_property(TARGET cutelyst-qt5 PROPERTY DEBUG_POSTFIX "d")
-  foreach(cfg ${CMAKE_CONFIGURATION_TYPES})
-    string(TOUPPER ${cfg} CFG)
-    set_target_properties(cutelyst-qt5
-      PROPERTIES
-      LIBRARY_OUTPUT_DIRECTORY_${CFG} "${CMAKE_CURRENT_BINARY_DIR}"
-      RUNTIME_OUTPUT_DIRECTORY_${CFG} "${CMAKE_CURRENT_BINARY_DIR}"
-      )
-  endforeach()
 endif()
+
 target_compile_definitions(cutelyst-qt5
   PRIVATE
     PLUGINS_PREFER_DEBUG_POSTFIX=$<CONFIG:Debug>


### PR DESCRIPTION
Fix for https://github.com/cutelyst/cutelyst/issues/51

The output directories for WIN32 builds are specified already here https://github.com/cutelyst/cutelyst/blob/master/CMakeLists.txt#L45. 