### PR TITLE
Memcached plugin Qt 5.6 compatibility fix

### DIFF
--- a/Cutelyst/Plugins/Memcached/memcached.cpp
+++ b/Cutelyst/Plugins/Memcached/memcached.cpp
@@ -218,7 +218,7 @@ bool Memcached::set(const QString &key, const QByteArray &value, time_t expirati
     QByteArray _value = value;
 
     if (mcd->d_ptr->compression && (_value.size() > mcd->d_ptr->compressionThreshold)) {
-        flags.setFlag(MemcachedPrivate::Compressed);
+        flags |= MemcachedPrivate::Compressed;
         _value = qCompress(value, mcd->d_ptr->compressionLevel);
     }
 
@@ -258,7 +258,7 @@ bool Memcached::setByKey(const QString &groupKey, const QString &key, const QByt
     QByteArray _value = value;
 
     if (mcd->d_ptr->compression && (_value.size() > mcd->d_ptr->compressionThreshold)) {
-        flags.setFlag(MemcachedPrivate::Compressed);
+        flags |= MemcachedPrivate::Compressed;
         _value = qCompress(value, mcd->d_ptr->compressionLevel);
     }
 
@@ -299,7 +299,7 @@ bool Memcached::add(const QString &key, const QByteArray &value, time_t expirati
     QByteArray _value = value;
 
     if (mcd->d_ptr->compression && (_value.size() > mcd->d_ptr->compressionThreshold)) {
-        flags.setFlag(MemcachedPrivate::Compressed);
+        flags |= MemcachedPrivate::Compressed;
         _value = qCompress(value, mcd->d_ptr->compressionLevel);
     }
 
@@ -339,7 +339,7 @@ bool Memcached::addByKey(const QString &groupKey, const QString &key, const QByt
     QByteArray _value = value;
 
     if (mcd->d_ptr->compression && (_value.size() > mcd->d_ptr->compressionThreshold)) {
-        flags.setFlag(MemcachedPrivate::Compressed);
+        flags |= MemcachedPrivate::Compressed;
         _value = qCompress(value, mcd->d_ptr->compressionLevel);
     }
 
@@ -380,7 +380,7 @@ bool Memcached::replace(const QString &key, const QByteArray &value, time_t expi
     QByteArray _value = value;
 
     if (mcd->d_ptr->compression && (_value.size() > mcd->d_ptr->compressionThreshold)) {
-        flags.setFlag(MemcachedPrivate::Compressed);
+        flags |= MemcachedPrivate::Compressed;
         _value = qCompress(value, mcd->d_ptr->compressionLevel);
     }
 
@@ -420,7 +420,7 @@ bool Memcached::replaceByKey(const QString &groupKey, const QString &key, const 
     QByteArray _value = value;
 
     if (mcd->d_ptr->compression && (_value.size() > mcd->d_ptr->compressionThreshold)) {
-        flags.setFlag(MemcachedPrivate::Compressed);
+        flags |= MemcachedPrivate::Compressed;
         _value = qCompress(value, mcd->d_ptr->compressionLevel);
     }
 
@@ -934,7 +934,7 @@ bool Memcached::cas(const QString &key, const QByteArray &value, time_t expirati
     QByteArray _value = value;
 
     if (mcd->d_ptr->compression && (_value.size() > mcd->d_ptr->compressionThreshold)) {
-        flags.setFlag(MemcachedPrivate::Compressed);
+        flags |= MemcachedPrivate::Compressed;
         _value = qCompress(value, mcd->d_ptr->compressionLevel);
     }
 
@@ -975,7 +975,7 @@ bool Memcached::casByKey(const QString &groupKey, const QString &key, const QByt
     QByteArray _value = value;
 
     if (mcd->d_ptr->compression && (_value.size() > mcd->d_ptr->compressionThreshold)) {
-        flags.setFlag(MemcachedPrivate::Compressed);
+        flags |= MemcachedPrivate::Compressed;
         _value = qCompress(value, mcd->d_ptr->compressionLevel);
     }
 

--- a/Cutelyst/Plugins/Memcached/memcached.cpp
+++ b/Cutelyst/Plugins/Memcached/memcached.cpp
@@ -111,7 +111,7 @@ bool Memcached::setup(Application *app)
          QStringLiteral("tcp_nodelay"),
          QStringLiteral("tcp_keepalive")
     }) {
-        if (map.value(flag, d->defaultConfig.value(flag, false).toBool()).toBool()) {
+        if (map.value(flag, d->defaultConfig.value(flag, false)).toBool()) {
             const QString flagStr = QLatin1String("--") + flag.toUpper().replace(QLatin1Char('_'), QLatin1Char('-'));
             config.push_back(flagStr);
         }
@@ -134,7 +134,7 @@ bool Memcached::setup(Application *app)
          QStringLiteral("io_msg_watermark"),
          QStringLiteral("rcv_timeout")
     }) {
-        QString _val = map.value(opt, d->defaultConfig.value(opt).toString()).toString();
+        QString _val = map.value(opt, d->defaultConfig.value(opt)).toString();
         if (!_val.isEmpty()) {
             const QString optStr = QLatin1String("--") + opt.toUpper().replace(QLatin1Char('_'), QLatin1Char('-')) + QLatin1Char('=') + _val;
             config.push_back(optStr);
@@ -150,9 +150,9 @@ bool Memcached::setup(Application *app)
     memcached_st *new_memc = memcached(configString.constData(), configString.size());
 
     if (new_memc) {
-        d->compression = map.value(QStringLiteral("compression"), false).toBool();
-        d->compressionLevel = map.value(QStringLiteral("compression_level"), -1).toInt();
-        d->compressionThreshold = map.value(QStringLiteral("compression_threshold"), 100).toInt();
+        d->compression = map.value(QStringLiteral("compression"), d->defaultConfig.value(QStringLiteral("compression"), false)).toBool();
+        d->compressionLevel = map.value(QStringLiteral("compression_level"), d->defaultConfig.value(QStringLiteral("compression_level"),  -1)).toInt();
+        d->compressionThreshold = map.value(QStringLiteral("compression_threshold"), d->defaultConfig.value(QStringLiteral("compression_threshold"), 100)).toInt();
         if (d->compression) {
             qCInfo(C_MEMCACHED, "Compression: enabled (Compression level: %i, Compression threshold: %i bytes)", d->compressionLevel, d->compressionThreshold);
         } else {

--- a/tests/testmemcached.cpp
+++ b/tests/testmemcached.cpp
@@ -910,7 +910,9 @@ TestEngine* TestMemcached::getEngine()
     auto engine = new TestEngine(app, QVariantMap());
     auto plugin = new Memcached(app);
     QVariantMap pluginConfig{
-        {QStringLiteral("binary_protocol"), true}
+        {QStringLiteral("binary_protocol"), true},
+        {QStringLiteral("compression"), true},
+        {QStringLiteral("compression_threshold"), 10}
     };
     plugin->setDefaultConfig(pluginConfig);
     new MemcachedTest(app);


### PR DESCRIPTION
I used QFlags::testFlag() that was introduced in Qt 5.7 so that it breaks compatibility to Qt 5.6. Beside that there is now support for default compression settings and compression is enabled for the unit tests.