### PR TITLE
Fix Memcached plugin when using unix socket to connect to server

### DIFF
--- a/Cutelyst/Plugins/Memcached/memcached.cpp
+++ b/Cutelyst/Plugins/Memcached/memcached.cpp
@@ -84,7 +84,7 @@ bool Memcached::setup(Application *app)
             }
             if (!name.isEmpty()) {
                 if (name.startsWith(QLatin1Char('/'))) {
-                    config.push_back(QLatin1String("--SOCKET=") + name + QLatin1String("/?") + weight);
+                    config.push_back(QLatin1String("--SOCKET=\"") + name + QLatin1String("/?") + weight + QLatin1Char('"'));
                 } else {
                     config.push_back(QLatin1String("--SERVER=") + name + QLatin1Char(':') + port + QLatin1String("/?") + weight);
                 }


### PR DESCRIPTION
When using a unix socket to connect to the Memcached server, the
configuration string for the socket missed quotation marks. Other than
connectiong to a server using TCP or UDP, the string for the socket
connection needs quotation marks to handle path names correctly.