### PR TITLE
Add configuration man pages to some plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ set (BUILDDIR "${CMAKE_BINARY_DIR}")
 set (CUTELYST_PLUGINS_DIR "${CMAKE_INSTALL_PREFIX}/lib/cutelyst2-plugins" CACHE PATH "Output directory for cutelyst plugins")
 set (DOXYGEN_TIMESTAMP "YES" CACHE STRING "Enables or disables the footer timestamp in API documentation. Allowed values: YES or NO")
 set (QHG_LOCATION "qhelpgenerator" CACHE FILEPATH "Path to the qhelpgenerator executable")
+set (MANDIR "${DATADIR}/man" CACHE PATH "Directory to install man pages")
 
 add_definitions("-DLOCALSTATEDIR=\"${LOCALSTATEDIR}\"")
 

--- a/Cutelyst/Plugins/CSRFProtection/CMakeLists.txt
+++ b/Cutelyst/Plugins/CSRFProtection/CMakeLists.txt
@@ -36,3 +36,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CutelystQt5CSRFProtection.pc.in
     @ONLY
 )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CutelystQt5CSRFProtection.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CutelystQt5CSRFProtection.5.in
+    ${CMAKE_CURRENT_BINARY_DIR}/Cutelyst2Qt5CSRFProtection.5
+    @ONLY
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Cutelyst2Qt5CSRFProtection.5 DESTINATION ${MANDIR}/man5)

--- a/Cutelyst/Plugins/CSRFProtection/CutelystQt5CSRFProtection.5.in
+++ b/Cutelyst/Plugins/CSRFProtection/CutelystQt5CSRFProtection.5.in
@@ -1,0 +1,76 @@
+.TH Cutelyst@PROJECT_VERSION_MAJOR@Qt5CSRFProtection 5 "2018-01-11" "Cutelyst@PROJECT_VERSION_MAJOR@Qt5CSRFProtection @PROJECT_VERSION@"
+
+.SH NAME
+Cutelyst@PROJECT_VERSION_MAJOR@Qt5CSRFProtection - Configuration of the CSRFProtection Plugin for the Cutelyst Web Framework
+.SH DESCRIPTION
+The CSRFProtection plugin implements a synchronizer token pattern (STP) to protect input forms against
+.UR https://en.wikipedia.org/wiki/Cross-site_request_forgery
+Cross Site Request Forgery (CSRF/XSRF) attacks
+.UE .
+This type of attack occurs when a malicious website contains a link, a form button or some JavaScript that is intended to perform some action on your website, using the credentials of a logged-in user who visits the malicious site in their browser.
+.SH CONFIGURATION
+There are some options you can set in your application configuration file in the
+.I Cutelyst_CSRFProtection_Plugin
+section.
+.PP
+.I cookie_age
+(integer value, default: 31449600)
+.RS 4
+The age/expiration time of the cookie in seconds.
+.PP
+The reason for setting a long-lived expiration time is to avoid problems in the case of a user closing a browser or bookmarking a page and then loading that page from a browser cache. Without persistent cookies, the form submission would fail in this case.
+.PP
+Some browsers (specifically Internet Explorer) can disallow the use of persistent cookies or can have the indexes to the cookie jar corrupted on disk, thereby causing CSRF protection checks to (sometimes intermittently) fail. Change this setting to @c 0 to use session-based CSRF cookies, which keep the cookies in-memory instead of on persistent storage.
+.RE
+.PP
+.I cookie_domain
+(string value, default: empty)
+.RS 4
+The domain to be used when setting the CSRF cookie. This can be useful for easily allowing cross-subdomain requests to be excluded from the normal cross site request forgery protection. It should be set to a string such as ".example.com" to allow a POST request from a form on one subdomain to be accepted by a view served from another subdomain.
+.PP
+Please note that the presence of this setting does not imply that the CSRF protection is safe from cross-subdomain attacks by default - please see the
+.B NOTES
+section.
+.RE
+.PP
+.I cookie_secure
+(boolean value, default: false)
+.RS 4
+Whether to use a secure cookie for the CSRF cookie. If this is set to
+.IR true ,
+the cookie will be marked as secure, which means browsers may ensure that the cookie is only sent with an HTTPS connection.
+.RE
+.PP
+.I trusted_origins
+(string list, default: empty)
+.RS 4
+A comma separated list of hosts which are trusted origins for unsafe requests (e.g. POST). For a secure unsafe request, the CSRF protection requires that the request have a
+.B Referer
+header that matches the origin present in the
+.B Host
+header. This prevents, for example, a POST request from
+.I subdomain.example.com
+from succeeding against
+.IR api.example.com .
+If you need cross-origin unsafe requests over HTTPS, continuing the example, add "subdomain.example.com" to this list. The setting also supports subdomains, so you could add ".example.com", for example, to allow access from all subdomains of
+.IR example.com .
+.RE
+.PP
+.I log_failed_ip
+(boolean value, default: false)
+.RS 4
+If this is set to
+.IR true ,
+the log output for failed checks will contain the IP address of the remote client.
+.RE
+.SH EXAMPLES
+.RS 0
+[Cutelyst_CSRFProtection_Plugin]
+.RE
+.RS 0
+cookie_secure=true
+.RE
+.SH NOTES
+Subdomains within a site will be able to set cookies on the client for the whole domain. By setting the cookie and using a corresponding token, subdomains will be able to circumvent the CSRF protection. The only way to avoid this is to ensure that subdomains are controlled by trusted users (or, are at least unable to set cookies). Note that even without CSRF, there are other vulnerabilities, such as session fixation, that make giving subdomains to untrusted parties a bad idea, and these vulnerabilities cannot easily be fixed with current browsers.
+.SH LOGGING CATEGORY
+cutelyst.plugin.csrfprotection

--- a/Cutelyst/Plugins/Memcached/CMakeLists.txt
+++ b/Cutelyst/Plugins/Memcached/CMakeLists.txt
@@ -39,3 +39,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CutelystQt5Memcached.pc.in
     @ONLY
 )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Cutelyst2Qt5Memcached.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CutelystQt5Memcached.5.in
+    ${CMAKE_CURRENT_BINARY_DIR}/Cutelyst2Qt5Memcached.5
+    @ONLY
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Cutelyst2Qt5Memcached.5 DESTINATION ${MANDIR}/man5)

--- a/Cutelyst/Plugins/Memcached/CutelystQt5Memcached.5.in
+++ b/Cutelyst/Plugins/Memcached/CutelystQt5Memcached.5.in
@@ -82,6 +82,8 @@ is not available on your system, have a look a the
 .UR http://docs.libmemcached.org/libmemcached_configuration.html
 online documentation of libmemcached
 .UE .
+.SH LOGGING CATEGORY
+cutelyst.plugin.memcached
 .SH "SEE ALSO"
 .BR Cutelyst@PROJECT_VERSION_MAJOR@Qt5MemcachedSessionStore (5)
 .BR libmemcached_configuration (3)

--- a/Cutelyst/Plugins/Memcached/CutelystQt5Memcached.5.in
+++ b/Cutelyst/Plugins/Memcached/CutelystQt5Memcached.5.in
@@ -5,7 +5,7 @@ Cutelyst@PROJECT_VERSION_MAJOR@Qt5Memcached - Configuration of the Memcached Plu
 .SH DESCRIPTION
 The Memcached plugin for Cutelyst can be used to store, retrieve, delete and modify data on a Memcached general-purpose distributed memory caching system. It uses libmemcached to connect to a pool of memcached servers and to perform the caching operations.
 .SH CONFIGURATION
-The Memcached plugin can be configured in the Cutelyst configuration file in the
+The Memcached plugin can be configured in the Cutelyst application configuration file in the
 .I Cutelyst_Memcached_Plugin
 section.
 It uses the same configuration strings as

--- a/Cutelyst/Plugins/Memcached/CutelystQt5Memcached.5.in
+++ b/Cutelyst/Plugins/Memcached/CutelystQt5Memcached.5.in
@@ -1,0 +1,87 @@
+.TH Cutelyst@PROJECT_VERSION_MAJOR@Qt5Memcached 5 "2018-01-11" "Cutelyst@PROJECT_VERSION_MAJOR@Qt5Memcached @PROJECT_VERSION@"
+
+.SH NAME
+Cutelyst@PROJECT_VERSION_MAJOR@Qt5Memcached - Configuration of the Memcached Plugin for the Cutelyst Web Framework
+.SH DESCRIPTION
+The Memcached plugin for Cutelyst can be used to store, retrieve, delete and modify data on a Memcached general-purpose distributed memory caching system. It uses libmemcached to connect to a pool of memcached servers and to perform the caching operations.
+.SH CONFIGURATION
+The Memcached plugin can be configured in the Cutelyst configuration file in the
+.I Cutelyst_Memcached_Plugin
+section.
+It uses the same configuration strings as
+.BR libmemcached_configuration (3)
+but in lowercase and without the dashes in front and for consistence - replaced by _ . So --BINARY-PROTOCOL will be binary_protocol. To add servers and/or sockets use the
+.I servers
+configuration key. Servers can be added with name, port and weight, separated by
+.I ,
+(comma) - multiple servers are separated by a
+.I ;
+(semicolon). To add sockets, use a full path as name. If no configuration has been set or if the
+.I servers
+configuration key is empty, a default server at localhost on port 11211 will be used.
+.PP
+Additional to the configuration options of
+.BR libmemcached_configuration (3)
+there are some plugin specific options:
+.PP
+.I compression
+(default: false)
+.RS 4
+boolean value, enables compression of input values based on qCompress / zlib
+.RE
+.PP
+.I compression_level
+(default: -1)
+.RS 4
+integer value, the compression level used by qCompress
+.RE
+.PP
+.I compression_threshold
+(default: 100)
+.RS 4
+integer value, the compression size threshold in bytes, only input values bigger than the threshold will be compressed
+.RE
+.PP
+.I encryption_key
+(default: empty)
+.RS 4
+string value, if set and not empty, AES encryption will be enabled
+.RE
+.PP
+.I sasl_user
+(default: empty)
+.RS 4
+string value, if set and not empty, SASL authentication will be used - note that SASL support has to be enabled when building libmemcached
+.RE
+.PP
+.I sasl_password
+(default: empty)
+.RS 4
+string value, if set and not empty, SASL authentication will be used
+.RE
+.SH EXAMPLES
+.RS 0
+[Cutelyst_Memcached_Plugin]
+.RE
+.RS 0
+servers=cache.example.com,11211,2;/path/to/memcached.sock,1
+.RE
+.RS 0
+binary_protocol=true
+.RE
+.RS 0
+namespace=foobar
+.RE
+.SH NOTES
+If you want to use non-ASCII key names you have to enable the
+.IR binary_protocol .
+.PP
+If
+.BR libmemcached_configuration (3)
+is not available on your system, have a look a the
+.UR http://docs.libmemcached.org/libmemcached_configuration.html
+online documentation of libmemcached
+.UE .
+.SH "SEE ALSO"
+.BR Cutelyst@PROJECT_VERSION_MAJOR@Qt5MemcachedSessionStore (5)
+.BR libmemcached_configuration (3)

--- a/Cutelyst/Plugins/MemcachedSessionStore/CMakeLists.txt
+++ b/Cutelyst/Plugins/MemcachedSessionStore/CMakeLists.txt
@@ -37,3 +37,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CutelystQt5MemcachedSessionStore.pc.i
     @ONLY
 )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Cutelyst2Qt5MemcachedSessionStore.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CutelystQt5MemcachedSessionStore.5.in
+    ${CMAKE_CURRENT_BINARY_DIR}/Cutelyst2Qt5MemcachedSessionStore.5
+    @ONLY
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Cutelyst2Qt5MemcachedSessionStore.5 DESTINATION ${MANDIR}/man5)

--- a/Cutelyst/Plugins/MemcachedSessionStore/CutelystQt5MemcachedSessionStore.5.in
+++ b/Cutelyst/Plugins/MemcachedSessionStore/CutelystQt5MemcachedSessionStore.5.in
@@ -7,7 +7,7 @@ This session store saves session data to Memcached servers using the
 .BR Cutelyst@PROJECT_VERSION_MAJOR@Qt5Memcached (5)
 plugin.
 .SH CONFIGURATION
-The Cutelyst@PROJECT_VERSION_MAJOR@Qt5MemcachedSessionStore plugin can be configured in the cutelyst configuration file in the
+The Cutelyst@PROJECT_VERSION_MAJOR@Qt5MemcachedSessionStore plugin can be configured in the Cutelyst application configuration file in the
 .I Cutelyst_MemcachedSessionStore_Plugin
 section.
 .PP

--- a/Cutelyst/Plugins/MemcachedSessionStore/CutelystQt5MemcachedSessionStore.5.in
+++ b/Cutelyst/Plugins/MemcachedSessionStore/CutelystQt5MemcachedSessionStore.5.in
@@ -27,5 +27,7 @@ group_key=sessions
 .RE
 .SH NOTES
 The memcached server does not guarantee the existence of the session data. It might for example delete the data because it runs out of memory and deletes session data. So be careful when using this plugin to store sessions.
+.SH LOGGING CATEGORY
+cutelyst.plugin.memcachedsessionstore
 .SH "SEE ALSO"
 .BR Cutelyst@PROJECT_VERSION_MAJOR@Qt5Memcached (5)

--- a/Cutelyst/Plugins/MemcachedSessionStore/CutelystQt5MemcachedSessionStore.5.in
+++ b/Cutelyst/Plugins/MemcachedSessionStore/CutelystQt5MemcachedSessionStore.5.in
@@ -1,0 +1,31 @@
+.TH Cutelyst@PROJECT_VERSION_MAJOR@Qt5MemcachedSessionStore 5 "2018-01-11" "Cutelyst@PROJECT_VERSION_MAJOR@Qt5MemcachedSessionStore @PROJECT_VERSION@"
+
+.SH NAME
+Cutelyst@PROJECT_VERSION_MAJOR@Qt5MemcachedSessionStore - Configuration of the Memcached Session Store Plugin for the Cutelyst Web Framework
+.SH DESCRIPTION
+This session store saves session data to Memcached servers using the
+.BR Cutelyst@PROJECT_VERSION_MAJOR@Qt5Memcached (5)
+plugin.
+.SH CONFIGURATION
+The Cutelyst@PROJECT_VERSION_MAJOR@Qt5MemcachedSessionStore plugin can be configured in the cutelyst configuration file in the
+.I Cutelyst_MemcachedSessionStore_Plugin
+section.
+.PP
+Currently there are the following configuration options:
+.PP
+.I group_key
+(default: empty)
+.RS 4
+string value, defines a group key to store the data on a specific server
+.RE
+.SH EXAMPLES
+.RS 0
+[Cutelyst_MemcachedSessionStore_Plugin]
+.RE
+.RS 0
+group_key=sessions
+.RE
+.SH NOTES
+The memcached server does not guarantee the existence of the session data. It might for example delete the data because it runs out of memory and deletes session data. So be careful when using this plugin to store sessions.
+.SH "SEE ALSO"
+.BR Cutelyst@PROJECT_VERSION_MAJOR@Qt5Memcached (5)

--- a/Cutelyst/Plugins/Session/CMakeLists.txt
+++ b/Cutelyst/Plugins/Session/CMakeLists.txt
@@ -37,3 +37,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CutelystQt5Session.pc.in
     @ONLY
 )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Cutelyst2Qt5Session.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CutelystQt5Session.5.in
+    ${CMAKE_CURRENT_BINARY_DIR}/Cutelyst2Qt5Session.5
+    @ONLY
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Cutelyst2Qt5Session.5 DESTINATION ${MANDIR}/man5)

--- a/Cutelyst/Plugins/Session/CutelystQt5Session.5.in
+++ b/Cutelyst/Plugins/Session/CutelystQt5Session.5.in
@@ -1,0 +1,39 @@
+.TH Cutelyst@PROJECT_VERSION_MAJOR@Qt5Session 5 "2018-01-11" "Cutelyst@PROJECT_VERSION_MAJOR@Qt5Session @PROJECT_VERSION@"
+
+.SH NAME
+Cutelyst@PROJECT_VERSION_MAJOR@Qt5Session - Configuration of the Session Plugin for the Cutelyst Web Framework
+.SH DESCRIPTION
+The Session plugin for Cutelyst can be used to generate user sessions that are stored on the server side in a session store and on the user side in a session cookie. The name of the session cookie is the name of the application + "_session".
+.SH CONFIGURATION
+The Session plugin can be configured in the Cutelyst application configuration file in the
+.I Cutelyst_Session_Plugin
+section.
+.PP
+.I expires
+(integer value, default: 7200)
+.RS 4
+Expiration duration of the cookie in seconds.
+.RE
+.PP
+.I verify_address
+(boolean value, default: false)
+.RS 4
+If enabled, the plugin will check if the IP address of the requesting user matches the address stored in the session data. In case of a mismatch, the session will be deleted.
+.RE
+.PP
+.I verify_user_agent
+(boolean value, default: false)
+.RS 4
+If true, the plugin will check if the user agent of the requesting user matches the user agent stored in the session data. In case of a mismatch, the session will be deleted.
+.RE
+.SH EXAMPLES
+.RS 0
+[Cutelyst_Session_Plugin]
+.RE
+.RS 0
+expires=1234
+.RE
+.SH LOGGING CATEGORY
+cutelyst.plugin.session
+.SH "SEE ALSO"
+.BR Cutelyst@PROJECT_VERSION_MAJOR@Qt5MemcachedSessionStore (5)

--- a/Cutelyst/Plugins/Session/session.h
+++ b/Cutelyst/Plugins/Session/session.h
@@ -69,9 +69,9 @@ public:
 
     /**
      * If config has
-     * [Plugin_Session]
+     * [Cutelyst_Session_Plugin]
      * expires = 1234
-     * it will change de default expires which is 7200 (two hours)
+     * it will change the default expires which is 7200 (two hours)
      */
     virtual bool setup(Application *app) final;
 


### PR DESCRIPTION
I wrote small man pages for some of my plugins describing the various configuration file options read by this plugins. In particular they cover the following plugins:
* Memcached
* MemcachedSessionStore
* CSRFProtection
They will be installed in the man page section number 5 (File formats and configuration files).