### PR TITLE
CSRFProtection plugin: improve docs and add method to check result

### DIFF
--- a/Cutelyst/Plugins/CSRFProtection/csrfprotection.cpp
+++ b/Cutelyst/Plugins/CSRFProtection/csrfprotection.cpp
@@ -51,6 +51,7 @@
 #define CONTEXT_CSRF_COOKIE_NEEDS_RESET "_csrfcookieneedsreset"
 #define CONTEXT_CSRF_PROCESSING_DONE "_csrfprocessingdone"
 #define CONTEXT_CSRF_COOKIE_SET "_csrfcookieset"
+#define CONTEXT_CSRF_CHECK_PASSED "_csrfcheckpassed"
 
 Q_LOGGING_CATEGORY(C_CSRFPROTECTION, "cutelyst.plugin.csrfprotection")
 
@@ -199,6 +200,15 @@ QString CSRFProtection::getTokenFormField(Context *c)
     form = QStringLiteral("<input type=\"hidden\" name=\"%1\" value=\"%2\">").arg(csrf->d_ptr->formInputName, QString::fromLatin1(CSRFProtection::getToken(c)));
 
     return form;
+}
+
+bool CSRFProtection::checkPassed(Context *c)
+{
+    if (CSRFProtectionPrivate::secureMethods.contains(c->req()->method())) {
+        return true;
+    } else {
+        return c->property(CONTEXT_CSRF_CHECK_PASSED).toBool();
+    }
 }
 
 //void CSRFProtection::rotateToken(Context *c)
@@ -389,6 +399,8 @@ void CSRFProtectionPrivate::setToken(Context *c)
  */
 void CSRFProtectionPrivate::reject(Context *c, const QString &logReason, const QString &displayReason)
 {
+    c->setProperty(CONTEXT_CSRF_CHECK_PASSED, false);
+
     if (!csrf) {
         qCCritical(C_CSRFPROTECTION) << "CSRFProtection plugin not registered";
         return;
@@ -426,6 +438,7 @@ void CSRFProtectionPrivate::reject(Context *c, const QString &logReason, const Q
 
 void CSRFProtectionPrivate::accept(Context *c)
 {
+    c->setProperty(CONTEXT_CSRF_CHECK_PASSED, true);
     c->setProperty(CONTEXT_CSRF_PROCESSING_DONE, true);
 }
 

--- a/Cutelyst/Plugins/CSRFProtection/csrfprotection.h
+++ b/Cutelyst/Plugins/CSRFProtection/csrfprotection.h
@@ -110,6 +110,10 @@ class CSRFProtectionPrivate;
  * that can be used to define a detach to action per method. If the detach to action is not set or could not be found
  * a default error page will be generated.
  *
+ * @note If you are using redirects, the default generated message will not work. Use either an action to detach to
+ * or check the result of the CSRF protection with CSRFProtection::checkPassed() to handle failed checks in your
+ * contoller methods.
+ *
  * @code{.cpp}
  * bool MyCutelystApp::init()
  * {
@@ -315,6 +319,14 @@ public:
      * @endcode
      */
     static QString getTokenFormField(Context *c);
+
+    /**
+     * Returns @c true if the CSRF protection check has successfully been passed. You can use this
+     * function in your contoller methods to handle CSRF protection results. For HTTP methods that
+     * are secure according to RFC 7231 (GET, HEAD, OPTIONS and TRACE) this will return always
+     * @c true. For all other methods it will return @c false if the CSRF protection check has failed.
+     */
+    static bool checkPassed(Context *c);
 
 protected:
     CSRFProtectionPrivate *d_ptr;


### PR DESCRIPTION
I added a note to the documentation how to handle redirects with CSRF
protection. Additionally I added a new static method to check the result
of the CSRF protection in contoller methods.