### PR TITLE
ValidatorResult: add some convenience functions

### DIFF
--- a/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "validatorresult_p.h"
+#include <QJsonValue>
+#include <QJsonArray>
 
 using namespace Cutelyst;
 
@@ -61,4 +63,24 @@ QStringList ValidatorResult::errorStrings() const
 QHash<QString, QStringList> ValidatorResult::errors() const
 {
     return d->errors;
+}
+
+QJsonObject ValidatorResult::errorsJsonObject() const
+{
+    QJsonObject json;
+
+    if (!d->errors.empty()) {
+        QHash<QString,QStringList>::const_iterator i = d->errors.constBegin();
+        while (i != d->errors.constEnd()) {
+            json.insert(i.key(), QJsonValue(QJsonArray::fromStringList(i.value())));
+            ++i;
+        }
+    }
+
+    return json;
+}
+
+QStringList ValidatorResult::failedFields() const
+{
+    return QStringList(d->errors.keys());
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorresult.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult.h
@@ -23,6 +23,7 @@
 #include <QStringList>
 #include <QSharedDataPointer>
 #include <QVariantHash>
+#include <QJsonObject>
 
 namespace Cutelyst {
 
@@ -31,7 +32,7 @@ class ValidatorResultPrivate;
 /*!
  * \brief Contains the result of Validator.
  *
- * ValidatorResult will be returned by Validator when calling Validator::validate(). It contains information
+ * %ValidatorResult will be returned by Validator when calling Validator::validate(). It contains information
  * about occured validation errors, like the error strings of each failed validator and a list of fields where
  * validation failed.
  *
@@ -61,9 +62,9 @@ class ValidatorResultPrivate;
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorResult {
 public:
     /*!
-     * \brief Constructs a new ValidatorResult.
+     * \brief Constructs a new %ValidatorResult.
      *
-     * A newly constructed ValidatorResult willl be valid by default, because it
+     * A newly constructed %ValidatorResult willl be valid by default, because it
      * does not cotain any error information.
      */
     ValidatorResult();
@@ -79,19 +80,19 @@ public:
     ValidatorResult& operator =(const ValidatorResult &other);
 
     /*!
-     * \brief Deconstructs the ValidatorResult.
+     * \brief Deconstructs the %ValidatorResult.
      */
     ~ValidatorResult();
 
     /*!
      * \brief Returns \c true if the validation was successful.
      *
-     * \note A newly constructed ValidatorResult will be valid by default.
+     * \note A newly constructed %ValidatorResult will be valid by default.
      */
     bool isValid() const;
 
     /*!
-     * \brief Adds new error information to the
+     * \brief Adds new error information to the internal QHash.
      * \param field     Name of the input field that has input errors.
      * \param message   Error message shown to the user.
      */
@@ -112,6 +113,23 @@ public:
      * will be the list of errors for that field.
      */
     QHash<QString,QStringList> errors() const;
+
+    /*!
+     * \brief Returns the dictionray containing fields with errors as JSON object.
+     *
+     * This returns the same data as errors() does but converted into a JSON object
+     * that has the field names as \a keys and the values will be a JSON array of
+     * strings containing the errors for the field.
+     *
+     * \since Cutelyst 1.12.0
+     */
+    QJsonObject errorsJsonObject() const;
+
+    /*!
+     * \brief Returns a list of fields with errors.
+     * \since Cutelyst 1.12.0
+     */
+    QStringList failedFields() const;
 
     /*!
      * \brief Returns \c true if the validation was successful.


### PR DESCRIPTION
This adds some small convenience functions to ValidatorResult for easier handling with JSON APIs. First one is ValidatorResult::errorsJsonObject() that returns the input field names with their errors as JSON object. The other one is ValidatorResult::failedFields() that simply returns a list of all field names that have validation errors.