### PR TITLE
Memcached plugin: add preprocessor switch to enable/disable SASL support

### DIFF
--- a/Cutelyst/Plugins/Memcached/memcached.cpp
+++ b/Cutelyst/Plugins/Memcached/memcached.cpp
@@ -206,6 +206,8 @@ bool Memcached::setup(Application *app)
             qCInfo(C_MEMCACHED, "Encryption: disabled");
         }
 
+#ifdef LIBMEMCACHED_WITH_SASL_SUPPORT
+#if LIBMEMCACHED_WITH_SASL_SUPPORT == 1
         const QString saslUser = map.value(QStringLiteral("sasl_user")).toString();
         const QString saslPass = map.value(QStringLiteral("sasl_password")).toString();
         if (!saslUser.isEmpty() && !saslPass.isEmpty()) {
@@ -219,6 +221,8 @@ bool Memcached::setup(Application *app)
         } else {
             qCInfo(C_MEMCACHED, "SASL authentication: disabled");
         }
+#endif
+#endif
 
         if (d->memc) {
             memcached_free(d->memc);

--- a/Cutelyst/Plugins/Memcached/memcached.h
+++ b/Cutelyst/Plugins/Memcached/memcached.h
@@ -58,7 +58,7 @@ class MemcachedPrivate;
  * @li @a compression_level - integer value, the compression level used by qCompress (default: -1)
  * @li @a compression_threshold - integer value, the compression size threshold in bytes, only input values bigger than the threshold will be compressed (default: 100)
  * @li @a encryption_key - string value, if set and not empty, AES encryption will be enabled (default: empty)
- * @li @a sasl_user - string value, if set and not empty, SASL authentication will be used (default: empty)
+ * @li @a sasl_user - string value, if set and not empty, SASL authentication will be used - note that SASL support has been enabled when building libmemcached (default: empty)
  * @li @a sasl_password - string value, if set and not empty, SASL authentication will be used (default: empty)
  *
  * @note If you want to use non-ASCII key names you have to enable the binary protocol.
@@ -72,7 +72,7 @@ class MemcachedPrivate;
  * [Cutelyst_Memcached_Plugin]
  * servers=cache.example.com,11211,2;/path/to/memcached.sock,1
  * binary_protocol=true
- * namespace=tritratrullala
+ * namespace=foobar
  * @endcode
  *
  * <H3>Expiration times</H3>

--- a/Cutelyst/Plugins/Memcached/memcached.h
+++ b/Cutelyst/Plugins/Memcached/memcached.h
@@ -58,7 +58,7 @@ class MemcachedPrivate;
  * @li @a compression_level - integer value, the compression level used by qCompress (default: -1)
  * @li @a compression_threshold - integer value, the compression size threshold in bytes, only input values bigger than the threshold will be compressed (default: 100)
  * @li @a encryption_key - string value, if set and not empty, AES encryption will be enabled (default: empty)
- * @li @a sasl_user - string value, if set and not empty, SASL authentication will be used - note that SASL support has been enabled when building libmemcached (default: empty)
+ * @li @a sasl_user - string value, if set and not empty, SASL authentication will be used - note that SASL support has to be enabled when building libmemcached (default: empty)
  * @li @a sasl_password - string value, if set and not empty, SASL authentication will be used (default: empty)
  *
  * @note If you want to use non-ASCII key names you have to enable the binary protocol.

--- a/Cutelyst/Plugins/Memcached/memcached_p.h
+++ b/Cutelyst/Plugins/Memcached/memcached_p.h
@@ -36,9 +36,13 @@ public:
     ~MemcachedPrivate()
     {
         if (memc) {
+#ifdef LIBMEMCACHED_WITH_SASL_SUPPORT
+#if LIBMEMCACHED_WITH_SASL_SUPPORT == 1
             if (saslEnabled) {
                 memcached_destroy_sasl_auth_data(memc);
             }
+#endif
+#endif
             memcached_free(memc);
         }
     }


### PR DESCRIPTION
libmemcached provides the preprocessor definition
LIBMEMCACHED_WITH_SASL_SUPPORT. Use this to enable or disable the
support for SASL authentication in the libmemcached based Cutelyst
Memcached plugin.