### PR TITLE
Validator plugin v2: translation support and clean up

### DIFF
--- a/Cutelyst/Plugins/Memcached/memcached.cpp
+++ b/Cutelyst/Plugins/Memcached/memcached.cpp
@@ -105,7 +105,7 @@ bool Memcached::setup(Application *app)
         const QString _val = map.value(opt, d->defaultConfig.value(opt)).toString();
         if (!_val.isEmpty()) {
             const QString optStr = QLatin1String("--") + opt.toUpper().replace(QLatin1Char('_'), QLatin1Char('-')) + QLatin1Char('=') + _val;
-            config.push_back(optStr);
+            config.push_back(optStr); // clazy:exclude=reserve-candidates
         }
     }
 

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed.cpp
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed.cpp
@@ -131,7 +131,7 @@ bool StaticCompressed::setup(Application *app)
 
     qCInfo(C_STATICCOMPRESSED, "Supported compressions: %s", qPrintable(supportedCompressions.join(QLatin1Char(','))));
 
-    connect(app, &Application::beforePrepareAction, [d](Context *c, bool *skipMethod) {
+    connect(app, &Application::beforePrepareAction, this, [d](Context *c, bool *skipMethod) {
         d->beforePrepareAction(c, skipMethod);
     });
 
@@ -193,7 +193,7 @@ bool StaticCompressedPrivate::locateCompressedFile(Context *c, const QString &re
                         compressedPath = locateCacheFile(path, currentDateTime, Brotli)                        ;
                         if (!compressedPath.isEmpty()) {
                             qCDebug(C_STATICCOMPRESSED, "Serving brotli compressed data from \"%s\".", qPrintable(compressedPath));
-                            contentEncoding = QLatin1String("br");
+                            contentEncoding = QStringLiteral("br");
                         }
                     } else
 #endif

--- a/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
+++ b/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
@@ -1,124 +1,84 @@
 set(plugin_validator_SRC
     validator.cpp
     validator_p.h
-    validator.h
     validatorrule.cpp
     validatorrule_p.h
-    validatorrule.h
     validatoraccepted.cpp
     validatoraccepted_p.h
-    validatoraccepted.h
     validatorafter.cpp
     validatorafter_p.h
-    validatorafter.h
     validatoralpha.cpp
     validatoralpha_p.h
-    validatoralpha.h
     validatoralphadash.cpp
     validatoralphadash_p.h
-    validatoralphadash.h
     validatoralphanum.cpp
     validatoralphanum_p.h
-    validatoralphanum.h
     validatorbefore.cpp
     validatorbefore_p.h
-    validatorbefore.h
     validatorbetween.cpp
     validatorbetween_p.h
-    validatorbetween.h
     validatorboolean.cpp
     validatorboolean_p.h
-    validatorboolean.h
     validatorconfirmed.cpp
     validatorconfirmed_p.h
-    validatorconfirmed.h
     validatordate.cpp
     validatordate_p.h
-    validatordate.h
     validatordatetime.cpp
     validatordatetime_p.h
-    validatordatetime.h
     validatordifferent.cpp
     validatordifferent_p.h
-    validatordifferent.h
     validatordigits.cpp
     validatordigits_p.h
-    validatordigits.h
     validatordigitsbetween.cpp
     validatordigitsbetween_p.h
-    validatordigitsbetween.h
     validatoremail.cpp
     validatoremail_p.h
-    validatoremail.h
     validatorfilled.cpp
     validatorfilled_p.h
-    validatorfilled.h
     validatorin.cpp
     validatorin_p.h
-    validatorin.h
     validatorinteger.cpp
     validatorinteger_p.h
-    validatorinteger.h
     validatorip.cpp
     validatorip_p.h
-    validatorip.h
     validatorjson.cpp
     validatorjson_p.h
-    validatorjson.h
     validatormax.cpp
     validatormax_p.h
-    validatormax.h
     validatormin.cpp
     validatormin_p.h
-    validatormin.h
     validatornotin.cpp
     validatornotin_p.h
-    validatornotin.h
     validatornumeric.cpp
     validatornumeric_p.h
-    validatornumeric.h
     validatorpresent.cpp
     validatorpresent_p.h
-    validatorpresent.h
     validatorregularexpression.cpp
     validatorregularexpression_p.h
-    validatorregularexpression.h
     validatorrequired.cpp
     validatorrequired_p.h
-    validatorrequired.h
     validatorrequiredif.cpp
     validatorrequiredif_p.h
-    validatorrequiredif.h
     validatorrequiredunless.cpp
     validatorrequiredunless_p.h
-    validatorrequiredunless.h
     validatorrequiredwith.cpp
     validatorrequiredwith_p.h
-    validatorrequiredwith.h
     validatorrequiredwithall.cpp
     validatorrequiredwithall_p.h
-    validatorrequiredwithall.h
     validatorrequiredwithout.cpp
     validatorrequiredwithout_p.h
-    validatorrequiredwithout.h
     validatorrequiredwithoutall.cpp
     validatorrequiredwithoutall_p.h
-    validatorrequiredwithoutall.h
     validatorsame.cpp
     validatorsame_p.h
-    validatorsame.h
     validatorsize.cpp
     validatorsize_p.h
-    validatorsize.h
     validatortime.cpp
     validatortime_p.h
-    validatortime.h
     validatorurl.cpp
     validatorurl_p.h
-    validatorurl.h
     validatorresult.cpp
     validatorresult_p.h
-    validatorresult.h
 ) 
 
 
@@ -183,6 +143,7 @@ set_target_properties(Cutelyst2Qt5UtilsValidator PROPERTIES
 
 target_link_libraries(Cutelyst2Qt5UtilsValidator
     PRIVATE Cutelyst2Qt5::Core
+    Qt5::Network
 )
 
 set_property(TARGET Cutelyst2Qt5UtilsValidator PROPERTY PUBLIC_HEADER ${plugin_validator_HEADERS})

--- a/Cutelyst/Plugins/Utils/Validator/Validators
+++ b/Cutelyst/Plugins/Utils/Validator/Validators
@@ -24,7 +24,7 @@
 #include "validatornumeric.h"
 #include "validatorpresent.h"
 #include "validatorregularexpression.h"
-#include "validatorrequired.h" 
+#include "validatorrequired.h"
 #include "validatorrequiredif.h"
 #include "validatorrequiredunless.h"
 #include "validatorrequiredwith.h"

--- a/Cutelyst/Plugins/Utils/Validator/validator.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validator.cpp
@@ -25,13 +25,13 @@ using namespace Cutelyst;
 
 Q_LOGGING_CATEGORY(C_VALIDATOR, "cutelyst.utils.validator")
 
-Validator::Validator(const QLatin1String &translationContext) :
+Validator::Validator(QLatin1String translationContext) :
     d_ptr(new ValidatorPrivate(translationContext))
 {
 }
 
 #ifdef Q_COMPILER_INITIALIZER_LISTS
-Validator::Validator(std::initializer_list<ValidatorRule *> validators, const QLatin1String &translationContext) :
+Validator::Validator(std::initializer_list<ValidatorRule *> validators, QLatin1String translationContext) :
     d_ptr(new ValidatorPrivate(validators, translationContext))
 {
 }

--- a/Cutelyst/Plugins/Utils/Validator/validator.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validator.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,25 +19,20 @@
 #include "validator_p.h"
 #include <Cutelyst/context.h>
 #include <Cutelyst/request.h>
-#include <QtCore/QLoggingCategory>
+#include <QLoggingCategory>
 
 using namespace Cutelyst;
 
 Q_LOGGING_CATEGORY(C_VALIDATOR, "cutelyst.utils.validator")
 
-Validator::Validator() :
-    d_ptr(new ValidatorPrivate)
+Validator::Validator(const QLatin1String &translationContext) :
+    d_ptr(new ValidatorPrivate(translationContext))
 {
 }
 
 #ifdef Q_COMPILER_INITIALIZER_LISTS
-Validator::Validator(std::initializer_list<ValidatorRule *> validators) :
-    d_ptr(new ValidatorPrivate(validators))
-{
-}
-
-Validator::Validator(std::initializer_list<ValidatorRule *> validators, std::initializer_list<std::pair<QString, QString> > labelDictionary) :
-    d_ptr(new ValidatorPrivate(validators, labelDictionary))
+Validator::Validator(std::initializer_list<ValidatorRule *> validators, const QLatin1String &translationContext) :
+    d_ptr(new ValidatorPrivate(validators, translationContext))
 {
 }
 #endif
@@ -60,13 +55,62 @@ Cutelyst::ValidatorResult Validator::validate(Context *c, ValidatorFlags flags) 
 {
     ValidatorResult result;
 
-    if (!c) {
-        qCWarning(C_VALIDATOR) << "No valid Context set, aborting validation.";
+    Q_ASSERT(c);
+
+    ParamsMultiMap params;
+    if (flags.testFlag(BodyParamsOnly)) {
+        params = c->req()->bodyParameters();
+    } else if (flags.testFlag(QueryParamsOnly)) {
+        params = c->req()->queryParameters();
+    } else {
+        params = c->req()->parameters();
+    }
+
+    result = validate(c, params, flags);
+
+    return result;
+}
+
+ValidatorResult Validator::validate(Context *c, const ParamsMultiMap &params, ValidatorFlags flags) const
+{
+    ValidatorResult result;
+
+    Q_ASSERT(c);
+    Q_D(const Validator);
+
+    if (d->validators.empty()) {
+        qCWarning(C_VALIDATOR) << "Validation started with empty validator list.";
         return result;
     }
 
-    const ParamsMultiMap params = c->request()->parameters();
-    result = validate(params, flags);
+    if (params.empty()) {
+        qCWarning(C_VALIDATOR) << "Validation started with empty parameters.";
+    }
+
+    const bool stopOnFirstError = flags.testFlag(StopOnFirstError);
+    const bool noTrimming = flags.testFlag(NoTrimming);
+
+    for (ValidatorRule *v : d->validators) {
+
+        if (noTrimming) {
+            v->setTrimBefore(false);
+        }
+
+        const ValidatorReturnType singleResult = v->validate(c, params);
+
+        if (singleResult.extra.isValid()) {
+            result.addExtra(v->field(), singleResult.extra);
+        }
+
+        if (singleResult) {
+            result.addValue(v->field(), singleResult.value);
+        } else {
+            result.addError(v->field(), singleResult.errorMessage);
+            if (stopOnFirstError) {
+                break;
+            }
+        }
+    }
 
     if (!result && flags.testFlag(FillStashOnError)) {
         c->setStash(QStringLiteral("validationErrorStrings"), result.errorStrings());
@@ -86,74 +130,9 @@ Cutelyst::ValidatorResult Validator::validate(Context *c, ValidatorFlags flags) 
     return result;
 }
 
-ValidatorResult Validator::validate(const ParamsMultiMap &params, ValidatorFlags flags) const
-{
-    ValidatorResult result;
-
-    Q_D(const Validator);
-
-    if (d->validators.empty()) {
-        qCWarning(C_VALIDATOR) << "Validation started with empty validator list.";
-        return result;
-    }
-
-    if (params.isEmpty()) {
-        qCWarning(C_VALIDATOR) << "Validation started with empty parameters.";
-    }
-
-    const bool stopOnFirstError = flags.testFlag(StopOnFirstError);
-    const bool noTrimming = flags.testFlag(NoTrimming);
-
-    for (ValidatorRule *v : d->validators) {
-        v->setParameters(params);
-
-        if (v->label().isEmpty()) {
-            v->setLabel(d->labelDict.value(v->field()));
-        }
-
-        if (noTrimming) {
-            v->setTrimBefore(false);
-        }
-
-        const QString singleResult = v->validate();
-
-        if (!singleResult.isEmpty()) {
-            result.addError(v->field(), singleResult);
-
-            if (stopOnFirstError) {
-                return result;
-            }
-        }
-    }
-
-    return result;
-}
-
 void Validator::addValidator(ValidatorRule *v)
 {
     Q_D(Validator);
+    v->setTranslationContext(d->translationContext);
     d->validators.push_back(v);
-}
-
-void Validator::setLabelDictionary(const QHash<QString, QString> &labelDict)
-{
-    Q_D(Validator);
-    d->labelDict = labelDict;
-}
-
-void Validator::addLabelDictionary(const QHash<QString, QString> &labelDict)
-{
-    Q_D(Validator);
-    if (!labelDict.isEmpty()) {
-        QHash<QString, QString>::const_iterator i = labelDict.constBegin();
-        while (i != labelDict.constEnd()) {
-            d->labelDict.insert(i.key(), i.value());
-        }
-    }
-}
-
-void Validator::addLabel(const QString &field, const QString &label)
-{
-    Q_D(Validator);
-    d->labelDict.insert(field, label);
 }

--- a/Cutelyst/Plugins/Utils/Validator/validator.h
+++ b/Cutelyst/Plugins/Utils/Validator/validator.h
@@ -243,7 +243,7 @@ public:
     /*!
      * \brief Constructs a new %Validator.
      */
-    explicit Validator(const QLatin1String &translationContext = QLatin1String());
+    explicit Validator(QLatin1String translationContext = QLatin1String());
 
 #ifdef Q_COMPILER_INITIALIZER_LISTS
     /*!
@@ -253,7 +253,7 @@ public:
      *
      * This constructor is only available if the compiler supports C++11 std::initializer_list.
      */
-    explicit Validator(std::initializer_list<ValidatorRule*> validators, const QLatin1String &translationContext = QLatin1String());
+    explicit Validator(std::initializer_list<ValidatorRule*> validators, QLatin1String translationContext = QLatin1String());
 #endif
 
     /*!

--- a/Cutelyst/Plugins/Utils/Validator/validator.h
+++ b/Cutelyst/Plugins/Utils/Validator/validator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -25,50 +25,79 @@
 
 namespace Cutelyst {
 
+/*!
+ * \defgroup plugins-utils-validator Validator
+ * \brief Provides an API to validate input values.
+ *
+ * The %Validator plugin provides an API to validate input values that are send by a user to the application,
+ * typically in the request body if it is a POST request or the URL query if it is a GET request. The plugin
+ * already provides \link plugins-utils-validator-rules validator rules\endlink for common tasks and input
+ * types but can be extended by deriving a new rule class from ValidatorRule. %Validator rules are not meant
+ * to be used on their own but as part of the Validator class that processes the input data. However some
+ * validator rules export their validation logic in a static member function that can be used without Validator
+ * directly on a value. See the documentation of Validator to learn more about how to use it.
+ *
+ * <h3>Logging</h3>
+ * Information is logged to the \c cutelyst.utils.validator logging category. Failed validation will only be logged
+ * if debug output is enabled. Other errors like failed parsing and missing validation data will be logged to
+ * the warning category.
+ *
+ * <h3>Building and using</h3>
+ * The plugin is linked to %Cutelyst Core API and the QtNetwork module. To use it in your application, link your
+ * application to \a Cutelyst2Qt5::Utils::Validator.
+ */
+
 class ValidatorPrivate;
 class Context;
 class ValidatorRule;
 
 /*!
+ * \ingroup plugins-utils-validator
  * \brief Validation processor for input data
  *
- * Validator can validate input data from the Context or a ParamsMultiMap using validation rules
- * implemented as classes derived from ValidatorRule. As long as the Validator::StopOnFirstError flasg is not set,
+ * %Validator can validate input data from the Context or a ParamsMultiMap using validation rules
+ * implemented as classes derived from ValidatorRule. As long as the Validator::StopOnFirstError flag is not set,
  * all validations will be performed until the end. Validations will be performed in the order they were added
- * on construction or via addValidator(). Any field can have any amount of validators.
+ * on construction or via addValidator(). Any field can have any amount of validators. The %Validator will
+ * take ownership of the added \link plugins-utils-validator-rules validator rules\endlink and will delete them
+ * on it's own destruction.
  *
  * Any validator requires at least the name of the \a field that should be validated. Some validators have
  * additional mandatory parameters that have to be set. The ValidatorSame for example has a mandatory parameter to set
  * the name of the other field to compare the values.
  *
- * The main Validator provides some comfort functions. One is the ability to set a label dictionary for generic error messages.
- * Every ValidatorRule will return a generic error message if no custom error message has been set. To use a label that is more
- * appropriate for displaying the field name and that should at best be the same as the label used in the HTML part, you could
- * set the label name on every validator. But if you are using more than one validator on a field, it might be easier to use
- * the constructor that takes the label dictionary as list or to use setLabelDictionary() to set a dictionary that automatically sets
- * the label for every field and validator.
+ * If you are using \link ValidatorMessages custom translatable error messages\endlink, you have to set the translation
+ * context on the %Validator on the constructor. The same translation context has than to be used with the custom strings
+ * for the validators. See ValidatorMessages for more information about translation of custom messages.
  *
- * The other comfort function can be used via the Validator::FillStashOnError flag. If you set the flag on the validate() function that takes
- * the Context pointer as parameter, it will add all error information as well as the not sensible input data to the \link Context::stash() stash \endlink
- * using the fillStash() function.
+ * Setting the \link Validator::FillStashOnError FillStashOnError\endlink flag on the validate() function will add all
+ * error information as well as the not sensible (not containing the string \c "password" in the field name) input
+ * data to the \link Context::stash() stash\endlink if validation fails.
  *
- * \par Usage example
+ * If only parameters from the request body or the request URL query should be taken into account by the validator,
+ * use the \link Validator::BodyParamsOnly BodyParamsOnly\endlink or \link Validator::QueryParamsOnly QueryParamsOnyly\endlink
+ * flag on the validate() function. If both are set, \link Validator::BodyParamsOnly BodyParamsOnly\endlink takes precedence.
+ * If nothing is set, all parameters to validate will be taken from both, body and query.
  *
- * Validators can be used standalone, but that is not their intention - they are designed to validate input
- * data of form fields and API requests and so on. So they work best together with this main Validator and directly on the
- * Context \link Context::stash() stash \endlink.
+ * <h3>Usage example</h3>
  *
- * Most validators will succeed if the input field is empty. You should use them together with one of the required validators
- * if the input field is required. This approach is more flexible than having a simple switch in any validator. There are
- * different validators to require a field that make it possible to have more complex requirements. You can find information
- * about the behavior on empty input fields in the documenation of every validator. You can find some more general information
- * at ValidatorRule and for sure in the documentation for every single validator. Information about writing your own
- * validators that work with this concept can be found at ValidatorRule.
+ * In %Cutelyst 1.x \link plugins-utils-validator-rules validator rules\endlink were usable standalone without being part
+ * of a %Validator object - even though they were never meant to be. This changed in %Cutelyst 2.0.0 so that only the constructor
+ * and destructor of a ValiadtorRule are public anymore. However they now can be used more flexible by pointing them to other
+ * input fields or stash keys to get validation data like compare values. Some validator rules like the ValidatorEmail export
+ * their validation logic as static function so that it can be used standalone directly on a value without needing a Context.
  *
- * Validator will retrun a ValidatorResult after validation has been performed. The result can be used to check the validity of the
- * input data. It will contain error messages from every failed ValidatorRule and a list of field names for which validation failed.
- * If there are no failed validation, the result will be valid, what you can check via ValidatorResult::isValid() or directly with
- * an if statement.
+ * Most validators will succeed if the input field is empty. You should use them together with one of the \link ValidatorRequired
+ * required validators\endlink if the input field is required. This approach is more flexible than having a simple switch in any
+ * validator. There are different validators to require a field that make it possible to have more complex requirements. You can
+ * find information about the behavior on empty input fields in the documenation of every validator rule. You can find some more
+ * general information at ValidatorRule and for sure in the documentation for every single \link plugins-utils-validator-rules
+ * validator rule\endlink. Information about writing your own validators that work with this concept can be found at ValidatorRule.
+ *
+ * %Validator will return a ValidatorResult after validation has been performed. The result can be used to check the validity of the
+ * input data. It will contain error messages from every failed ValidatorRule and a list of field names for which validation failed
+ * as well as the extracted values from the fields under validation. If there are no failed validations, the result will be valid,
+ * what you can check via ValidatorResult::isValid() or directly with an if statement.
  *
  * \code{.cpp}
  * #include <Cutelyst/Plugins/Utils/Validator> // includes the main validator
@@ -79,7 +108,7 @@ class ValidatorRule;
  * {
  *      if (c->req()->isPost()) {
  *
- *          // create a new static Validator with a set of rules and a label dictionary
+ *          // create a new static Validator with a set of rules and a translation context
  *          static Validator v({
  *              // this one will require the username to be present and not empty
  *              new ValidatorRequired(QStringLiteral("username")),
@@ -88,15 +117,20 @@ class ValidatorRule;
  *              // to have a length between 3 and 255 characters
  *              new ValidatorBetween(QStringLiteral("username"), QMetaType::QString, 3, 255),
  *
- *              // username can be long, but we dont want have anything else than alpha-numeric characters, dashes
- *              // and underscores in it
- *              new ValidatorAlphaDash(QStringLiteral("username")),
+ *              // username can be long, but we dont want have anything else than ASCII alpha-numeric characters,
+ *              // dashes and underscores in it
+ *              new ValidatorAlphaDash(QStringLiteral("username"), true),
  *
  *              // we also require an email address
  *              new ValidatorRequired(QStringLiteral("email")),
  *
  *              // and damn sure, the email address should be valid, at least it should look like valid
- *              new ValidatorEmail(QStringLiteral("email")),
+ *              // we are using a custom validation error message without a label
+ *              new ValidatorEmail(QStringLiteral("email"),
+ *                                 ValidatorEmail::Valid, // really strict validation
+ *                                 false, // we will not perform a DNS check
+ *                                 ValidatorMessages(nullptr, QT_TRANSLATE_NOOP("MyController", "The email address in the Email field is not valid."))
+ *                                ),
  *
  *              // seems like we are building a registration form, so lets require a password
  *              new ValidatorRequired(QStringLiteral("password")),
@@ -106,16 +140,11 @@ class ValidatorRule;
  *
  *              // the user should confirm the password in another field
  *              // and here we are using a custom error message
- *              new ValidatorConfirmed(QStringLiteral("password"), QString(), tr("Please enter the same password again in the confirmation field."))
- *          }, {
- *              // we will use a dictionary for our validators to generate generic error messages with
- *              // appropriate field labels, the labels could also be set per validator, but when using
- *              // multiple validators per field it is easier to let the main Validator set them for all
- *              // validators used on the specific field
- *              {QStringLiteral("username"), QStringLiteral("Username")},
- *              {QStringLiteral("email"), QStringLiteral("Email")},
- *              {QStringLiteral("password"), QStringLiteral("Password")}
- *          });
+ *              new ValidatorConfirmed(QStringLiteral("password"),
+ *                                     ValidatorMessages(QT_TRANSLATE_NOOP("MyController", "Password"),
+ *                                                       QT_TRANSLATE_NOOP("MyController", "Please enter the same password again in the confirmation field."))
+ *                                    );
+ *          }, QLatin1String("MyController"));
  *
  *          // ok, now we have all our validators in place - let the games begin
  *          // we will set the FillStashOnError flag to automatically fill the context stash with error data
@@ -137,24 +166,27 @@ class ValidatorRule;
  * }
  * \endcode
  *
- * \par Automatically filling the stash
+ * <h3>Automatically filling the stash</h3>
  *
- * If you set the Validator::FillStashOnError on the validate() function that takes a Context pointer,
- * the Validator will automatically fill the \link Context::stash() stash \endlink of the Context with error
- * information and field values that are not sensible (field names that do not contain \c password).
+ * If you set the \link Validator::FillStashOnError FillStashOnError\endlink flag on the validate() function,
+ * the %Validator will automatically fill the \link Context::stash() stash \endlink of the Context with error
+ * information and field values that are not sensible (field names that do not contain <code>"password"</code>).
  *
- * Beside the field values added with their field names, Validator will add two more entries to the stash:
+ * Beside the field values added with their field names, %Validator will add two more entries to the stash:
  * \li \a validationErrorStrings - a QStringList containing a list of all validation error messages, returned by ValidatorResult::errorStrings()
  * \li \a validationErrors - a QHash containing a dictionary with field names and their error strings, returned by ValidatorResult::errors()
  *
- * Let's assume that a user enters the following values into the form fields from the above example:
+ * Let's assume that a user enters the following values into the form fields from the example above:
  * \li \c username = detlef
  * \li \c email = detlef\@irgendwo
  * \li \c password = schalke04
  * \li \c password_confirmation = schalke05
  *
- * The validation will fail, because the email address is not valid and the password confirmation does not match the password.
- * Validator will add the following entries to the \link Context::stash() stash \endlink:
+ * The validation will fail, because the email address is not completely valid (it uses a TLD as domain, what is allowed according to RFC5321, but
+ * we set the ValidatorEmail::Valid category as threshold for the validation, thas does not allow TLDs as domain part) and the password confirmation
+ * does not match the password.
+ *
+ * %Validator will add the following entries to the \link Context::stash() stash \endlink:
  * \li \c username: "detlef"
  * \li \c email: "detlef@irgendwo"
  * \li \c validationErrorStrings: ["The email address in the Email field is not valid.", "Please enter the same password again in the confirmation field."]
@@ -163,33 +195,33 @@ class ValidatorRule;
  * The sensible data of the password fields is not part of the stash, but the other values can be used to prefill the form fields for the next attempt of
  * our little Schalke fan and can give him some hints what was wrong.
  *
- * \par Usage with Grantlee
+ * <h3>Usage with Grantlee</h3>
  *
- * The following example shows possible usage of the error data with \link GrantleeView Grantlee \endlink and the Bootstrap framework.
+ * The following example shows possible usage of the error data with \link GrantleeView Grantlee \endlink and the Bootstrap3 framework.
  *
  * \code{.html}
  * {% if validationErrorStrings.count %}
-    <div class="alert alert-warning" role="alert">
-        <h4 class="alert-heading">Errors in input data</h4>
-        <p>
-        <ul>
-            {% for errorString in validationErrorStrings %}
-            <li>{{ errorString }}</li>
-            {% endfor %}
-        </ul>
-        </p>
-    </div>
-    {% endif %}
+   <div class="alert alert-warning" role="alert">
+       <h4 class="alert-heading">Errors in input data</h4>
+       <p>
+       <ul>
+           {% for errorString in validationErrorStrings %}
+           <li>{{ errorString }}</li>
+           {% endfor %}
+       </ul>
+       </p>
+   </div>
+   {% endif %}
 
-    <form>
+   <form>
 
-        <div class="form-group{% if validationErrors.email.count %} has-warning{% endif %}">
-            <label for="email">Email</label>
-            <input type="email" id="email" name="email" maxlength="255" class="form-control{% if validationErrors.email.count %} form-control-warning{% endif %}" placeholder="Email" aria-describedby="emailHelpBlock" required value="{{ email }}">
-            <small id="emailHelpBlock" class="form-text text-muted">The email address will be used to send notifications and to restore lost passwords. Maximum length: 255</small>
-        </div>
+       <div class="form-group{% if validationErrors.email.count %} has-warning{% endif %}">
+           <label for="email">Email</label>
+           <input type="email" id="email" name="email" maxlength="255" class="form-control{% if validationErrors.email.count %} form-control-warning{% endif %}" placeholder="Email" aria-describedby="emailHelpBlock" required value="{{ email }}">
+           <small id="emailHelpBlock" class="form-text text-muted">The email address will be used to send notifications and to restore lost passwords. Maximum length: 255</small>
+       </div>
 
-    </form>
+   </form>
  * \endcode
  */
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT Validator
@@ -199,35 +231,29 @@ public:
      * \brief Flags that change the behavior of the Validator.
      */
     enum ValidatorFlag {
-        NoSpecialBehavior   = 0,    /**< No special behavior, the default. */
-        StopOnFirstError    = 1,    /**< Will stop the validation process on the first failed validation. */
-        FillStashOnError    = 2,    /**< Will fill the context's stash with error information. Will therefore only have an effect, if validate() has been started with a valid Context. */
-        NoTrimming          = 4,    /**< Will set ValidatorRule::setTrimBefore() to \c false on every validator. (default behavior is \c true) */
+        NoSpecialBehavior   =  0,    /**< No special behavior, the default. */
+        StopOnFirstError    =  1,    /**< Will stop the validation process on the first failed validation. */
+        FillStashOnError    =  2,    /**< Will fill the context's stash with error information. */
+        NoTrimming          =  4,    /**< Will set \link ValidatorRule::trimBefore() trimBefore()\endlink to \c false on every validator. (default behavior is \c true) */
+        BodyParamsOnly      =  8,    /**< Will only check for parameters that are send in the \link Request::bodyParameters() request body\endlink. (since Cutelyst 2.0.0) */
+        QueryParamsOnly     = 16     /**< Will only check for parameters that are part of the \link Request::queryParameters() request URL query\endlink. (since Cutelyst 2.0.0) */
     };
     Q_DECLARE_FLAGS(ValidatorFlags, ValidatorFlag)
 
     /*!
-     * \brief Constructs a new Validator.
+     * \brief Constructs a new %Validator.
      */
-    Validator();
+    explicit Validator(const QLatin1String &translationContext = QLatin1String());
 
 #ifdef Q_COMPILER_INITIALIZER_LISTS
     /*!
-     * \brief Constructs a new Validator using the defined \a validators.
-     * \param validators    List of validators that should be performed on the input fields. Will get destroyed on Validator destruction.
+     * \brief Constructs a new %Validator using the defined \a validators.
+     * \param validators List of validators that should be performed on the input fields. The %Validator will take ownerhip
+     * of them and will destroy them on it's own destruction.
      *
      * This constructor is only available if the compiler supports C++11 std::initializer_list.
      */
-    explicit Validator(std::initializer_list<ValidatorRule*> validators);
-
-    /*!
-     * \brief Constructs a new Validator using the defined \a validators and \a labelDictionary.
-     * \param validators        List of validators that should be performed on the input fields. Will get destroyed on Validator destruction.
-     * \param labelDictionary   Dictionary translating the field names into human readable labels for generic error messages.
-     *
-     * This constructor is only available if the compiler supports C++11 std::initializer_list.
-     */
-    Validator(std::initializer_list<ValidatorRule*> validators, std::initializer_list<std::pair<QString,QString> > labelDictionary);
+    explicit Validator(std::initializer_list<ValidatorRule*> validators, const QLatin1String &translationContext = QLatin1String());
 #endif
 
     /*!
@@ -263,9 +289,10 @@ public:
      * Returns a ValidatorResult that contains information about validation errors, if any. The result can be checked
      * directly in \c if statements.
      *
-     * Validator::FillStashOnError will not have any effect if using this function.
+     * If Validator::FillStashOnError is set, it will fill the stash of Context \c with error data and not
+     * sensible input values.
      */
-    ValidatorResult validate(const ParamsMultiMap &parameters, ValidatorFlags flags = NoSpecialBehavior) const;
+    ValidatorResult validate(Context *c, const ParamsMultiMap &parameters, ValidatorFlags flags = NoSpecialBehavior) const;
 
     /*!
      * \brief Adds a new validator to the list of validators.
@@ -274,42 +301,6 @@ public:
      * all added rules will get destroyed, too.
      */
     void addValidator(ValidatorRule *v);
-
-    /*!
-     * \brief Sets a new label dictionary.
-     *
-     * Sets a new dictionary that translates between field names and field labels. The entries are used to create generic error messages.
-     * Every validator can store field \link ValidatorRule::label() label \endlink that can be used to for generic error messages
-     * If there is no label and no custom error message set on a validator, a generic error message will be returned on failed validation
-     * that contains the field name. The field name might be looking ugly and uninformative to the user, so now the label comes into the game.
-     *
-     * You can set a label on each validator separately, but if you are using multiple validators on the same field, it might be easier to define
-     * them here. The main validator will then set the label to every validator for that field that has no own label set.
-     *
-     * The key of the QHash is the field name, the value is the label.
-     *
-     * \sa addLabelDictionary(), addLabel()
-     */
-    void setLabelDictionary(const QHash<QString,QString> &labelDict);
-
-    /*!
-     * \brief Adds a dictionary to the label dictionary.
-     *
-     * Adds \a labelDict to the internal label dictionary. The key of the QHash is the field name, the value is the label.
-     * See setLabelDictionary() for further information.
-     *
-     * \sa setLabelDictionary(), addLabel()
-     */
-    void addLabelDictionary(const QHash<QString,QString> &labelDict);
-
-    /*!
-     * \brief Adds a single entry to the label dictionary.
-     *
-     * Adds the \a label for the \a field to the internal label dictionary. See setLabelDictionary() for further information.
-     *
-     * \sa setLabelDictionary(), addLabelDictionary()
-     */
-    void addLabel(const QString &field, const QString &label);
 
 protected:
     const QScopedPointer<ValidatorPrivate> d_ptr;

--- a/Cutelyst/Plugins/Utils/Validator/validator_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validator_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,17 +27,21 @@ namespace Cutelyst {
 class ValidatorPrivate
 {
 public:
-    ValidatorPrivate() {}
+    ValidatorPrivate(const QLatin1String &trContext) :
+        translationContext(trContext)
+    {}
 
 #ifdef Q_COMPILER_INITIALIZER_LISTS
-    ValidatorPrivate(std::initializer_list<ValidatorRule*> vals) :
+    ValidatorPrivate(std::initializer_list<ValidatorRule*> vals, const QLatin1String &trContext) :
+        translationContext(trContext),
         validators(vals)
-    {}
-
-    ValidatorPrivate(std::initializer_list<ValidatorRule*> vals, std::initializer_list<std::pair<QString, QString> > labelDictionary) :
-        validators(vals),
-        labelDict(labelDictionary)
-    {}
+    {
+        if (!validators.empty()) {
+            for (ValidatorRule* r : validators) {
+                r->setTranslationContext(trContext);
+            }
+        }
+    }
 #endif
 
     ~ValidatorPrivate() {
@@ -47,9 +51,9 @@ public:
         }
     }
 
+    QLatin1String translationContext;
     ParamsMultiMap params;
     std::vector<ValidatorRule*> validators;
-    QHash<QString,QString> labelDict;
 };
 
 }

--- a/Cutelyst/Plugins/Utils/Validator/validator_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validator_p.h
@@ -27,12 +27,12 @@ namespace Cutelyst {
 class ValidatorPrivate
 {
 public:
-    ValidatorPrivate(const QLatin1String &trContext) :
+    ValidatorPrivate(QLatin1String trContext) :
         translationContext(trContext)
     {}
 
 #ifdef Q_COMPILER_INITIALIZER_LISTS
-    ValidatorPrivate(std::initializer_list<ValidatorRule*> vals, const QLatin1String &trContext) :
+    ValidatorPrivate(std::initializer_list<ValidatorRule*> vals, QLatin1String trContext) :
         translationContext(trContext),
         validators(vals)
     {

--- a/Cutelyst/Plugins/Utils/Validator/validatoraccepted.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoraccepted.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,15 +26,16 @@ namespace Cutelyst {
 class ValidatorAcceptedPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if a field is available and has a specific value.
  *
  * The \a field under validation must be \c yes, \c on, \c 1, or \c true. This is useful for validating "Terms of Service" acceptance.
  * This check will also fail if the input data for the specified \a field is empty or if the \a field is not part of the input data.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  */
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorAccepted : public ValidatorRule
 {
@@ -42,11 +43,10 @@ public:
     /*!
      * \brief Constructs a new accepted validator.
      *
-     * \param field         Name of the input field to validate.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param field     Name of the input field to validate.
+     * \param messages  Custom error message if validation fails.
      */
-    ValidatorAccepted(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorAccepted(const QString &field, const ValidatorMessages &messages = ValidatorMessages());
 
     /*!
      * \brief Deconstructs the accepted validator.
@@ -54,20 +54,25 @@ public:
     ~ValidatorAccepted();
 
     /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
+     * \ingroup plugins-utils-validator-rules
+     * \brief Returns \c true if the \a value is \c yes, \c on, \c 1, or \c true.
+     * \param value The value to validate.
+     * \return \c true if the \a value is \c yes, \c on, \c 1, or \c true.
      */
-    QString validate() const override;
+    static bool validate(const QString &value);
 
 protected:
     /*!
-     * \brief Creates a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain \c true.
      */
-    QString genericValidationError() const override;
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
 
     /*!
-     * Constructs a new ValidatorAccepted object with the given private class.
+     * \brief Creates a generic error message.
      */
-    ValidatorAccepted(ValidatorAcceptedPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
 
 private:
     Q_DECLARE_PRIVATE(ValidatorAccepted)

--- a/Cutelyst/Plugins/Utils/Validator/validatoraccepted_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoraccepted_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorAcceptedPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorAcceptedPrivate(const QString f, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e)
+    ValidatorAcceptedPrivate(const QString &f, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString())
     {}
 };
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorafter.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorafter.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,22 +18,13 @@
 
 #include "validatorafter_p.h"
 
-#include <QtCore/QLoggingCategory>
+#include <QLocale>
 
 using namespace Cutelyst;
 
-Q_LOGGING_CATEGORY(C_VALIDATORAFTER, "cutelyst.utils.validator.after")
-
-ValidatorAfter::ValidatorAfter(const QString &field, const QVariant &dateTime, const QString &inputFormat, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorAfterPrivate(field, dateTime, inputFormat, label, customError))
+ValidatorAfter::ValidatorAfter(const QString &field, const QVariant &comparison, const QString &timeZone, const char *inputFormat, const Cutelyst::ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(*new ValidatorAfterPrivate(field, comparison, timeZone, inputFormat, messages, defValKey))
 {
-
-}
-
-ValidatorAfter::ValidatorAfter(ValidatorAfterPrivate &dd) :
-    ValidatorRule(dd)
-{
-
 }
 
 ValidatorAfter::~ValidatorAfter()
@@ -41,121 +32,134 @@ ValidatorAfter::~ValidatorAfter()
 
 }
 
-QString ValidatorAfter::validate() const
+ValidatorReturnType ValidatorAfter::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
     Q_D(const ValidatorAfter);
 
-    const QString v = value();
+    const QString v = value(params);
 
     if (!v.isEmpty()) {
 
-        if (d->date.type() == QVariant::Date) {
+        const QTimeZone tz = d->extractTimeZone(c, params, d->timeZone);
 
-            const QDate odate = d->date.toDate();
-            if (!odate.isValid()) {
-                qCWarning(C_VALIDATORAFTER) << "Invalid validation date.";
-                result = validationDataError();
+        const QVariant _comp = (d->comparison.type() == QVariant::String)
+                ? d->extractOtherDateTime(c, params, d->comparison.toString(), tz, d->inputFormat)
+                : d->comparison;
+
+        if (_comp.type() == QVariant::Date) {
+
+            const QDate odate = _comp.toDate();
+            if (Q_UNLIKELY(!odate.isValid())) {
+                qCWarning(C_VALIDATOR, "ValidatorAfter: Invalid comparison date and time for field %s at %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                result.errorMessage = validationDataError(c);
             } else {
-                const QDate date = d->extractDate(v, d->inputFormat);
-                if (!date.isValid()) {
-                    qCWarning(C_VALIDATORAFTER) << "Can not parse input date:" << v;
-                    result = parsingError();
+                const QDate date = d->extractDate(c, v, d->inputFormat);
+                if (Q_UNLIKELY(!date.isValid())) {
+                    qCWarning(C_VALIDATOR, "ValidatorAfter: Can not parse input date \"%s\" for field %s at %s::%s.", qPrintable(v), qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                    result.errorMessage = parsingError(c, odate);
                 } else {
-                    if (date <= odate) {
-                        result = validationError();
+                    if (Q_UNLIKELY(date <= odate)) {
+                        qCDebug(C_VALIDATOR, "ValidatorAfter: Validation failed at %s::%s for field %s: Input date \"%s\" is not after \"%s\".", qPrintable(c->controllerName()), qPrintable(c->actionName()), qPrintable(field()), qPrintable(date.toString()), qPrintable(odate.toString()));
+                        result.errorMessage = validationError(c, odate);
+                    } else {
+                        result.value.setValue<QDate>(date);
                     }
                 }
             }
 
-        } else if (d->date.type() == QVariant::DateTime) {
+        } else if (_comp.type() == QVariant::DateTime) {
 
-            const QDateTime odatetime = d->date.toDateTime();
-            if (!odatetime.isValid()) {
-                qCWarning(C_VALIDATORAFTER) << "Invalid validation date and time.";
-                result = validationDataError();
+            const QDateTime odatetime = _comp.toDateTime();
+            if (Q_UNLIKELY(!odatetime.isValid())) {
+                qCWarning(C_VALIDATOR, "ValidatorAfter: Invalid comparison date and time for field %s at %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                result.errorMessage = validationDataError(c);
             } else {
-                const QDateTime datetime = d->extractDateTime(v, d->inputFormat);
-                if (!datetime.isValid()) {
-                    qCWarning(C_VALIDATORAFTER) << "Can not parse input date and time:" << v;
-                    result = parsingError();
+                const QDateTime datetime = d->extractDateTime(c, v, d->inputFormat, tz);
+                if (Q_UNLIKELY(!datetime.isValid())) {
+                    qCWarning(C_VALIDATOR, "ValidatorAfter: Can not parse input date and time \"%s\" for field %s at %s::%s.", qPrintable(v), qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                    result.errorMessage = parsingError(c, odatetime);
                 } else {
-                    if (datetime <= odatetime) {
-                        result = validationError();
+                    if (Q_UNLIKELY(datetime <= odatetime)) {
+                        qCDebug(C_VALIDATOR, "ValidatorAfter: Validation failed at %s::%s for field %s: Input date and time \"%s\" is not after \"%s\".", qPrintable(c->controllerName()), qPrintable(c->actionName()), qPrintable(field()), qPrintable(datetime.toString()), qPrintable(odatetime.toString()));
+                        result.errorMessage = validationError(c, odatetime);
+                    } else {
+                        result.value.setValue<QDateTime>(datetime);
                     }
                 }
             }
 
-        } else if (d->date.type() == QVariant::Time) {
+        } else if (_comp.type() == QVariant::Time) {
 
-            const QTime otime = d->date.toTime();
-            if (!otime.isValid()) {
-                qCWarning(C_VALIDATORAFTER) << "Invalid validation time.";
-                result = validationDataError();
+            const QTime otime = _comp.toTime();
+            if (Q_UNLIKELY(!otime.isValid())) {
+                qCWarning(C_VALIDATOR, "ValidatorAfter: Invalid comparison time for field %s at %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                result.errorMessage = validationDataError(c);
             } else {
-                const QTime time = d->extractTime(v, d->inputFormat);
-                if (!time.isValid()) {
-                    qCWarning(C_VALIDATORAFTER) << "Can not parse input time:" << v;
-                    result = parsingError();
+                const QTime time = d->extractTime(c, v, d->inputFormat);
+                if (Q_UNLIKELY(!time.isValid())) {
+                    qCWarning(C_VALIDATOR, "ValidatorAfter: Can not parse input time \"%s\" for field %s at %s::%s.", qPrintable(v), qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                    result.errorMessage = parsingError(c, otime);
                 } else {
-                    if (time <= otime) {
-                        result = validationError();
+                    if (Q_UNLIKELY(time <= otime)) {
+                        qCDebug(C_VALIDATOR, "ValidatorAfter: Validation failed at %s::%s for field %s: Input time \"%s\" is not after \"%s\".", qPrintable(c->controllerName()), qPrintable(c->actionName()), qPrintable(field()), qPrintable(time.toString()), qPrintable(otime.toString()));
+                        result.errorMessage = validationError(c, otime);
+                    } else {
+                        result.value.setValue<QTime>(time);
                     }
                 }
             }
 
         } else {
-            qCWarning(C_VALIDATORAFTER) << "Invalid validation data:" << d->date;
-            result = validationDataError();
+            qCWarning(C_VALIDATOR) << "ValidatorAfter: Invalid validation data for field" << field() << "at" << c->controllerName() << "::" << c->actionName() << ":" << d->comparison;
+            result.errorMessage = validationDataError(c);
         }
+    } else {
+        defaultValue(c, &result, "ValidatorAfter");
     }
 
     return result;
 }
 
-QString ValidatorAfter::genericValidationError() const
+QString ValidatorAfter::genericValidationError(Cutelyst::Context *c, const QVariant &errorData) const
 {
     QString error;
 
     Q_D(const ValidatorAfter);
 
-    QString compDateTime;
+    const QString _label = label(c);
+    if (_label.isEmpty()) {
 
-    switch (d->date.type()) {
-    case QVariant::Date:
-        //: date shown in validator error message
-        compDateTime = d->date.toDate().toString(QStringLiteral("dd.MM.yyyy"));
-        break;
-    case QVariant::DateTime:
-        //: date and time shown in validator error message
-        compDateTime = d->date.toDateTime().toString(QStringLiteral("dd.MM.yyyy HH:mm"));
-        break;
-    case QVariant::Time:
-        //: time shown in the validator error message
-        compDateTime = d->date.toTime().toString(QStringLiteral("dd.MM.yyyy HH:mm"));
-    default:
-        break;
-    }
-
-    if (label().isEmpty()) {
-
-        error = QStringLiteral("Has to be after %1.").arg(compDateTime);
+        switch (errorData.type()) {
+        case QVariant::Date:
+            error = QStringLiteral("Has to be after %1.").arg(errorData.toDate().toString(c->locale().dateFormat(QLocale::ShortFormat)));
+            break;
+        case QVariant::DateTime:
+            error = QStringLiteral("Has to be after %1.").arg(errorData.toDateTime().toString(c->locale().dateTimeFormat(QLocale::ShortFormat)));
+            break;
+        case QVariant::Time:
+            error = QStringLiteral("Has to be after %1.").arg(errorData.toTime().toString(c->locale().timeFormat(QLocale::ShortFormat)));
+            break;
+        default:
+            error = validationDataError(c);
+            break;
+        }
 
     } else {
 
-        switch(d->date.type()) {
+        switch(errorData.type()) {
         case QVariant::Date:
-            error = QStringLiteral("The date in the “%1” field must be after %2.").arg(label(), compDateTime);
+            error = c->translate("Cutelyst::ValidatorAfter", "The date in the “%1” field must be after %2.").arg(_label, errorData.toDate().toString(c->locale().dateFormat(QLocale::ShortFormat)));
             break;
         case QVariant::DateTime:
-            error = QStringLiteral("The date and time in the “%1” field must be after %2.").arg(label(), compDateTime);
+            error = c->translate("Cutelyst::ValidatorAfter", "The date and time in the “%1” field must be after %2.").arg(_label, errorData.toDateTime().toString(c->locale().dateTimeFormat(QLocale::ShortFormat)));
             break;
         case QVariant::Time:
-            error = QStringLiteral("The time in the “%1” field must be after %2.").arg(label(), compDateTime);
+            error = c->translate("Cutelyst::ValidatorAfter", "The time in the “%1” field must be after %2.").arg(_label, errorData.toTime().toString(c->locale().timeFormat(QLocale::ShortFormat)));
             break;
         default:
-            error = validationDataError();
+            error = validationDataError(c);
             break;
         }
 
@@ -164,14 +168,63 @@ QString ValidatorAfter::genericValidationError() const
     return error;
 }
 
-void ValidatorAfter::setDateTime(const QVariant &dateTime)
+QString ValidatorAfter::genericValidationDataError(Context *c, const QVariant &errorData) const
 {
-    Q_D(ValidatorAfter);
-    d->date = dateTime;
+    QString error;
+
+    Q_UNUSED(errorData)
+    error = c->translate("Cutelyst::ValidatorAfter", "The comparison value is not a valid date and/or time, or cannot be found.");
+
+    return error;
 }
 
-void ValidatorAfter::setInputFormat(const QString &format)
+QString ValidatorAfter::genericParsingError(Context *c, const QVariant &errorData) const
 {
-    Q_D(ValidatorAfter);
-    d->inputFormat = format;
+    QString error;
+
+    Q_D(const ValidatorAfter);
+
+    const QString _label = label(c);
+    if (d->inputFormat) {
+        if (_label.isEmpty()) {
+            error = c->translate("Cutelyst::ValidatorAfter", "Could not be parsed according to the follwing date and/or time format: %1").arg(c->translate(d->translationContext.data(), d->inputFormat));
+        } else {
+            error = c->translate("Cutelyst::ValidatorAfter", "The value of the “%1” field could not be parsed according to the follwing date and/or time format: %2").arg(_label, c->translate(d->translationContext.data(), d->inputFormat));
+        }
+    } else {
+
+        if (_label.isEmpty()) {
+            switch (errorData.type()) {
+            case QMetaType::QDateTime:
+                error = c->translate("Cutelyst::ValidatorAfter", "Could not be parsed as date and time.");
+                break;
+            case QMetaType::QTime:
+                error = c->translate("Cutelyst::ValidatorAfter", "Could not be parsed as time.");
+                break;
+            case QMetaType::QDate:
+                error = c->translate("Cutelyst::ValidatorAfter", "Could not be parsed as date.");
+                break;
+            default:
+                error = validationDataError(c);
+                break;
+            }
+        } else {
+            switch (errorData.type()) {
+            case QMetaType::QDateTime:
+                error = c->translate("Cutelyst::ValidatorAfter", "The value of the “%1” field could not be parsed as date and time.").arg(_label);
+                break;
+            case QMetaType::QTime:
+                error = c->translate("Cutelyst::ValidatorAfter", "The value of the “%1” field could not be parsed as time.").arg(_label);
+                break;
+            case QMetaType::QDate:
+                error = c->translate("Cutelyst::ValidatorAfter", "The value of the “%1” field could not be parsed as date.").arg(_label);
+                break;
+            default:
+                error = validationDataError(c);
+                break;
+            }
+        }
+    }
+
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorafter.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorafter.cpp
@@ -126,8 +126,6 @@ QString ValidatorAfter::genericValidationError(Cutelyst::Context *c, const QVari
 {
     QString error;
 
-    Q_D(const ValidatorAfter);
-
     const QString _label = label(c);
     if (_label.isEmpty()) {
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorafter.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorafter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,29 +20,71 @@
 
 #include <Cutelyst/cutelyst_global.h>
 #include "validatorrule.h"
+#include <QTimeZone>
 
 namespace Cutelyst {
 
 class ValidatorAfterPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if a date, time or datetime is after a comparison value.
  *
- * This will check if the date, time or datetime in the input \a field is after a comparison value set via \a dateTime in the constructor
- * or via setDateTime(). It depends on the comparison value how the input data is handled. If the comparative value is a QDateTime,
- * the input data will be converted into a QDateTime to compare the both values and so on.
+ * This will check if the date, time or datetime in the input \a field is earlier than the \a comparison value set in the constructor.
+ * It depends on the comparison value how the input data is handled. If the comparative value is a QDateTime,
+ * the input data will be converted into a QDateTime to compare the both values. The same happens for QTime and QDate. It is also
+ * possible to use a QString as \a comparison value. Using a QString makes it possible to compare the input field against a value from
+ * the \link Context::stash() stash\endlink.
  *
- * If the input data can not be parsed into a comparable format, the validation fails and ValidatorRule::parsingError() will return \c true.
- * It will also fail if the comparative value is not of type QDate, QTime or QDateTime. Use \a inputFormat parameter of the constructor
- * or setInputFormat() to set a custom input format. If no input format has been set, the validator will try to parse the input according
- * to the following definitions: Qt::ISODate, Qt::RFC2822Date, Qt::TextDate
+ * To specify a time zone that should be used for the input field - and the comparison input field if one is used, give either the IANA
+ * time zone ID name to the \a timeZone argument of the constructor or the name of an input field or stash key that contains the ID name.
+ * It will then be first tried to create a valid QTimeZone from the \a timeZone, if that fails it will first try to get the time zone from
+ * the input parameters and if there is no key with that name, trying it with the \link Context::stash() stash\endlink. Stash or input
+ * parameter can either contain a valid IANA time zone ID or the offset from UTC in seconds.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * If the input data can not be parsed into a comparable format, the validation fails and ValidatorRule::parsingError() will return
+ * the error string. It will also fail if the comparative value is not of type QDate, QTime, QDateTime or QString. Use \a inputFormat
+ * parameter of the constructor to set a custom input format. If that fails or if there is no custom \a inputFormat set, it will try
+ * to parse the date based on standard formats in the following order: \link Context::locale() Context locale's \endlink
+ * \link QLocale::toDate() toDate() \endlink with QLocale::ShortFormat and QLocale::LongFormat, Qt::ISODate, Qt::RFC2822Date and Qt::TextDate
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
+ *
+ * \par Examples
+ * \code{.cpp}
+ * void MyController::form_do(Context *c)
+ * {
+ *     Validator v({
+ *                  // compare against a specific date
+ *                  new ValidatorAfter(QStringLiteral("datefield"), QDate(2018, 1, 1)),
+ *
+ *                  // compare against a specific date and time that might have a format different for every language
+ *                  new ValidatorAfter(QStringLiteral("datefield2"),
+ *                                     QDateTime::fromString(QStringLiteral("2018-01-01T18:18:18"), Qt::ISODate),
+ *                                     QString(),
+ *                                     QT_TRANSLATE_NOOP("MyController", "MM/dd/yyyy, HH:mm")),
+ *
+ *                  // compare against a datetime in the stash
+ *                  new ValidatorAfter(QStringLiteral("datetime"), QStringLiteral("stashkey"))
+ *
+ *                  // compare against a datetime and set the input fields time zone
+ *                  new ValidatorAfter(QStringLiteral("datetime2"),
+ *                                     QDateTime(QDate(2018, 1, 15), QTime(12,0), QTimeZone(QByteArrayLiteral("Europe/Berlin")),
+ *                                     QStringLiteral("America/Rio_Branco")),
+ *
+ *                  // compare against a datetime and read input fields time zone from another input field
+ *                  new ValidatorAfter(QStringLiteral("datetime3"),
+ *                                     QDateTime(QDate(2018, 1, 15), QTime(12,0), QTimeZone(QByteArrayLiteral("Europe/Berlin")),
+ *                                     QStringLiteral("tz_field"))
+ *                }, QLatin1String("MyController"));
+ * }
+ * \endcode
+ *
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorBefore
  */
@@ -52,40 +94,42 @@ public:
     /*!
      * \brief Constructs a new after validator.
      * \param field         Name of the input field to validate.
-     * \param dateTime      QDate, QTime or QDateTime to compare against. Any other type will lead to a validation data error and valiation fails.
-     * \param inputFormat   Optional input format for input data parsing.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param comparison    The value or stash key to compare against.
+     * \param timeZone      IANA time zone ID or stash key containing the ID
+     * \param inputFormat   Optional input format for input data parsing, can be translatable.
+     * \param messages      Custom error message if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorAfter(const QString &field, const QVariant &dateTime, const QString &inputFormat = QString(), const QString &label = QString(), const QString &customError = QString());
+    ValidatorAfter(const QString &field, const QVariant &comparison, const QString &timeZone = QString(), const char *inputFormat = nullptr, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
 
     /*!
      * \brief Deconstructs the after validator.
      */
     ~ValidatorAfter();
 
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the QDate, QTime or QDateTime to compare against.
-     */
-    void setDateTime(const QVariant &dateTime);
-
-    /*!
-     * \brief Sets optional format for input data parsing.
-     */
-    void setInputFormat(const QString &format);
-
 protected:
-    QString genericValidationError() const override;
+    /*!
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the converted input parameter
+     * value as QDateTime, QDate or QTime, accoring to the type of the \a comparison value.
+     */
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
 
     /*!
-     * Constructs a new ValidatorAfter object with the given private class.
+     * \brief Returns a generic error if validation failed.
      */
-    ValidatorAfter(ValidatorAfterPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
+
+    /*!
+     * \brief Returns a generic error if comparison data was invalid.
+     */
+    QString genericValidationDataError(Context *c, const QVariant &errorData = QVariant()) const override;
+
+    /*!
+     * \brief Returns a generic error if the input value could not be parsed.
+     */
+    QString genericParsingError(Context *c, const QVariant &errorData = QVariant()) const override;
 
 private:
     Q_DECLARE_PRIVATE(ValidatorAfter)

--- a/Cutelyst/Plugins/Utils/Validator/validatorafter_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorafter_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,14 +27,16 @@ namespace Cutelyst {
 class ValidatorAfterPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorAfterPrivate(const QString &f, const QVariant &d, const QString &i, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
-        date(d),
+    ValidatorAfterPrivate(const QString &f, const QVariant &comp, const QString &tz, const char *i, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
+        comparison(comp),
+        timeZone(tz),
         inputFormat(i)
     {}
 
-    QVariant date;
-    QString inputFormat;
+    QVariant comparison;
+    QString timeZone;
+    const char *inputFormat = nullptr;
 };
 
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoralpha.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralpha.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,14 +21,8 @@
 
 using namespace Cutelyst;
 
-ValidatorAlpha::ValidatorAlpha(const QString &field, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorAlphaPrivate(field, label, customError))
-{
-
-}
-
-ValidatorAlpha::ValidatorAlpha(ValidatorAlphaPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorAlpha::ValidatorAlpha(const QString &field, bool asciiOnly, const Cutelyst::ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(*new ValidatorAlphaPrivate(field, asciiOnly, messages, defValKey))
 {
 
 }
@@ -38,24 +32,55 @@ ValidatorAlpha::~ValidatorAlpha()
 
 }
 
-QString ValidatorAlpha::validate() const
+ValidatorReturnType ValidatorAlpha::validate(Cutelyst::Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
-    if (!value().isEmpty() && !value().contains(QRegularExpression(QStringLiteral("^[\\pL\\pM]+$")))) {
-        result = validationError();
+    Q_D(const ValidatorAlpha);
+
+    const QString v = value(params);
+    if (!v.isEmpty()) {
+        if (Q_LIKELY(ValidatorAlpha::validate(v, d->asciiOnly))) {
+            result.value.setValue<QString>(v);
+            qCDebug(C_VALIDATOR, "ValidatorAlhpa: Validation failed for field %s at %s::%s: %s contains characters that are not allowed.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), qPrintable(v));
+        } else {
+            result.errorMessage = validationError(c);
+        }
+    } else {
+        defaultValue(c, &result, "ValidatorAlpha");
     }
 
     return result;
 }
 
-QString ValidatorAlpha::genericValidationError() const
+bool ValidatorAlpha::validate(const QString &value, bool asciiOnly)
+{
+    bool valid = true;
+
+    if (asciiOnly) {
+        for (const QChar &ch : value) {
+            const ushort &uc = ch.unicode();
+            if (!(((uc > 64) && (uc < 91)) || ((uc > 96) && (uc < 123)))) {
+                valid = false;
+                break;
+            }
+        }
+    } else {
+        valid = value.contains(QRegularExpression(QStringLiteral("^[\\pL\\pM]+$")));
+    }
+
+    return valid;
+}
+
+QString ValidatorAlpha::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
-    if (label().isEmpty()) {
-        error = QStringLiteral("Must be entirely alphabetic characters.");
+    Q_UNUSED(errorData)
+    const QString _label = label(c);
+    if (_label.isEmpty()) {
+        error = c->translate("Cutelyst::ValidatorAlhpa", "Must be entirely alphabetic characters.");
     } else {
-        error = QStringLiteral("The text in the “%1” field must be entirely alphabetic characters.").arg(label());
+        error = c->translate("Cutelyst::ValidatorAlhpa", "The text in the “%1” field must be entirely alphabetic characters.").arg(_label);
     }
     return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoralpha.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralpha.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,23 +26,27 @@ namespace Cutelyst {
 class ValidatorAlphaPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Validates an input field for only alphabetic content.
  *
  * The \a field under validation is only allowed to contain alphabetic characters.
+ * If \a asciiOnly is set to \c true, only US-ASCII characters are allowed, otherwise all UTF-8 alpha-numeric characters are allowed.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
- *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
  * \par Examples
  * \code
  * "Hallo Kuddel!" // invalid
- * "HalloKöddel" // valid
+ * "HalloKöddel" // valid if asciiOnly is false, otherwise it is false
+ * "HalloKuddel" // valid if asciiOnly is true
  * " " // valid if trimBefore is true, invalid if trimBefore is false
  * \endcode
+ *
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorAlphaDash, ValidatorAlphaNum
  */
@@ -53,10 +57,11 @@ public:
      * \brief Constructs a new alpha validator.
      *
      * \param field         Name of the input field to validate.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param asciiOnly     If \c true, only ASCII characters are allowed.
+     * \param messages      Custom error messages if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorAlpha(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorAlpha(const QString &field, bool asciiOnly = false, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
 
     /*!
      * \brief Deconstructs the alpha validator.
@@ -64,20 +69,27 @@ public:
     ~ValidatorAlpha();
 
     /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
+     * \ingroup plugins-utils-validator-rules
+     * \brief Returns \c true if \a value only contains alphabetic characters.
+     * \param value     The value to validate.
+     * \param asciiOnly If \c true, only ASCII characters are allowed.
+     * \return \c true if the \a value only contains alphabetic characters
      */
-    QString validate() const override;
+    static bool validate(const QString &value, bool asciiOnly = false);
 
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
 
     /*!
-     * Constructs a new ValidatorAlpha object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorAlpha(ValidatorAlphaPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
 
 private:
     Q_DECLARE_PRIVATE(ValidatorAlpha)

--- a/Cutelyst/Plugins/Utils/Validator/validatoralpha_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralpha_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,9 +26,12 @@ namespace Cutelyst {
 class ValidatorAlphaPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorAlphaPrivate(const QString &f, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e)
+    ValidatorAlphaPrivate(const QString &f, bool ao, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
+        asciiOnly(ao)
     {}
+
+    bool asciiOnly = false;
 };
 
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphadash.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphadash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,23 +26,27 @@ namespace Cutelyst {
 class ValidatorAlphaDashPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks a value for only alpha-numeric content and dashes and underscores.
  *
  * The \a field under validation is only allowed to contain alpha-numeric characters as well as dashes and underscores.
+ * If \a asciiOnly is set to \c true, only US-ASCII characters are allowed, otherwise all UTF-8 alpha-numeric characters are allowed.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
- *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
  * \par Examples
  * \code
  * "Hallo Kuddel!" // invalid
- * "Hallo_Köddel-2" // valid
+ * "Hallo_Köddel-2" // valid if asciiOnly is false
+ * "Hallo_Kuddel-2" // valid if asciiOnly is true
  * " " // valid if trimBefore is true, invalid if trimBefore is false
  * \endcode
+ *
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorAlpha, ValidatorAlphaNum
  */
@@ -51,11 +55,12 @@ class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorAlphaDash : public Validat
 public:
     /*!
      * \brief Constructs a new alpha dash validator.
-     * \param field         Name of the input field to validate.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param field     Name of the input field to validate.
+     * \param asciiOnly If \c true, only ASCII characters are allowed.
+     * \param messages  Custom error message if validation fails.
+     * \param defValKey \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorAlphaDash(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorAlphaDash(const QString &field, bool asciiOnly = false, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
 
     /*!
      * \brief Deconstructs the alpha dash validator.
@@ -63,20 +68,27 @@ public:
     ~ValidatorAlphaDash();
 
     /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
+     * \ingroup plugins-utils-validator-rules
+     * \brief Returns \c true if the \a value only contains alpha-numeric characters, dashes and underscores.
+     * \param value     The value to validate as it is.
+     * \param asciiOnly If \c true, only ASCII characters are allowed.
+     * \return \c true if the \a value only contains alpha-numeric characters, dashes and underscores
      */
-    QString validate() const override;
+    static bool validate(const QString &value, bool asciiOnly = false);
 
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
 
     /*!
-     * Constructs a new ValidatorAlphaDash object with the given private class.
+     * \brief Returns a generic error message.
      */
-    ValidatorAlphaDash(ValidatorAlphaDashPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
 
 private:
     Q_DECLARE_PRIVATE(ValidatorAlphaDash)

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphadash_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphadash_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,9 +26,12 @@ namespace Cutelyst {
 class ValidatorAlphaDashPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorAlphaDashPrivate(const QString &f, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e)
+    ValidatorAlphaDashPrivate(const QString &f, bool ao, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
+        asciiOnly(ao)
     {}
+
+    bool asciiOnly = false;
 };
 
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphanum.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphanum.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,23 +26,26 @@ namespace Cutelyst {
 class ValidatorAlphaNumPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks a value for only alpha-numeric content.
  *
  * The \a field under validation is only allowed to contain alpha-numeric characters.
+ * If \a asciiOnly is set to \c true, only US-ASCII characters are allowed, otherwise all UTF-8 alpha-numeric characters are allowed.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
- *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
  * \par Examples
  * \code
  * "Hallo Kuddel!" // invalid
- * "HalloKöddel2" // valid
+ * "HalloKöddel2" // valid if asciiOnly is false
  * " " // valid if trimBefore is true, invaid if trimBefore is false
  * \endcode
+ *
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorAlpha, ValidatorAlphaDash
  */
@@ -51,11 +54,12 @@ class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorAlphaNum : public Validato
 public:
     /*!
      * \brief Constructs a new alpha num validator.
-     * \param field         Name of the input field to validate.
-     * \param label         Human readable input field label, used for error messages.
-     * \param customError   Custom errror message if validation fails.
+     * \param field     Name of the input field to validate.
+     * \param asciiOnly     If \c true, only ASCII characters are allowed.
+     * \param messages  Custom error message if validation fails.
+     * \param defValKey \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorAlphaNum(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorAlphaNum(const QString &field, bool asciiOnly = false, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
 
     /*!
      * \brief Deconstructs the alpha num validator.
@@ -63,20 +67,27 @@ public:
     ~ValidatorAlphaNum();
 
     /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
+     * \ingroup plugins-utils-validator-rules
+     * \brief Returns \c true if \a value only contains alpha-numeric characters.
+     * \param value     The value to validate as it is.
+     * \param asciiOnly If \c true, only ASCII characters are allowed.
+     * \return \c true if the \a value only contains alpha-numeric characters
      */
-    QString validate() const override;
+    static bool validate(const QString &value, bool asciiOnly = false);
 
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
 
     /*!
-     * Constructs a new ValidatorAlphaNum object with the given private class.
+     * \brief Returns a generic error message.
      */
-    ValidatorAlphaNum(ValidatorAlphaNumPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
 
 private:
     Q_DECLARE_PRIVATE(ValidatorAlphaNum)

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphanum_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphanum_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,9 +26,12 @@ namespace Cutelyst {
 class ValidatorAlphaNumPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorAlphaNumPrivate(const QString &f, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e)
+    ValidatorAlphaNumPrivate(const QString &f, bool ao, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
+        asciiOnly(ao)
     {}
+
+    bool asciiOnly = false;
 };
 
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorbefore.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbefore.cpp
@@ -127,8 +127,6 @@ QString ValidatorBefore::genericValidationError(Cutelyst::Context *c, const QVar
 {
     QString error;
 
-    Q_D(const ValidatorBefore);
-
     const QString _label = label(c);
     if (_label.isEmpty()) {
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorbefore.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbefore.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,23 +26,64 @@ namespace Cutelyst {
 class ValidatorBeforePrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if a date, time or datetime is before a comparison value.
  *
- * This will check if the date, time or datetime in the input \a field is before a comparison value set via \a dateTime in the constructor
- * or via setDateTime(). It depends on the comparison value how the input data is handled. If the comparative value is a QDateTime,
- * the input data will be converted into a QDateTime to compare the both values and so on.
+ * This will check if the date, time or datetime in the input \a field is later than the \a comparison value set in the constructor
+ * or via setComparison(). It depends on the comparison value how the input data is handled. If the comparative value is a QDateTime,
+ * the input data will be converted into a QDateTime to compare the both values. The same happens for QTime and QDate. It is also
+ * possible to use a QString as \a comparison value. Using a QString makes it possible to compare the input field against a value from
+ * the \link Context::stash() stash\endlink.
  *
- * If the input data can not be parsed into a comparable format, the validation fails and ValidatorRule::parsingError() will return \c true.
- * It will also fail if the comparative value is not of type QDate, QTime or QDateTime. Use \a inputFormat parameter of the constructor
- * or setInputFormat() to set a custom input format. If no input format has been set, the validator will try to parse the input according
- * to the following definitions: Qt::ISODate, Qt::RFC2822Date, Qt::TextDate
+ * To specify a time zone that should be used for the input field - and the comparison input field if one is used, give either the IANA
+ * time zone ID name to the \a timeZone argument of the constructor or the name of an input field or stash key that contains the ID name.
+ * It will then be first tried to create a valid QTimeZone from the \a timeZone, if that fails it will first tryp to get the time zone from
+ * the input parameters and if there is no key with the name trying it with the \link Context::stash() stash\endlink. Stash or input parameter
+ * can either contain a valid IANA time zone ID or the offset from UTC in seconds.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * If the input data can not be parsed into a comparable format, the validation fails and ValidatorRule::parsingError() will return
+ * the error string. It will also fail if the comparative value is not of type QDate, QTime, QDateTime or QString. Use \a inputFormat
+ * parameter of the constructor to set a custom input format. If that fails or if there is no custom \a inputFormat set, it will try
+ * to parse the date based on standard formats in the following order: \link Context::locale() Context locale's \endlink
+ * \link QLocale::toDate() toDate() \endlink with QLocale::ShortFormat and QLocale::LongFormat, Qt::ISODate, Qt::RFC2822Date and Qt::TextDate
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
+ *
+ * \par Examples
+ * \code{.cpp}
+ * void MyController::form_do(Context *c)
+ * {
+ *     Validator v({
+ *                  // compare against a specific date
+ *                  new ValidatorBefore(QStringLiteral("datefield"), QDate(2018, 1, 1)),
+ *
+ *                  // compare against a specific date and time that might have a format different for every language
+ *                  new ValidatorBefore(QStringLiteral("datefield2"),
+ *                                      QDateTime::fromString(QStringLiteral("2018-01-01T18:18:18"), Qt::ISODate),
+ *                                      QString(),
+ *                                      QT_TRANSLATE_NOOP("MyController", "yyyy-MM-ddTHH:mm:ss")),
+ *
+ *                  // compare against a datetime in the stash
+ *                  new ValidatorBefore(QStringLiteral("datetime"), QStringLiteral("stashkey"))
+ *
+ *                  // compare against a datetime and set the input fields time zone
+ *                  new ValidatorBefore(QStringLiteral("datetime2"),
+ *                                      QDateTime(QDate(2018, 1, 15), QTime(12,0), QTimeZone(QByteArrayLiteral("Europe/Berlin")),
+ *                                      QStringLiteral("America/Rio_Branco")),
+ *
+ *                  // compare against a datetime and read input fields time zone from another input field
+ *                  new ValidatorBefore(QStringLiteral("datetime3"),
+ *                                      QDateTime(QDate(2018, 1, 15), QTime(12,0), QTimeZone(QByteArrayLiteral("Europe/Berlin")),
+ *                                      QStringLiteral("tz_field"))
+ *                }, QLatin1String("MyController"));
+ * }
+ * \endcode
+ *
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorAfter
  */
@@ -52,43 +93,42 @@ public:
     /*!
      * \brief Constructs a new before validator.
      * \param field         Name of the input field to validate.
-     * \param dateTime      QDate, QTime or QDateTime to compare against. Any other type will lead to a validation data error and valiation fails.
-     * \param inputFormat   Optional input format for input data parsing.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param comparison    The value or stash key to compare against.
+     * \param timeZone      IANA time zone ID, name of a input field containing the ID or stash key containing the ID
+     * \param inputFormat   Optional input format for input data parsing, can be translatable.
+     * \param messages      Custom error message if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorBefore(const QString &field, const QVariant &dateTime, const QString &inputFormat = QString(), const QString &label = QString(), const QString &customError = QString());
+    ValidatorBefore(const QString &field, const QVariant &comparison, const QString &timeZone = QString(), const char *inputFormat = nullptr, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
 
     /*!
      * \brief Deconstructs the before validator.
      */
     ~ValidatorBefore();
 
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the QDate, QTime or QDateTime to compare against.
-     */
-    void setDateTime(const QVariant &dateTime);
-
-    /*!
-     * \brief Sets optional format for input data parsing.
-     */
-    void setInputFormat(const QString &format);
-
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the converted input parameter
+     * value as QDateTime, QDate or QTime, accoring to the type of the \a comparison value.
      */
-    QString genericValidationError() const override;
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
 
     /*!
-     * Constructs a new ValidatorBefore object with the given private class.
+     * \brief Returns a generic error if validation failed.
      */
-    ValidatorBefore(ValidatorBeforePrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
+
+    /*!
+     * \brief Returns a generic error if comparison data was invalid.
+     */
+    QString genericValidationDataError(Context *c, const QVariant &errorData = QVariant()) const override;
+
+    /*!
+     * \brief Returns a generic error if the input value could not be parsed.
+     */
+    QString genericParsingError(Context *c, const QVariant &errorData = QVariant()) const override;
 
 private:
     Q_DECLARE_PRIVATE(ValidatorBefore)

--- a/Cutelyst/Plugins/Utils/Validator/validatorbefore_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbefore_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,14 +27,16 @@ namespace Cutelyst {
 class ValidatorBeforePrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorBeforePrivate(const QString &f, const QVariant &d, const QString &i, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
-        date(d),
+    ValidatorBeforePrivate(const QString &f, const QVariant &comp, const QString &tz, const char *i, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
+        comparison(comp),
+        timeZone(tz),
         inputFormat(i)
     {}
 
-    QVariant date;
-    QString inputFormat;
+    QVariant comparison;
+    QString timeZone;
+    const char *inputFormat = nullptr;
 };
 
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorbetween.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbetween.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,130 +20,287 @@
 
 using namespace Cutelyst;
 
-ValidatorBetween::ValidatorBetween(const QString &field, QMetaType::Type type, double min, double max, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorBetweenPrivate(field, type, min, max, label, customError))
+ValidatorBetween::ValidatorBetween(const QString &field, QMetaType::Type type, const QVariant &min, const QVariant &max, const ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(*new ValidatorBetweenPrivate(field, type, min, max, messages, defValKey))
 {
 }
-
-
-ValidatorBetween::ValidatorBetween(ValidatorBetweenPrivate &dd) :
-    ValidatorRule(dd)
-{
-}
-
 
 ValidatorBetween::~ValidatorBetween()
 {
 }
 
-
-
-QString ValidatorBetween::validate() const
+ValidatorReturnType ValidatorBetween::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
-    const QString v = value();
+    const QString v = value(params);
+
+    Q_D(const ValidatorBetween);
 
     if (!v.isEmpty()) {
-        Q_D(const ValidatorBetween);
+        bool ok = false;
+        bool valid = false;
 
-        if (d->type == QMetaType::Int) {
-            qlonglong val = v.toLongLong();
-            qlonglong min = (qlonglong)d->min;
-            qlonglong max = (qlonglong)d->max;
-            if ((val < min) || (val > max)) {
-                result = validationError();
+        switch (d->type) {
+        case QMetaType::Short:
+        case QMetaType::Int:
+        case QMetaType::Long:
+        case QMetaType::LongLong:
+        {
+            const qlonglong val = c->locale().toLongLong(v, &ok);
+            if (Q_UNLIKELY(!ok)) {
+                result.errorMessage = parsingError(c);
+                qCWarning(C_VALIDATOR, "ValidatorBetween: Failed to parse value of field %s into number at %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            } else {
+                const qlonglong min = d->extractLongLong(c, params, d->min, &ok);
+                if (Q_UNLIKELY(!ok)) {
+                    result.errorMessage = validationDataError(c, -1);
+                    qCWarning(C_VALIDATOR, "ValidatorBetween: Invalid minimum comparison value for field %s in %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                } else {
+                    const qlonglong max = d->extractLongLong(c, params, d->max, &ok);
+                    if (Q_UNLIKELY(!ok)) {
+                        result.errorMessage = validationDataError(c, 1);
+                        qCWarning(C_VALIDATOR, "ValidatorBetween: Invalid maximum comparison value for field %s in %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                    } else {
+                        if ((val < min) || (val > max)) {
+                            result.errorMessage = validationError(c, QVariantMap{
+                                                                      {QStringLiteral("val"), val},
+                                                                      {QStringLiteral("min"), min},
+                                                                      {QStringLiteral("max"), max}
+                                                                  });
+                            qCDebug(C_VALIDATOR, "ValidatorBetween: Validation failed for field %s in %s::%s: %lli is not between %lli and %lli.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), val, min, max);
+                        } else {
+                            valid = true;
+                        }
+                    }
+                }
             }
-        } else if (d->type == QMetaType::UInt) {
-            qulonglong val = v.toULongLong();
-            qulonglong min = (qulonglong)d->min;
-            qulonglong max = (qulonglong)d->max;
-            if ((val < min) || (val > max)) {
-                result = validationError();
-            }
-        } else if (d->type == QMetaType::Float) {
-            double val = v.toDouble();
-            if ((val < d->min) || (val > d->max)) {
-                result = validationError();
-            }
-        } else if (d->type == QMetaType::QString) {
-            int val = v.length();
-            int min = (int)d->min;
-            int max = (int)d->max;
-            if ((val < min) || (val > max)) {
-                result = validationError();
-            }
-        } else {
-            result = validationDataError();
         }
+            break;
+        case QMetaType::UShort:
+        case QMetaType::UInt:
+        case QMetaType::ULong:
+        case QMetaType::ULongLong:
+        {
+            const qulonglong val = v.toULongLong(&ok);
+            if (Q_UNLIKELY(!ok)) {
+                result.errorMessage = parsingError(c);
+                qCWarning(C_VALIDATOR, "ValidatorBetween: Failed to parse value of field %s into number at %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            } else {
+                const qulonglong min = d->extractULongLong(c, params, d->min, &ok);
+                if (Q_UNLIKELY(!ok)) {
+                    result.errorMessage = validationDataError(c, -1);
+                    qCWarning(C_VALIDATOR, "ValidatorBetween: Invalid minimum comparison value for field %s in %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                } else {
+                    const qulonglong max = d->extractULongLong(c, params, d->max, &ok);
+                    if (Q_UNLIKELY(!ok)) {
+                        result.errorMessage = validationDataError(c, 1);
+                        qCWarning(C_VALIDATOR, "ValidatorBetween: Invalid maximum comparison value for field %s in %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                    } else {
+                        if ((val < min) || (val > max)) {
+                            result.errorMessage = validationError(c, QVariantMap{
+                                                                      {QStringLiteral("val"), val},
+                                                                      {QStringLiteral("min"), min},
+                                                                      {QStringLiteral("max"), max}
+                                                                  });
+                            qCDebug(C_VALIDATOR, "ValidatorBetween: Validation failed for field %s in %s::%s: %llu is not between %llu and %llu.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), val, min, max);
+                        } else {
+                            valid = true;
+                        }
+                    }
+                }
+            }
+        }
+            break;
+        case QMetaType::Float:
+        case QMetaType::Double:
+        {
+            const double val = v.toDouble(&ok);
+            if (Q_UNLIKELY(!ok)) {
+                result.errorMessage = parsingError(c);
+                qCWarning(C_VALIDATOR, "ValidatorBetween: Failed to parse value of field %s into number at %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            } else {
+                const double min = d->extractDouble(c, params, d->min, &ok);
+                if (Q_UNLIKELY(!ok)) {
+                    result.errorMessage = validationDataError(c, -1);
+                    qCWarning(C_VALIDATOR, "ValidatorBetween: Invalid minimum comparison value for field %s in %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                } else {
+                    const double max = d->extractDouble(c, params, d->max, &ok);
+                    if (Q_UNLIKELY(!ok)) {
+                        result.errorMessage = validationDataError(c, 1);
+                        qCWarning(C_VALIDATOR, "ValidatorBetween: Invalid maximum comparison value for field %s in %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                    } else {
+                        if ((val < min) || (val > max)) {
+                            result.errorMessage = validationError(c, QVariantMap{
+                                                                      {QStringLiteral("val"), val},
+                                                                      {QStringLiteral("min"), min},
+                                                                      {QStringLiteral("max"), max}
+                                                                  });
+                            qCDebug(C_VALIDATOR, "ValidatorBetween: Validation failed for field %s in %s::%s: %f is not between %f and %f.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), val, min, max);
+                        } else {
+                            valid = true;
+                        }
+                    }
+                }
+            }
+        }
+            break;
+        case QMetaType::QString:
+        {
+            const qlonglong val = static_cast<qlonglong>(v.length());
+            const qlonglong min = d->extractLongLong(c, params, d->min, &ok);
+            if (Q_UNLIKELY(!ok)) {
+                result.errorMessage = validationDataError(c, -1);
+                qCWarning(C_VALIDATOR, "ValidatorBetween: Invalid minimum comparison value for field %s in %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            } else {
+                const qlonglong max = d->extractLongLong(c, params, d->max, &ok);
+                if (Q_UNLIKELY(!ok)) {
+                    result.errorMessage = validationDataError(c, 1);
+                    qCWarning(C_VALIDATOR, "ValidatorBetween: Invalid maximum comparison value for field %s in %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                } else {
+                    if ((val < min) || (val > max)) {
+                        result.errorMessage = validationError(c, QVariantMap{
+                                                                  {QStringLiteral("val"), val},
+                                                                  {QStringLiteral("min"), min},
+                                                                  {QStringLiteral("max"), max}
+                                                              });
+                        qCDebug(C_VALIDATOR, "ValidatorBetween: Validation failed for field %s in %s::%s: string length %lli is not between %lli and %lli.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), val, min, max);
+                    } else {
+                        valid = true;
+                    }
+                }
+            }
+        }
+            break;
+        default:
+            qCWarning(C_VALIDATOR, "ValidatorBetween: The comparison type with ID %i for field %s at %s::%s is not supported.", static_cast<int>(d->type), qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            result.errorMessage = validationDataError(c, 0);
+            break;
+        }
+
+        if (valid) {
+            if (d->type != QMetaType::QString) {
+                const QVariant _v = d->valueToNumber(c, v, d->type);
+                if (_v.isValid()) {
+                    result.value = _v;
+                } else {
+                    result.errorMessage = parsingError(c);
+                }
+            } else {
+                result.value.setValue<QString>(v);
+            }
+        }
+    } else {
+        defaultValue(c, &result, "ValidatorBetween");
     }
 
     return result;
 }
 
-QString ValidatorBetween::genericValidationError() const
+QString ValidatorBetween::genericValidationError(Cutelyst::Context *c, const QVariant &errorData) const
 {
     QString error;
 
     Q_D(const ValidatorBetween);
 
+    const QVariantMap map = errorData.toMap();
     QString min, max;
-    if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::QString) {
-        min = QString::number(d->min, 'f', 0);
-        max = QString::number(d->max, 'f', 0);
-    } else {
-        min = QString::number(d->min);
-        max = QString::number(d->max);
+    switch (d->type) {
+    case QMetaType::Short:
+    case QMetaType::Int:
+    case QMetaType::Long:
+    case QMetaType::LongLong:
+    case QMetaType::QString:
+        min = c->locale().toString(map.value(QStringLiteral("min")).toLongLong());
+        max = c->locale().toString(map.value(QStringLiteral("max")).toLongLong());
+        break;
+    case QMetaType::UShort:
+    case QMetaType::UInt:
+    case QMetaType::ULong:
+    case QMetaType::ULongLong:
+        min = c->locale().toString(map.value(QStringLiteral("min")).toULongLong());
+        max = c->locale().toString(map.value(QStringLiteral("max")).toULongLong());
+        break;
+    case QMetaType::Float:
+    case QMetaType::Double:
+        min = c->locale().toString(map.value(QStringLiteral("min")).toDouble());
+        max = c->locale().toString(map.value(QStringLiteral("max")).toDouble());
+        break;
+    default:
+        error = validationDataError(c);
+        return error;
     }
 
-    if (label().isEmpty()) {
+    const QString _label = label(c);
 
-        switch (d->type) {
-        case QMetaType::Int:
-        case QMetaType::UInt:
-        case QMetaType::Float:
-            error = QStringLiteral("Value has to be between %1 and %2.").arg(min, max);
-            break;
-        case QMetaType::QString:
-            error = QStringLiteral("Length has to be between %1 and %2.").arg(min, max);
-        default:
-            error = validationDataError();
-            break;
+    if (_label.isEmpty()) {
+        if (d->type == QMetaType::QString) {
+            error = c->translate("Cutelyst::ValidatorBetween", "The text must be between %1 and %2 characters long.").arg(min, max);
+        } else {
+            error = c->translate("Cutelyst::ValidatorBetween", "The value must be between %1 and %2.").arg(min, max);
         }
-
     } else {
-
-        switch (d->type) {
-        case QMetaType::Int:
-        case QMetaType::UInt:
-        case QMetaType::Float:
-            error = QStringLiteral("The value of the “%1” field has to be between %2 and %3.").arg(label(), min, max);
-            break;
-        case QMetaType::QString:
-            error = QStringLiteral("The length of the “%1” field has to be between %2 and %3.").arg(label(), min, max);
-        default:
-            error = validationDataError();
-            break;
+        if (d->type == QMetaType::QString) {
+            error = c->translate("Cutelyst::ValidatorBetween", "The text in the “%1“ field must be between %2 and %3 characters long.").arg(_label, min, max);
+        } else {
+            error = c->translate("Cutelyst::ValidatorBetween", "The value in the “%1” field must be between %2 and %3.").arg(_label, min, max);
         }
     }
 
     return error;
 }
 
-void ValidatorBetween::setType(QMetaType::Type type)
+QString ValidatorBetween::genericValidationDataError(Context *c, const QVariant &errorData) const
 {
-    Q_D(ValidatorBetween);
-    d->type = type;
+    QString error;
+
+    int field = errorData.toInt();
+    const QString _label = label(c);
+
+    if (field == -1) {
+        if (_label.isEmpty()) {
+            error = c->translate("Cutelyst::ValidatorBetween", "The minimum comparison value is not valid.");
+        } else {
+            error = c->translate("Cutelyst::ValidatorBetween", "The minimum comparison value for the “%1” field is not valid.").arg(_label);
+        }
+    } else if (field == 0) {
+        Q_D(const ValidatorBetween);
+        if (_label.isEmpty()) {
+            error = c->translate("Cutelyst::ValidatorBetween", "The comparison type with ID %1 is not supported.").arg(static_cast<int>(d->type));
+        } else {
+            error = c->translate("Cutelyst::ValidatorBetween", "The comparison type with ID %1 for the “%2” field is not supported.").arg(QString::number(static_cast<int>(d->type)), _label);
+        }
+    } else if (field == 1) {
+        if (_label.isEmpty()) {
+            error = c->translate("Cutelyst::ValidatorBetween", "The maximum comparison value is not valid.");
+        } else {
+            error = c->translate("Cutelyst::ValidatorBetween", "The maximum comparison value for the “%1” field is not valid.").arg(_label);
+        }
+    }
+
+    return error;
 }
 
-void ValidatorBetween::setMin(double min)
+QString ValidatorBetween::genericParsingError(Context *c, const QVariant &errorData) const
 {
-    Q_D(ValidatorBetween);
-    d->min = min;
-}
+    QString error;
+    Q_UNUSED(errorData)
+    Q_D(const ValidatorBetween);
 
-void ValidatorBetween::setMax(double max)
-{
-    Q_D(ValidatorBetween);
-    d->max = max;
+    const QString _label = label(c);
+    if ((d->type == QMetaType::Float) || (d->type == QMetaType::Double)) {
+        if (_label.isEmpty()) {
+            error = c->translate("Cutelyst::ValidatorBetween", "Failed to parse the input value into a floating point number.");
+        } else {
+            error = c->translate("Cutelyst::ValidatorBetween", "Failed to parse the input value for the “%1” field into a floating point number.").arg(_label);
+        }
+    } else {
+        if (_label.isEmpty()) {
+            error = c->translate("Cutelyst::ValidatorBetween", "Failed to parse the input value into an integer number.");
+        } else {
+            error = c->translate("Cutelyst::ValidatorBetween", "Failed to parse the input value for the “%1” field into an integer number.").arg(_label);
+        }
+    }
+
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorbetween_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorbetween_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,16 +26,16 @@ namespace Cutelyst {
 class ValidatorBetweenPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorBetweenPrivate(const QString &f, QMetaType::Type t, double mi, double ma, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
-        type(t),
+    ValidatorBetweenPrivate(const QString &f, QMetaType::Type t, const QVariant &mi, const QVariant &ma, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
         min(mi),
-        max(ma)
+        max(ma),
+        type(t)
     {}
 
+    QVariant min;
+    QVariant max;
     QMetaType::Type type;
-    double min;
-    double max;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorboolean.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorboolean.cpp
@@ -36,8 +36,6 @@ ValidatorReturnType ValidatorBoolean::validate(Context *c, const ParamsMultiMap 
 
     const QString v = value(params);
 
-    Q_D(const ValidatorBoolean);
-
     if (!v.isEmpty()) {
         static const QStringList lt({QStringLiteral("1"), QStringLiteral("true"), QStringLiteral("on")});
         static const QStringList lf({QStringLiteral("0"), QStringLiteral("false"), QStringLiteral("off")});

--- a/Cutelyst/Plugins/Utils/Validator/validatorboolean.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorboolean.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,17 +26,18 @@ namespace Cutelyst {
 class ValidatorBooleanPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if a value can be casted into a boolean.
  *
- * The \a field under validation must constain one of the following acceptable input values: \c 1, \c 0, \c true, \c false, \c on and \c off.
- * This will only check for this values, but will not convert the input into a boolean.
+ * The \a field under validation must contain one of the following acceptable input values: \c 1, \c 0, \c true, \c false, \c on and \c off.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  */
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorBoolean : public ValidatorRule
 {
@@ -44,31 +45,29 @@ public:
     /*!
      * \brief Constructs a new validator.
      * \param field         Name of the input field to validate.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param messages      Custom error message if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorBoolean(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorBoolean(const QString &field, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the validator.
      */
     ~ValidatorBoolean();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will either contain \c true if the
+     * input value contains \c 1, \c true or \on, or \c false if value contains \c 0, \c false or \c off.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorBoolean object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorBoolean(ValidatorBooleanPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorBoolean)

--- a/Cutelyst/Plugins/Utils/Validator/validatorboolean_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorboolean_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorBooleanPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorBooleanPrivate(const QString &f, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e)
+    ValidatorBooleanPrivate(const QString &f, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk)
     {}
 };
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorconfirmed.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorconfirmed.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,17 +26,19 @@ namespace Cutelyst {
 class ValidatorConfirmedPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks for a confirmation input field.
  *
  * The \a field under validation must have a matching field of \c foo_confirmation. For example, if the field under
  * validation is \c password, a matching \c password_confirmation field must be present in the input with the same value.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorSame
  */
@@ -46,31 +48,27 @@ public:
     /*!
      * \brief Constructs a new confirmed validator.
      * \param field         Name of the input field to validate.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param messages      Custom error message if validation fails.
      */
-    ValidatorConfirmed(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorConfirmed(const QString &field, const ValidatorMessages &messages = ValidatorMessages());
     
     /*!
      * \brief Deconstructs the confirmed validator.
      */
     ~ValidatorConfirmed();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramater values as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorConfirmed object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorConfirmed(ValidatorConfirmedPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorConfirmed)

--- a/Cutelyst/Plugins/Utils/Validator/validatorconfirmed_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorconfirmed_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorConfirmedPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorConfirmedPrivate(const QString &f, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e)
+    ValidatorConfirmedPrivate(const QString &f, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString())
     {}
 };
     

--- a/Cutelyst/Plugins/Utils/Validator/validatordate.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordate.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,13 +21,8 @@
 
 using namespace Cutelyst;
 
-ValidatorDate::ValidatorDate(const QString &field, const QString &format, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorDatePrivate(field, format, label, customError))
-{
-}
-
-ValidatorDate::ValidatorDate(ValidatorDatePrivate &dd) :
-    ValidatorRule(dd)
+ValidatorDate::ValidatorDate(const QString &field, const char *inputFormat, const Cutelyst::ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(*new ValidatorDatePrivate(field, inputFormat, messages, defValKey))
 {
 }
 
@@ -36,49 +31,55 @@ ValidatorDate::~ValidatorDate()
 }
 
 
-QString ValidatorDate::validate() const
+ValidatorReturnType ValidatorDate::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
     Q_D(const ValidatorDate);
 
-    const QString v = value();
+    const QString v = value(params);
 
     if (!v.isEmpty()) {
-        const QDate date = d->extractDate(v, d->format);
+        const QDate date = d->extractDate(c, v, d->inputFormat);
 
         if (!date.isValid()) {
-            result = validationError();
+            result.errorMessage = validationError(c);
+            qCDebug(C_VALIDATOR, "ValidatorDate: Validation failed for value \"%s\" in field %s in %s::%s: not a valid date.", qPrintable(v), qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+        } else {
+            result.value.setValue<QDate>(date);
         }
+    } else {
+        defaultValue(c, &result, "ValidatorDate");
     }
 
     return result;
 }
 
-QString ValidatorDate::genericValidationError() const
+QString ValidatorDate::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
 
     Q_D(const ValidatorDate);
+    Q_UNUSED(errorData)
 
-    if (label().isEmpty()) {
+    const QString _label = label(c);
 
-        error = QStringLiteral("Not a valid date.");
+    if (_label.isEmpty()) {
+
+        if (d->inputFormat) {
+            error = c->translate("Cutelyst::ValidatorDate", "Not a valid date according to the following date format: %1").arg(c->translate(d->translationContext.data(), d->inputFormat));
+        } else {
+            error = c->translate("Cutelyst::ValidatorDate", "Not a valid date.");
+        }
 
     } else {
 
-        if (!d->format.isEmpty()) {
-            error = QStringLiteral("The data in the “%1” field can not be interpreted as date of this schema: “%2”").arg(label(), d->format);
+        if (d->inputFormat) {
+            error = c->translate("Cutelyst::ValidatorDate", "The value in the “%1” field can not be parsed as date according to the following scheme: %2").arg(_label, c->translate(d->translationContext.data(), d->inputFormat));
         } else {
-            error = QStringLiteral("The data in the “%1” field can not be interpreted as date.").arg(label());
+            error = c->translate("Cutelyst::ValidatorDate", "The value in the “%1” field can not be parsed as date.").arg(_label);
         }
     }
 
     return error;
-}
-
-void ValidatorDate::setFormat(const QString &format)
-{
-    Q_D(ValidatorDate);
-    d->format = format;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatordate.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -23,22 +23,26 @@
 
 
 namespace Cutelyst {
-    
+
 class ValidatorDatePrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if the input data is a valid date.
  *
- * This validator checks if the input \a field can be parsed into a QDate, it will check the parsing ability but will not convert the
- * input data into a QDate. If a custom \a format is given, the validator will at first try to parse the date according to that \a format.
- * If that fails, it will try to parse the date based on standard formats in the following order: Qt::ISODate, Qt::RFC2822Date, Qt::TextDate
+ * This validator checks if the input \a field can be parsed into a QDate, it will check the parsing ability and will convert the
+ * input data into a QDate. If a custom \a inputFormat is given, the validator will at first try to parse the date according to that format.
+ * If that fails or if there is no custom \a inputFormat set, it will try to parse the date based on standard formats in the following order:
+ * \link Context::locale() Context locale's \endlink \link QLocale::toDate() toDate() \endlink with QLocale::ShortFormat and QLocale::LongFormat,
+ * Qt::ISODate, Qt::RFC2822Date, Qt::TextDate
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorDateTime, ValidatorTime
  */
@@ -48,43 +52,35 @@ public:
     /*!
      * \brief Constructs a new date validator.
      * \param field         Name of the input field to validate.
-     * \param format        Optional date format for input parsing.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param inputFormat   Optional input format for input data parsing, can be translatable.
+     * \param messages      Custom error messages if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorDate(const QString &field, const QString &format = QString(), const QString &label = QString(), const QString &customError = QString());
-    
+    ValidatorDate(const QString &field, const char *inputFormat = nullptr, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
+
     /*!
      * \brief Deconstructs the date validator.
      */
     ~ValidatorDate();
-    
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
 
-    /*!
-     * \brief Sets an optional date format.
-     */
-    void setFormat(const QString &format);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramater value converted into a QDate.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorDate object with the given private class.
+     * \brief Returns a generic error if validation failed.
      */
-    ValidatorDate(ValidatorDatePrivate &dd);
-    
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
+
 private:
     Q_DECLARE_PRIVATE(ValidatorDate)
     Q_DISABLE_COPY(ValidatorDate)
 };
-    
+
 }
 
 #endif //CUTELYSTVALIDATORDATE_H

--- a/Cutelyst/Plugins/Utils/Validator/validatordate_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordate_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,12 +26,12 @@ namespace Cutelyst {
 class ValidatorDatePrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorDatePrivate(const QString &f, const QString &inf, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
-        format(inf)
+    ValidatorDatePrivate(const QString &f, const char *i, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
+        inputFormat(i)
     {}
 
-    QString format;
+    const char *inputFormat = nullptr;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatordatetime.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordatetime.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,18 +26,28 @@ namespace Cutelyst {
 class ValidatorDateTimePrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if the input data is a valid datetime.
  *
- * This validator checks if the input \a field can be parsed into a QDateTime, it will check the parsing ability but will not convert the
- * input data into a QDateTime. If a custom \a format is given, the validator will at first try to parse the datetime according to that \a format.
- * If that fails, it will try to parse the datetime based on standard formats in the following order: Qt::ISODate, Qt::RFC2822Date, Qt::TextDate
+ * This validator checks if the input \a field can be parsed into a QDateTime, it will check the parsing ability and will convert the
+ * input data into a QDateTime. If a custom \a inputFormat is given, the validator will at first try to parse the date according to that format.
+ * If that fails or if there is no custom \a inputFormat set, it will try to parse the date and time based on standard formats in the following order:
+ * \link Context::locale() Context locale's \endlink \link QLocale::toDate() toDateTime() \endlink with QLocale::ShortFormat and QLocale::LongFormat,
+ * Qt::ISODate, Qt::RFC2822Date, Qt::TextDate
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * To specify a time zone that should be used for the input field - and the comparison input field if one is used, give either the IANA
+ * time zone ID name to the \a timeZone argument of the constructor or the name of an input field or stash key that contains the ID name.
+ * It will then be first tried to create a valid QTimeZone from the \a timeZone, if that fails it will first tryp to get the time zone from
+ * the input parameters and if there is no key with the name trying it with the \link Context::stash() stash\endlink. Stash or input parameter
+ * can either contain a valid IANA time zone ID or the offset from UTC in seconds.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
+ *
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorBefore
  */
@@ -47,37 +57,30 @@ public:
     /*!
      * \brief Constructs a new datetime validator.
      * \param field         Name of the input field to validate.
-     * \param format        Optional date format for input parsing.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param timeZone      IANA time zone ID, name of a input field containing the ID or stash key containing the ID
+     * \param inputFormat   Optional input format for input data parsing, can be translatable.
+     * \param messages      Custom error message if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorDateTime(const QString &field, const QString &format = QString(), const QString &label = QString(), const QString &customError = QString());
+    ValidatorDateTime(const QString &field, const QString &timeZone, const char *inputFormat = nullptr, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the datetime validator.
      */
     ~ValidatorDateTime();
-    
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
 
-    /*!
-     * \brief Sets an optional date format.
-     */
-    void setFormat(const QString &format);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input parameter value converted into a QDateTime.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorDateTime object with the given private class.
+     * \brief Returns a generic error if validation failed.
      */
-    ValidatorDateTime(ValidatorDateTimePrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorDateTime)

--- a/Cutelyst/Plugins/Utils/Validator/validatordatetime_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordatetime_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,12 +26,14 @@ namespace Cutelyst {
 class ValidatorDateTimePrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorDateTimePrivate(const QString &f, const QString &inf, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
-        format(inf)
+    ValidatorDateTimePrivate(const QString &f, const QString &tz, const char *inf, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
+        timeZone(tz),
+        inputFormat(inf)
     {}
 
-    QString format;
+    QString timeZone;
+    const char *inputFormat = nullptr;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatordifferent.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordifferent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,16 +26,18 @@ namespace Cutelyst {
 class ValidatorDifferentPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if two values are different.
  *
- * This will check if the value inf the input \a afield is different from the value in the \a other input field.
+ * This will check if the value in the one input \a field is different from the value in the \a other input field.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorSame
  */
@@ -46,44 +48,28 @@ public:
      * \brief Constructs a new different validator.
      * \param field         Name of the input field to validate.
      * \param other         Name of the other field to compare against.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param otherLabel    Human readable label of the other input field, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param otherLabel    Translatable label of the other input field, used for generic error messages.
+     * \param messages      Custom error messages if validation fails.
      */
-    ValidatorDifferent(const QString &field, const QString &other, const QString &label = QString(), const QString &otherLabel = QString(), const QString &customError = QString());
+    ValidatorDifferent(const QString &field, const QString &other, const char *otherLabel = nullptr, const ValidatorMessages &messages = ValidatorMessages());
     
     /*!
      * \brief Deconstructs the different validator.
      */
     ~ValidatorDifferent();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the name of the other field.
-     */
-    void setOtherField(const QString &otherField);
-
-    /*!
-     * \brief Sets the human readable label of the other field.
-     *
-     * This is used for displaying error messages.
-     */
-    void setOtherLabel(const QString &otherLabel);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorDifferent object with the given private class.
+     * \brief Returns a generic error if validation failed.
      */
-    ValidatorDifferent(ValidatorDifferentPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorDifferent)

--- a/Cutelyst/Plugins/Utils/Validator/validatordifferent_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordifferent_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,14 +26,14 @@ namespace Cutelyst {
 class ValidatorDifferentPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorDifferentPrivate(const QString &f, const QString &of, const QString &l, const QString &ol, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorDifferentPrivate(const QString &f, const QString &of, const char *ol, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString()),
         otherField(of),
         otherLabel(ol)
     {}
 
     QString otherField;
-    QString otherLabel;
+    const char *otherLabel = nullptr;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatordigits.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigits.cpp
@@ -87,8 +87,6 @@ QString ValidatorDigits::genericValidationError(Context *c, const QVariant &erro
 {
     QString error;
 
-    Q_D(const ValidatorDigits);
-
     const QString _label = label(c);
     const int _length = errorData.toInt();
 

--- a/Cutelyst/Plugins/Utils/Validator/validatordigits.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigits.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,17 +18,10 @@
 
 #include "validatordigits_p.h"
 
-#include <QRegularExpression>
-
 using namespace Cutelyst;
 
-ValidatorDigits::ValidatorDigits(const QString &field, int length, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorDigitsPrivate(field, length, label, customError))
-{
-}
-
-ValidatorDigits::ValidatorDigits(ValidatorDigitsPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorDigits::ValidatorDigits(const QString &field, const QVariant &length, const Cutelyst::ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(*new ValidatorDigitsPrivate(field, length, messages, defValKey))
 {
 }
 
@@ -36,54 +29,82 @@ ValidatorDigits::~ValidatorDigits()
 {
 }
 
-QString ValidatorDigits::validate() const
+ValidatorReturnType ValidatorDigits::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
     Q_D(const ValidatorDigits);
 
-    if (!value().isEmpty()) {
+    const QString v = value(params);
+    bool ok = false;
+    int _length = d->extractInt(c, params, d->length, &ok);
+    if (!ok) {
+        result.errorMessage = validationDataError(c);
+        return result;
+    }
 
-        if (value().contains(QRegularExpression(QStringLiteral("^[0-9]+$")))) {
-            if ((d->length > 0) && (value().length() != d->length)) {
-                result = validationError();
+    if (!v.isEmpty()) {
+
+        if (Q_LIKELY(ValidatorDigits::validate(v, _length))) {
+            if ((_length > 0) && (v.length() != _length)) {
+                result.errorMessage = validationError(c, _length);
+                qCDebug(C_VALIDATOR, "ValidatorDigits: Validation failed for value \"%s\" in field %s at %s::%s: does not contain exactly %i digit(s).", qPrintable(v), qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), _length);
+            } else {
+                result.value.setValue<QString>(v);
             }
         } else {
-            result = validationError();
+            result.errorMessage = validationError(c, _length);
+            qCDebug(C_VALIDATOR, "ValidatorDigits: Validation failed for value \"%s\" in field %s at %s::%s: does not only contain digits.", qPrintable(v), qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
         }
+
+    } else {
+        defaultValue(c, &result, "ValidatorDigits");
     }
 
     return result;
 }
 
-QString ValidatorDigits::genericValidationError() const
+bool ValidatorDigits::validate(const QString &value, int length)
+{
+    bool valid = true;
+
+    for (const QChar &ch : value) {
+        const ushort &uc = ch.unicode();
+        if (!((uc > 47) && (uc < 58))) {
+            valid = false;
+            break;
+        }
+    }
+
+    if (valid && (length > 0) && (length != value.length())) {
+        valid = false;
+    }
+
+    return valid;
+}
+
+QString ValidatorDigits::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
 
     Q_D(const ValidatorDigits);
 
-    if (label().isEmpty()) {
+    const QString _label = label(c);
+    const int _length = errorData.toInt();
 
-        if (d->length > 0) {
-            error = QStringLiteral("Must only contain exactly %1 digits.").arg(d->length);
+    if (_label.isEmpty()) {
+        if (_length > 0) {
+            error = c->translate("Cutelyst::ValidatorDigits", "Must contain exactly %n digit(s).", "", _length);
         } else {
-            error = QStringLiteral("Must only contain digits.");
+            error = c->translate("Cutelyst::ValidatorDigits", "Must only contain digits.");
         }
-
     } else {
-
-        if (d->length > 0) {
-            error = QStringLiteral("The “%1” field must only contain exactly %2 digits.").arg(label(), QString::number(d->length));
+        if (_length > 0) {
+            error = c->translate("Cutelyst::ValidatorDigits", "The “%1” field must contain exactly %n digit(s).", "", _length).arg(_label);
         } else {
-            error = QStringLiteral("The “%1” field must only contain digits.").arg(label());
+            error = c->translate("Cutelyst::ValidatorDigits", "The “%1” field must only contain digits.").arg(_label);
         }
     }
 
     return error;
-}
-
-void ValidatorDigits::setLength(int length)
-{
-    Q_D(ValidatorDigits);
-    d->length = length;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatordigits.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigits.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,18 +26,20 @@ namespace Cutelyst {
 class ValidatorDigitsPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks for digits only with optional length check.
  *
  * The \a field under validation must only contain digits with an optional exact \a length. If length is set to a value lower
  * or equal to \c 0, the length check will not be performed. The input digits will not be interpreted as numeric values
  * but as a string. So the length is not meant to test for an exact numeric value but for the string length.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorDigitsBetween
  */
@@ -47,39 +49,44 @@ public:
     /*!
      * \brief Constructs a new digits validator.
      * \param field         Name of the input field to validate.
-     * \param length        Length of the digits, defaults to \c -1 what disables the check.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param length        Exact length of the digits, defaults to \c -1. A value lower \c 1 disables the length check. Should be either an int to directly specify the length or the name
+     * of an input field or \link Context::stash() Stash \endlink key containing the length constraint.
+     * \param messages      Custom error messages if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorDigits(const QString &field, int length = -1, const QString &label = QString(), const QString &customError = QString());
+    ValidatorDigits(const QString &field, const QVariant &length = -1, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the digits validator.
      */
     ~ValidatorDigits();
-    
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
 
     /*!
-     * \brief Sets the allowed length of the input data.
+     * \ingroup plugins-utils-validator-rules
+     * \brief Returns \c true if \a value only contains digits.
      *
-     * Defaults to \c -1 what disables the length check.
+     * Note that this function will return \c true for an empty \a value if the \a length check is disabled.
+     *
+     * \param value     The value to validate as it is.
+     * \param length    Exact length of the digits, defaults to \c -1. A value lower \c 1 disables the length check.
+     * \return \c true if the \a value only contains digits
      */
-    void setLength(int length);
+    static bool validate(const QString &value, int length = -1);
 
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input parameter value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorDigits object with the given private class.
+     * \brief Returns a generic error if validation failed.
+     *
+     * \a errorData will contain \c 0, if \a length is greater than \c 0 and does not match the field value length, \a errorData will contain \c 1.
      */
-    ValidatorDigits(ValidatorDigitsPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorDigits)

--- a/Cutelyst/Plugins/Utils/Validator/validatordigits_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigits_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,12 +26,12 @@ namespace Cutelyst {
 class ValidatorDigitsPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorDigitsPrivate(const QString &f, int len, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorDigitsPrivate(const QString &f, const QVariant &len, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
         length(len)
     {}
 
-    int length;
+    QVariant length;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.cpp
@@ -98,8 +98,6 @@ QString ValidatorDigitsBetween::genericValidationError(Context *c, const QVarian
 {
     QString error;
 
-    Q_D(const ValidatorDigitsBetween);
-
     const QVariantList list = errorData.toList();
     const QString min = list.at(0).toString();
     const QString max = list.at(1).toString();

--- a/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,18 +26,20 @@ namespace Cutelyst {
 class ValidatorDigitsBetweenPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks for digits only with a length between min and max.
  *
  * The field under validation must only contain digits with a length between \a min and \a max. The digits
  * are not interpreteded as a numeric value but as a string, so the \a min and \a max values are not a range
- * for a numeric value but for the string length. Both values default to \c 0 what will disable the range check.
+ * for a numeric value but for the string length.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorDigits
  */
@@ -47,43 +49,43 @@ public:
     /*!
      * \brief Constructs a new digits between validator.
      * \param field         Name of the input field to validate.
-     * \param min           Minimum length of the digits
-     * \param max           Maximum length of the digits
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param min           Minimum length of the digits. Should either be an integer value to directly specify the length or the name of a \link Context::stash() Stash\endlink key containing the length constraint.
+     * \param max           Maximum length of the digits. Should either be an integer value to directly specify the length or the name of a \link Context::stash() Stash\endlink key containing the length constraint.
+     * \param messages      Custom error messages if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorDigitsBetween(const QString &field, int min, int max, const QString &label = QString(), const QString &customError = QString());
+    ValidatorDigitsBetween(const QString &field, const QVariant &min, const QVariant &max, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the digits between validator.
      */
     ~ValidatorDigitsBetween();
-    
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
 
     /*!
-     * \brief Sets the minimum length.
+     * \ingroup plugins-utils-validator-rules
+     * \brief Returns \c true if \a value only contains digits and has a length between \a min and \a max.
+     * \param value The value to validate as it is.
+     * \param min   Minimum length of the digits.
+     * \param max   Maximum length of the digits.
+     * \return \c true if \a value string only contains digits and has a length between \a min and \a max, otherwise it returns \a false.
+     * Nothe that this might return \c true for an empty value if 0 is between \a min and \a max.
      */
-    void setMin(int min);
+    static bool validate(const QString &value, int min, int max);
+    
+protected:    
+    /*!
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input parameter value as QString.
+     */
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
 
     /*!
-     * \brief Sets the maximum length.
+     * \brief Returns a generic error if validation failed.
+     *
+     * \a errorData will contain a QVariantList with the \a min value as first and the \a max value as second entry.
      */
-    void setMax(int max);
-    
-protected:
-    /*!
-     * \brief Returns a generic error message.
-     */
-    QString genericValidationError() const override;
-    
-    /*!
-     * Constructs a new ValidatorDigitsBetween object with the given private class.
-     */
-    ValidatorDigitsBetween(ValidatorDigitsBetweenPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorDigitsBetween)

--- a/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordigitsbetween_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,14 +26,14 @@ namespace Cutelyst {
 class ValidatorDigitsBetweenPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorDigitsBetweenPrivate(const QString &f, int mi, int ma, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorDigitsBetweenPrivate(const QString &f, const QVariant &mi, const QVariant &ma, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
         min(mi),
         max(ma)
     {}
 
-    int min;
-    int max;
+    QVariant min;
+    QVariant max;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,16 +18,16 @@
 
 #include "validatoremail_p.h"
 #include <QRegularExpression>
+#include <QEventLoop>
+#include <QDnsLookup>
+#include <QTimer>
+#include <QUrl>
+#include <algorithm>
 
 using namespace Cutelyst;
 
-ValidatorEmail::ValidatorEmail(const QString &field, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorEmailPrivate(field, label, customError))
-{
-}
-
-ValidatorEmail::ValidatorEmail(ValidatorEmailPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorEmail::ValidatorEmail(const QString &field, Category threshold, bool checkDns, const Cutelyst::ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(*new ValidatorEmailPrivate(field, threshold, checkDns, messages, defValKey))
 {
 }
 
@@ -35,57 +35,1523 @@ ValidatorEmail::~ValidatorEmail()
 {
 }
 
-QString ValidatorEmail::validate() const
+ValidatorReturnType ValidatorEmail::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
-//    bool isEmail = value().contains(QRegularExpression(QStringLiteral("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")));
+    const QString v = value(params);
 
-    if (!value().isEmpty() && !value().contains(QRegularExpression(QStringLiteral("(?(DEFINE)"
-                                                                                 "(?<addr_spec> (?&local_part) @ (?&domain) )"
-                                                                                 "(?<local_part> (?&dot_atom) | (?&quoted_string) | (?&obs_local_part) )"
-                                                                                 "(?<domain> (?&dot_atom) | (?&domain_literal) | (?&obs_domain) )"
-                                                                                 "(?<domain_literal> (?&CFWS)? \\[ (?: (?&FWS)? (?&dtext) )* (?&FWS)? \\] (?&CFWS)? )"
-                                                                                 "(?<dtext> [\\x21-\\x5a] | [\\x5e-\\x7e] | (?&obs_dtext) )"
-                                                                                 "(?<quoted_pair> \\\\ (?: (?&VCHAR) | (?&WSP) ) | (?&obs_qp) )"
-                                                                                 "(?<dot_atom> (?&CFWS)? (?&dot_atom_text) (?&CFWS)? )"
-                                                                                 "(?<dot_atom_text> (?&atext) (?: \\. (?&atext) )* )"
-                                                                                 "(?<atext> [a-zA-Z0-9!#$%&'*+\\/=?^_`{|}~-]+ )"
-                                                                                 "(?<atom> (?&CFWS)? (?&atext) (?&CFWS)? )"
-                                                                                 "(?<word> (?&atom) | (?&quoted_string) )"
-                                                                                 "(?<quoted_string> (?&CFWS)? \" (?: (?&FWS)? (?&qcontent) )* (?&FWS)? \" (?&CFWS)? )"
-                                                                                 "(?<qcontent> (?&qtext) | (?&quoted_pair) )"
-                                                                                 "(?<qtext> \\x21 | [\\x23-\\x5b] | [\\x5d-\\x7e] | (?&obs_qtext) )"
-                                                                                 "(?<FWS> (?: (?&WSP)* \\r\\n )? (?&WSP)+ | (?&obs_FWS) )"
-                                                                                 "(?<CFWS> (?: (?&FWS)? (?&comment) )+ (?&FWS)? | (?&FWS) )"
-                                                                                 "(?<comment> \\( (?: (?&FWS)? (?&ccontent) )* (?&FWS)? \\) )"
-                                                                                 "(?<ccontent> (?&ctext) | (?&quoted_pair) | (?&comment) )"
-                                                                                 "(?<ctext> [\\x21-\\x27] | [\\x2a-\\x5b] | [\\x5d-\\x7e] | (?&obs_ctext) )"
-                                                                                 "(?<obs_domain> (?&atom) (?: \\. (?&atom) )* )"
-                                                                                 "(?<obs_local_part> (?&word) (?: \\. (?&word) )* )"
-                                                                                 "(?<obs_dtext> (?&obs_NO_WS_CTL) | (?&quoted_pair) )"
-                                                                                 "(?<obs_qp> \\\\ (?: \\x00 | (?&obs_NO_WS_CTL) | \\n | \\r ) )"
-                                                                                 "(?<obs_FWS> (?&WSP)+ (?: \\r\\n (?&WSP)+ )* )"
-                                                                                 "(?<obs_ctext> (?&obs_NO_WS_CTL) )"
-                                                                                 "(?<obs_qtext> (?&obs_NO_WS_CTL) )"
-                                                                                 "(?<obs_NO_WS_CTL> [\\x01-\\x08] | \\x0b | \\x0c | [\\x0e-\\x1f] | \\x7f )"
-                                                                                 "(?<VCHAR> [\\x21-\\x7E] )"
-                                                                                 "(?<WSP> [ \\t] )"
-                                                                             ")"
-                                                                             "^(?&addr_spec)$"), QRegularExpression::ExtendedPatternSyntaxOption))) {
-        result = validationError();
+    Q_D(const ValidatorEmail);
+
+    if (!v.isEmpty()) {
+
+        QString email;
+        const int atPos = v.lastIndexOf(QLatin1Char('@'));
+        if (atPos > 0) {
+            const QStringRef local = v.leftRef(atPos);
+            const QString domain = v.mid(atPos + 1);
+            bool asciiDomain = true;
+            for (const QChar &ch : domain) {
+                const ushort &uc = ch.unicode();
+                if (uc > 127) {
+                    asciiDomain = false;
+                    break;
+                }
+            }
+
+            if (asciiDomain) {
+                email = v;
+            } else {
+                email = local + QLatin1Char('@') + QString::fromLatin1(QUrl::toAce(domain));
+            }
+        } else {
+            email = v;
+        }
+
+        ValidatorEmailDiagnoseStruct diag;
+
+        if (ValidatorEmailPrivate::checkEmail(email, d->checkDns, d->threshold, &diag)) {
+            if (!diag.literal.isEmpty()) {
+                result.value.setValue<QString>(diag.localpart + QLatin1Char('@') + diag.literal);
+            } else {
+                result.value.setValue<QString>(diag.localpart + QLatin1Char('@') + diag.domain);
+            }
+        } else {
+            result.errorMessage = validationError(c, QVariant::fromValue<Diagnose>(diag.finalStatus));
+        }
+
+        result.extra = QVariant::fromValue<QList<Diagnose>>(diag.returnStatus);
+
+    } else {
+        defaultValue(c, &result, "ValidatorEmail");
     }
+
 
     return result;
 }
 
-QString ValidatorEmail::genericValidationError() const
+QString ValidatorEmail::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
-    if (label().isEmpty()) {
-        error = QStringLiteral("Not a valid email address.");
-    } else {
-        error = QStringLiteral("The email address in the “%1” field is not valid.").arg(label());
-    }
+
+    error = ValidatorEmail::diagnoseString(c, errorData.value<Diagnose>(), label(c));
+
     return error;
+}
+
+bool ValidatorEmailPrivate::checkEmail(const QString &email, bool checkDNS, ValidatorEmail::Category threshold, ValidatorEmailDiagnoseStruct *diagnoseStruct)
+{
+    bool ret;
+
+    QList<ValidatorEmail::Diagnose> returnStatus{ValidatorEmail::ValidAddress};
+    int rawLength = email.length();
+
+    EmailPart context = ComponentLocalpart;
+    QList<EmailPart> contextStack{context};
+    EmailPart contextPrior = ComponentLocalpart;
+
+    QChar token;
+    QChar tokenPrior;
+
+    QString parseLocalPart;
+    QString parseDomain;
+    QString parseLiteral;
+    QMap<int, QString> atomListLocalPart;
+    QMap<int, QString> atomListDomain;
+    int elementCount = 0;
+    int elementLen = 0;
+    bool hypenFlag = false;
+    bool endOrDie = false;
+    int crlf_count = 0;
+
+    // US-ASCII visible characters not valid for atext (https://tools.ietf.org/html/rfc5322#section-3.2.3)
+    const QString stringSpecials = QStringLiteral("()<>[]:;@\\,.\"");
+
+    for (int i = 0; i < rawLength; i++) {
+        token = email[i];
+
+        switch (context) {
+        //-------------------------------------------------------------
+        // local-part
+        //-------------------------------------------------------------
+        case ComponentLocalpart:
+        {
+            // https://tools.ietf.org/html/rfc5322#section-3.4.1
+                        //   local-part      =   dot-atom / quoted-string / obs-local-part
+                        //
+                        //   dot-atom        =   [CFWS] dot-atom-text [CFWS]
+                        //
+                        //   dot-atom-text   =   1*atext *("." 1*atext)
+                        //
+                        //   quoted-string   =   [CFWS]
+                        //                       DQUOTE *([FWS] qcontent) [FWS] DQUOTE
+                        //                       [CFWS]
+                        //
+                        //   obs-local-part  =   word *("." word)
+                        //
+                        //   word            =   atom / quoted-string
+                        //
+                        //   atom            =   [CFWS] 1*atext [CFWS]
+
+            if (token == QLatin1Char('(')) { // comment
+                if (elementLen == 0) {
+                    // Comments are OK at the beginning of an element
+                    returnStatus.push_back((elementCount == 0) ? ValidatorEmail::CFWSComment : ValidatorEmail::DeprecatedComment);
+                } else {
+                    returnStatus.push_back(ValidatorEmail::CFWSComment);
+                    endOrDie = true; // We can't start a comment in the middle of an element, so this better be the end
+                }
+
+                contextStack.push_back(context);
+                context = ContextComment;
+            } else if (token == QLatin1Char('.')) { // Next dot-atom element
+                if (elementLen == 0) {
+                    // Another dot, already?
+                    returnStatus.push_back((elementCount == 0) ? ValidatorEmail::ErrorDotStart : ValidatorEmail::ErrorConsecutiveDots);
+                } else {
+                    // The entire local part can be a quoted string for RFC 5321
+                    // If it's just one atom that is quoten then it's an RFC 5322 obsolete form
+                    if (endOrDie) { returnStatus.push_back(ValidatorEmail::DeprecatedLocalpart); }
+                }
+
+                endOrDie = false; // CFWS & quoted strings are OK again now we're at the beginning of an element (although they are obsolete forms)
+                elementLen = 0;
+                elementCount++;
+                parseLocalPart += token;
+                atomListLocalPart[elementCount] = QString();
+            } else if (token == QLatin1Char('"')) {
+                if (elementLen == 0) {
+                    // The entire local-part can be a quoted string for RFC 5321
+                    // If it's just one atom that is quoted then it's an RFC 5322 obsolete form
+                    returnStatus.push_back((elementCount == 0) ? ValidatorEmail::RFC5321QuotedString : ValidatorEmail::DeprecatedLocalpart);
+
+                    parseLocalPart += token;
+                    atomListLocalPart[elementCount] += token;
+                    elementLen++;
+                    endOrDie = true; // quoted string must be the entire element
+                    contextStack.push_back(context);
+                    context = ContextQuotedString;
+                } else {
+                    returnStatus.push_back(ValidatorEmail::ErrorExpectingAText); // Fatal error
+                }
+            } else if ((token == QChar(QChar::CarriageReturn)) || (token == QChar(QChar::Space)) || (token == QChar(QChar::Tabulation))) { // Folding White Space
+                if ((token == QChar(QChar::CarriageReturn)) && ((++i == rawLength) || (email[i] != QChar(QChar::LineFeed)))) {
+                    returnStatus.push_back(ValidatorEmail::ErrorCRnoLF);
+                    break;
+                }
+
+                if (elementLen == 0) {
+                    returnStatus.push_back((elementCount == 0) ? ValidatorEmail::CFWSFWS : ValidatorEmail::DeprecatedFWS);
+                } else {
+                    endOrDie = true; // We can't start FWS in the middle of an element, so this better be the end
+                }
+
+                contextStack.push_back(context);
+                context = ContextFWS;
+                tokenPrior = token;
+            } else if (token == QLatin1Char('@')) {
+                // At this point we should have a valid local part
+                if (contextStack.size() != 1) {
+                    returnStatus.push_back(ValidatorEmail::ErrorFatal);
+                    qCCritical(C_VALIDATOR, "ValidatorEmail: Unexpected item on context stack");
+                    break;
+                }
+
+                if (parseLocalPart.isEmpty()) {
+                    returnStatus.push_back(ValidatorEmail::ErrorNoLocalPart); // Fatal error
+                } else if (elementLen == 0) {
+                    returnStatus.push_back(ValidatorEmail::ErrorDotEnd); // Fatal Error
+                } else if (parseLocalPart.size() > 64) {
+                    // https://tools.ietf.org/html/rfc5321#section-4.5.3.1.1
+                    // The maximum total length of a user name or other local-part is 64
+                    // octets.
+                    returnStatus.push_back(ValidatorEmail::RFC5322LocalTooLong);
+                } else if ((contextPrior == ContextComment) || (contextPrior == ContextFWS)) {
+                    // https://tools.ietf.org/html/rfc5322#section-3.4.1
+                    //   Comments and folding white space
+                    //   SHOULD NOT be used around the "@" in the addr-spec.
+                    //
+                    // https://tools.ietf.org/html/rfc2119
+                    // 4. SHOULD NOT   This phrase, or the phrase "NOT RECOMMENDED" mean that
+                    //    there may exist valid reasons in particular circumstances when the
+                    //    particular behavior is acceptable or even useful, but the full
+                    //    implications should be understood and the case carefully weighed
+                    //    before implementing any behavior described with this label.
+                    returnStatus.push_back(ValidatorEmail::DeprecatedCFWSNearAt);
+                }
+
+                context = ComponentDomain;
+                contextStack.clear();
+                contextStack.push_back(context);
+                elementCount = 0;
+                elementLen = 0;
+                endOrDie = false;
+
+            } else { // atext
+                // https://tools.ietf.org/html/rfc5322#section-3.2.3
+                //    atext           =   ALPHA / DIGIT /    ; Printable US-ASCII
+                //                        "!" / "#" /        ;  characters not including
+                //                        "$" / "%" /        ;  specials.  Used for atoms.
+                //                        "&" / "'" /
+                //                        "*" / "+" /
+                //                        "-" / "/" /
+                //                        "=" / "?" /
+                //                        "^" / "_" /
+                //                        "`" / "{" /
+                //                        "|" / "}" /
+                //
+                if (endOrDie) {
+                    switch (contextPrior) {
+                    case ContextComment:
+                    case ContextFWS:
+                        returnStatus.push_back(ValidatorEmail::ErrorATextAfterCFWS);
+                        break;
+                    case ContextQuotedString:
+                        returnStatus.push_back(ValidatorEmail::ErrorATextAfterQS);
+                        break;
+                    default:
+                        returnStatus.push_back(ValidatorEmail::ErrorFatal);
+                        qCCritical(C_VALIDATOR, "ValidatorEmail: More atext found where none is allowed, but unrecognised prior context.");
+                        break;
+                    }
+                } else {
+                    contextPrior = context;
+                    const ushort uni = token.unicode();
+
+                    if ((uni < 33) || (uni > 126) || (uni == 10) || stringSpecials.contains(token)) {
+                        returnStatus.push_back(ValidatorEmail::ErrorExpectingAText); // fatal error
+                    }
+
+                    parseLocalPart += token;
+                    atomListLocalPart[elementCount] += token;
+                    elementLen++;
+                }
+            }
+        }
+            break;
+        //-----------------------------------------
+        // Domain
+        //-----------------------------------------
+        case ComponentDomain:
+        {
+            // https://tools.ietf.org/html/rfc5322#section-3.4.1
+            //   domain          =   dot-atom / domain-literal / obs-domain
+            //
+            //   dot-atom        =   [CFWS] dot-atom-text [CFWS]
+            //
+            //   dot-atom-text   =   1*atext *("." 1*atext)
+            //
+            //   domain-literal  =   [CFWS] "[" *([FWS] dtext) [FWS] "]" [CFWS]
+            //
+            //   dtext           =   %d33-90 /          ; Printable US-ASCII
+            //                       %d94-126 /         ;  characters not including
+            //                       obs-dtext          ;  "[", "]", or "\"
+            //
+            //   obs-domain      =   atom *("." atom)
+            //
+            //   atom            =   [CFWS] 1*atext [CFWS]
+            // https://tools.ietf.org/html/rfc5321#section-4.1.2
+            //   Mailbox        = Local-part "@" ( Domain / address-literal )
+            //
+            //   Domain         = sub-domain *("." sub-domain)
+            //
+            //   address-literal  = "[" ( IPv4-address-literal /
+            //                    IPv6-address-literal /
+            //                    General-address-literal ) "]"
+            //                    ; See Section 4.1.3
+            // https://tools.ietf.org/html/rfc5322#section-3.4.1
+            //      Note: A liberal syntax for the domain portion of addr-spec is
+            //      given here.  However, the domain portion contains addressing
+            //      information specified by and used in other protocols (e.g.,
+            //      [RFC1034], [RFC1035], [RFC1123], [RFC5321]).  It is therefore
+            //      incumbent upon implementations to conform to the syntax of
+            //      addresses for the context in which they are used.
+            // is_email() author's note: it's not clear how to interpret this in
+            // the context of a general email address validator. The conclusion I
+            // have reached is this: "addressing information" must comply with
+            // RFC 5321 (and in turn RFC 1035), anything that is "semantically
+            // invisible" must comply only with RFC 5322.
+
+            if (token == QLatin1Char('(')) { // comment
+                if (elementLen == 0) {
+                    // Comments at the start of the domain are deprecated in the text
+                    // Comments at the start of a subdomain are obs-domain
+                    // (https://tools.ietf.org/html/rfc5322#section-3.4.1)
+                    returnStatus.push_back((elementCount == 0) ? ValidatorEmail::DeprecatedCFWSNearAt : ValidatorEmail::DeprecatedComment);
+                } else {
+                    returnStatus.push_back(ValidatorEmail::CFWSComment);
+                    endOrDie = true; // We can't start a comment in the middle of an element, so this better be the end
+                }
+
+                contextStack.push_back(context);
+                context = ContextComment;
+            } else if (token == QLatin1Char('.')) { // next dot-atom element
+                if (elementLen == 0) {
+                    // another dot, already?
+                    returnStatus.push_back((elementCount == 0) ? ValidatorEmail::ErrorDotStart : ValidatorEmail::ErrorConsecutiveDots);
+                } else if (hypenFlag) {
+                    // Previous subdomain ended in a hyphen
+                    returnStatus.push_back(ValidatorEmail::ErrorDomainHyphenEnd); // fatal error
+                } else {
+                    // Nowhere in RFC 5321 does it say explicitly that the
+                    // domain part of a Mailbox must be a valid domain according
+                    // to the DNS standards set out in RFC 1035, but this *is*
+                    // implied in several places. For instance, wherever the idea
+                    // of host routing is discussed the RFC says that the domain
+                    // must be looked up in the DNS. This would be nonsense unless
+                    // the domain was designed to be a valid DNS domain. Hence we
+                    // must conclude that the RFC 1035 restriction on label length
+                    // also applies to RFC 5321 domains.
+                    //
+                    // https://tools.ietf.org/html/rfc1035#section-2.3.4
+                    // labels          63 octets or less
+                    if (elementLen > 63) {
+                        returnStatus.push_back(ValidatorEmail::RFC5322LabelTooLong);
+                    }
+                }
+
+                endOrDie = false; // CFWS is OK again now we're at the beginning of an element (although it may be obsolete CFWS)
+                elementLen = 0;
+                elementCount++;
+                atomListDomain[elementCount] = QString();
+                parseDomain += token;
+
+            } else if (token == QLatin1Char('[')) { // Domain literal
+                if (parseDomain.isEmpty()) {
+                    endOrDie = true; // domain literal must be the only component
+                    elementLen++;
+                    contextStack.push_back(context);
+                    context = ComponentLiteral;
+                    parseDomain += token;
+                    atomListDomain[elementCount] += token;
+                    parseLiteral = QString();
+                } else {
+                    returnStatus.push_back(ValidatorEmail::ErrorExpectingAText); // Fatal error
+                }
+            } else if ((token == QChar(QChar::CarriageReturn)) || (token == QChar(QChar::Space)) || (token == QChar(QChar::Tabulation))) { // Folding White Space
+                if ((token == QChar(QChar::CarriageReturn)) && ((++i == rawLength) || email[i] != QChar(QChar::LineFeed))) {
+                    returnStatus.push_back(ValidatorEmail::ErrorCRnoLF); // Fatal error
+                    break;
+                }
+
+                if (elementLen == 0) {
+                    returnStatus.push_back((elementCount == 0) ? ValidatorEmail::DeprecatedCFWSNearAt : ValidatorEmail::DeprecatedFWS);
+                } else {
+                    returnStatus.push_back(ValidatorEmail::CFWSFWS);
+                    endOrDie = true; // We can't start FWS in the middle of an element, so this better be the end
+                }
+
+                contextStack.push_back(context);
+                context = ContextFWS;
+                tokenPrior = token;
+
+            } else { // atext
+                // RFC 5322 allows any atext...
+                // https://tools.ietf.org/html/rfc5322#section-3.2.3
+                //    atext           =   ALPHA / DIGIT /    ; Printable US-ASCII
+                //                        "!" / "#" /        ;  characters not including
+                //                        "$" / "%" /        ;  specials.  Used for atoms.
+                //                        "&" / "'" /
+                //                        "*" / "+" /
+                //                        "-" / "/" /
+                //                        "=" / "?" /
+                //                        "^" / "_" /
+                //                        "`" / "{" /
+                //                        "|" / "}" /
+                //                        "~"
+                // But RFC 5321 only allows letter-digit-hyphen to comply with DNS rules (RFCs 1034 & 1123)
+                // https://tools.ietf.org/html/rfc5321#section-4.1.2
+                //   sub-domain     = Let-dig [Ldh-str]
+                //
+                //   Let-dig        = ALPHA / DIGIT
+                //
+                //   Ldh-str        = *( ALPHA / DIGIT / "-" ) Let-dig
+                //
+
+                if (endOrDie) {
+                    // We have encountered atext where it is no longer valid
+                    switch (contextPrior) {
+                    case ContextComment:
+                    case ContextFWS:
+                        returnStatus.push_back(ValidatorEmail::ErrorATextAfterCFWS);
+                        break;
+                    case ComponentLiteral:
+                        returnStatus.push_back(ValidatorEmail::ErrorATextAfterDomLit);
+                        break;
+                    default:
+                        returnStatus.push_back(ValidatorEmail::ErrorFatal);
+                        qCCritical(C_VALIDATOR, "ValidatorEmail: More atext found where none is allowed, but unrecognised prior context.");
+                        break;
+                    }
+                }
+
+                const ushort uni = token.unicode();
+                hypenFlag = false; // Assume this token isn't a hyphen unless we discover it is
+
+                if ((uni < 33) || (uni > 126) || stringSpecials.contains(token)) {
+                    returnStatus.push_back(ValidatorEmail::ErrorExpectingAText); // Fatal error
+                } else if (token == QLatin1Char('-')) {
+                    if (elementLen == 0) {
+                        // Hyphens can't be at the beggining of a subdomain
+                        returnStatus.push_back(ValidatorEmail::ErrorDomainHyphenStart); // Fatal error
+                    }
+                    hypenFlag = true;
+                } else if (!(((uni > 47) && (uni < 58)) || ((uni > 64) && (uni < 91)) || ((uni > 96) && (uni < 123)))) {
+                    // NOt an RFC 5321 subdomain, but still ok by RFC 5322
+                    returnStatus.push_back(ValidatorEmail::RFC5322Domain);
+                }
+
+                parseDomain += token;
+                atomListDomain[elementCount] += token;
+                elementLen++;
+            }
+        }
+            break;
+        //-------------------------------------------------------------
+        // Domain literal
+        //-------------------------------------------------------------
+        case ComponentLiteral:
+        {
+            // https://tools.ietf.org/html/rfc5322#section-3.4.1
+            //   domain-literal  =   [CFWS] "[" *([FWS] dtext) [FWS] "]" [CFWS]
+            //
+            //   dtext           =   %d33-90 /          ; Printable US-ASCII
+            //                       %d94-126 /         ;  characters not including
+            //                       obs-dtext          ;  "[", "]", or "\"
+            //
+            //   obs-dtext       =   obs-NO-WS-CTL / quoted-pair
+            if (token == QLatin1Char(']')) { // End of domain literal
+                if (static_cast<int>(*std::max_element(returnStatus.constBegin(), returnStatus.constEnd())) < static_cast<int>(ValidatorEmail::Deprecated)) {
+                    // Could be a valid RFC 5321 address literal, so let's check
+
+                    // https://tools.ietf.org/html/rfc5321#section-4.1.2
+                    //   address-literal  = "[" ( IPv4-address-literal /
+                    //                    IPv6-address-literal /
+                    //                    General-address-literal ) "]"
+                    //                    ; See Section 4.1.3
+                    //
+                    // https://tools.ietf.org/html/rfc5321#section-4.1.3
+                    //   IPv4-address-literal  = Snum 3("."  Snum)
+                    //
+                    //   IPv6-address-literal  = "IPv6:" IPv6-addr
+                    //
+                    //   General-address-literal  = Standardized-tag ":" 1*dcontent
+                    //
+                    //   Standardized-tag  = Ldh-str
+                    //                     ; Standardized-tag MUST be specified in a
+                    //                     ; Standards-Track RFC and registered with IANA
+                    //
+                    //   dcontent       = %d33-90 / ; Printable US-ASCII
+                    //                  %d94-126 ; excl. "[", "\", "]"
+                    //
+                    //   Snum           = 1*3DIGIT
+                    //                  ; representing a decimal integer
+                    //                  ; value in the range 0 through 255
+                    //
+                    //   IPv6-addr      = IPv6-full / IPv6-comp / IPv6v4-full / IPv6v4-comp
+                    //
+                    //   IPv6-hex       = 1*4HEXDIG
+                    //
+                    //   IPv6-full      = IPv6-hex 7(":" IPv6-hex)
+                    //
+                    //   IPv6-comp      = [IPv6-hex *5(":" IPv6-hex)] "::"
+                    //                  [IPv6-hex *5(":" IPv6-hex)]
+                    //                  ; The "::" represents at least 2 16-bit groups of
+                    //                  ; zeros.  No more than 6 groups in addition to the
+                    //                  ; "::" may be present.
+                    //
+                    //   IPv6v4-full    = IPv6-hex 5(":" IPv6-hex) ":" IPv4-address-literal
+                    //
+                    //   IPv6v4-comp    = [IPv6-hex *3(":" IPv6-hex)] "::"
+                    //                  [IPv6-hex *3(":" IPv6-hex) ":"]
+                    //                  IPv4-address-literal
+                    //                  ; The "::" represents at least 2 16-bit groups of
+                    //                  ; zeros.  No more than 4 groups in addition to the
+                    //                  ; "::" and IPv4-address-literal may be present.
+                    //
+                    // is_email() author's note: We can't use ip2long() to validate
+                    // IPv4 addresses because it accepts abbreviated addresses
+                    // (xxx.xxx.xxx), expanding the last group to complete the address.
+                    // filter_var() validates IPv6 address inconsistently (up to PHP 5.3.3
+                    // at least) -- see https://bugs.php.net/bug.php?id=53236 for example
+
+                    int maxGroups = 8;
+                    int index = -1;
+                    QString addressLiteral = parseLiteral;
+
+                    QRegularExpression ipv4Regex(QStringLiteral("\\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"));
+                    QRegularExpressionMatch ipv4Match = ipv4Regex.match(addressLiteral);
+                    if (ipv4Match.hasMatch()) {
+                        index = addressLiteral.lastIndexOf(ipv4Match.captured());
+                        if (index != 0) {
+                            addressLiteral = addressLiteral.midRef(0, index) + QLatin1String("0:0"); // Convert IPv4 part to IPv6 format for further testing
+                        }
+                    }
+
+                    if (index == 0) {
+                        // Nothing there except a valid IPv4 address, so...
+                        returnStatus.push_back(ValidatorEmail::RFC5321AddressLiteral);
+                    } else if (QString::compare(addressLiteral.left(5), QLatin1String("IPv6:")) != 0) {
+                        returnStatus.push_back(ValidatorEmail::RFC5322DomainLiteral);
+                    } else {
+                        QString ipv6 = addressLiteral.mid(5);
+                        const QStringList matchesIP = ipv6.split(QLatin1Char(':'));
+                        int groupCount = matchesIP.size();
+                        index = ipv6.indexOf(QLatin1String("::"));
+
+                        if (index < 0) {
+                            // We need exactly the right number of groups
+                            if (groupCount != maxGroups) {
+                                returnStatus.push_back(ValidatorEmail::RFC5322IPv6GroupCount);
+                            }
+                        } else {
+                            if (index != ipv6.lastIndexOf(QLatin1String("::"))) {
+                                returnStatus.push_back(ValidatorEmail::RFC5322IPv62x2xColon);
+                            } else {
+                                if ((index == 0) || (index == (ipv6.length() - 2))) {
+                                    maxGroups++;
+                                }
+
+                                if (groupCount > maxGroups) {
+                                    returnStatus.push_back(ValidatorEmail::RFC5322IPv6MaxGroups);
+                                } else if (groupCount == maxGroups) {
+                                    returnStatus.push_back(ValidatorEmail::RFC5321IPv6Deprecated);  // Eliding a single "::"
+                                }
+                            }
+                        }
+
+                        if ((ipv6[0] == QLatin1Char(':')) && (ipv6[1] != QLatin1Char(':'))) {
+                            returnStatus.push_back(ValidatorEmail::RFC5322IPv6ColonStart); // Address starts with a single colon
+                        } else if ((ipv6.rightRef(2)[1] == QLatin1Char(':')) && (ipv6.rightRef(2)[0] != QLatin1Char(':'))) {
+                            returnStatus.push_back(ValidatorEmail::RFC5322IPv6ColonEnd); // Address ends with a single colon
+                        } else {
+                            int unmatchedChars = 0;
+                            for (const QString &ip : matchesIP) {
+                                if (!ip.contains(QRegularExpression(QStringLiteral("^[0-9A-Fa-f]{0,4}$")))) {
+                                    unmatchedChars++;
+                                }
+                            }
+                            if (unmatchedChars != 0) {
+                                returnStatus.push_back(ValidatorEmail::RFC5322IPv6BadChar);
+                            } else {
+                                returnStatus.push_back(ValidatorEmail::RFC5321AddressLiteral);
+                            }
+                        }
+                    }
+
+                } else {
+                    returnStatus.push_back(ValidatorEmail::RFC5322DomainLiteral);
+                }
+
+                parseDomain += token;
+                atomListDomain[elementCount] += token;
+                elementLen++;
+                contextPrior = context;
+                context = contextStack.takeLast();
+            } else if (token == QLatin1Char('\\')) {
+                returnStatus.push_back(ValidatorEmail::RFC5322DomLitOBSDText);
+                contextStack.push_back(context);
+                context = ContextQuotedPair;
+            } else if ((token == QChar(QChar::CarriageReturn)) || (token == QChar(QChar::Space)) || (token == QChar(QChar::Tabulation))) { // Folding White Space
+                if ((token == QChar(QChar::CarriageReturn)) && ((++i == rawLength) || (email[i] != QChar(QChar::LineFeed)))) {
+                    returnStatus.push_back(ValidatorEmail::ErrorCRnoLF); // Fatal error
+                    break;
+                }
+
+                returnStatus.push_back(ValidatorEmail::CFWSFWS);
+                contextStack.push_back(context);
+                context = ContextFWS;
+                tokenPrior = token;
+
+            } else { // dtext
+                // https://tools.ietf.org/html/rfc5322#section-3.4.1
+                //   dtext           =   %d33-90 /          ; Printable US-ASCII
+                //                       %d94-126 /         ;  characters not including
+                //                       obs-dtext          ;  "[", "]", or "\"
+                //
+                //   obs-dtext       =   obs-NO-WS-CTL / quoted-pair
+                //
+                //   obs-NO-WS-CTL   =   %d1-8 /            ; US-ASCII control
+                //                       %d11 /             ;  characters that do not
+                //                       %d12 /             ;  include the carriage
+                //                       %d14-31 /          ;  return, line feed, and
+                //                       %d127              ;  white space characters
+                const ushort uni = token.unicode();
+
+                // CR, LF, SP & HTAB have already been parsed above
+                if ((uni > 127) || (uni == 0) || (uni == QLatin1Char('['))) {
+                    returnStatus.push_back(ValidatorEmail::ErrorExpectingDText); // Fatal error
+                    break;
+                } else if ((uni < 33) || (uni == 127)) {
+                    returnStatus.push_back(ValidatorEmail::RFC5322DomLitOBSDText);
+                }
+
+                parseLiteral += token;
+                parseDomain += token;
+                atomListDomain[elementCount] += token;
+                elementLen++;
+            }
+        }
+            break;
+        //-------------------------------------------------------------
+        // Quoted string
+        //-------------------------------------------------------------
+        case ContextQuotedString:
+        {
+            // https://tools.ietf.org/html/rfc5322#section-3.2.4
+            //   quoted-string   =   [CFWS]
+            //                       DQUOTE *([FWS] qcontent) [FWS] DQUOTE
+            //                       [CFWS]
+            //
+            //   qcontent        =   qtext / quoted-pair
+            if (token == QLatin1Char('\\')) { // Quoted pair
+                contextStack.push_back(context);
+                context = ContextQuotedPair;
+            } else if ((token == QChar(QChar::CarriageReturn)) || (token == QChar(QChar::Tabulation))) { // Folding White Space
+                // Inside a quoted string, spaces are allowed as regular characters.
+                // It's only FWS if we include HTAB or CRLF
+                if ((token == QChar(QChar::CarriageReturn)) && ((++i == rawLength) || (email[i] != QChar(QChar::LineFeed)))) {
+                    returnStatus.push_back(ValidatorEmail::ErrorCRnoLF);
+                    break;
+                }
+
+                // https://tools.ietf.org/html/rfc5322#section-3.2.2
+                //   Runs of FWS, comment, or CFWS that occur between lexical tokens in a
+                //   structured header field are semantically interpreted as a single
+                //   space character.
+
+                // https://tools.ietf.org/html/rfc5322#section-3.2.4
+                //   the CRLF in any FWS/CFWS that appears within the quoted-string [is]
+                //   semantically "invisible" and therefore not part of the quoted-string
+
+                parseLocalPart += QChar(QChar::Space);
+                atomListLocalPart[elementCount] += QChar(QChar::Space);
+                elementLen++;
+
+                returnStatus.push_back(ValidatorEmail::CFWSFWS);
+                contextStack.push_back(context);
+                context = ContextFWS;
+                tokenPrior = token;
+            } else if (token == QLatin1Char('"')) { // end of quoted string
+                parseLocalPart += token;
+                atomListLocalPart[elementCount] +=token;
+                elementLen++;
+                contextPrior = context;
+                context = contextStack.takeLast();
+            } else { // qtext
+                // https://tools.ietf.org/html/rfc5322#section-3.2.4
+                //   qtext           =   %d33 /             ; Printable US-ASCII
+                //                       %d35-91 /          ;  characters not including
+                //                       %d93-126 /         ;  "\" or the quote character
+                //                       obs-qtext
+                //
+                //   obs-qtext       =   obs-NO-WS-CTL
+                //
+                //   obs-NO-WS-CTL   =   %d1-8 /            ; US-ASCII control
+                //                       %d11 /             ;  characters that do not
+                //                       %d12 /             ;  include the carriage
+                //                       %d14-31 /          ;  return, line feed, and
+                //                       %d127              ;  white space characters
+                const ushort uni = token.unicode();
+
+                if ((uni > 127) || (uni == 0) || (uni == 10)) {
+                    returnStatus.push_back(ValidatorEmail::ErrorExpectingQText); // Fatal error
+                } else if ((uni < 32) || (uni == 127)) {
+                    returnStatus.push_back(ValidatorEmail::DeprecatedQText);
+                }
+
+                parseLocalPart += token;
+                atomListLocalPart[elementCount] += token;
+                elementLen++;
+            }
+
+            // https://tools.ietf.org/html/rfc5322#section-3.4.1
+            //   If the
+            //   string can be represented as a dot-atom (that is, it contains no
+            //   characters other than atext characters or "." surrounded by atext
+            //   characters), then the dot-atom form SHOULD be used and the quoted-
+            //   string form SHOULD NOT be used.
+            // To do
+        }
+            break;
+        //-------------------------------------------------------------
+        // Quoted pair
+        //-------------------------------------------------------------
+        case ContextQuotedPair:
+        {
+            // https://tools.ietf.org/html/rfc5322#section-3.2.1
+            //   quoted-pair     =   ("\" (VCHAR / WSP)) / obs-qp
+            //
+            //   VCHAR           =  %d33-126            ; visible (printing) characters
+            //   WSP             =  SP / HTAB           ; white space
+            //
+            //   obs-qp          =   "\" (%d0 / obs-NO-WS-CTL / LF / CR)
+            //
+            //   obs-NO-WS-CTL   =   %d1-8 /            ; US-ASCII control
+            //                       %d11 /             ;  characters that do not
+            //                       %d12 /             ;  include the carriage
+            //                       %d14-31 /          ;  return, line feed, and
+            //                       %d127              ;  white space characters
+            //
+            // i.e. obs-qp       =  "\" (%d0-8, %d10-31 / %d127)
+
+            const ushort uni = token.unicode();
+
+            if (uni > 127) {
+                returnStatus.push_back(ValidatorEmail::ErrorExpectingQpair); // Fatal error
+            } else if (((uni < 31) && (uni != 9)) || (uni == 127)) {
+                returnStatus.push_back(ValidatorEmail::DeprecatedQP);
+            }
+
+            // At this point we know where this qpair occurred so
+            // we could check to see if the character actually
+            // needed to be quoted at all.
+            // https://tools.ietf.org/html/rfc5321#section-4.1.2
+            //   the sending system SHOULD transmit the
+            //   form that uses the minimum quoting possible.
+
+            contextPrior = context;
+            context = contextStack.takeLast();
+
+            switch (context) {
+            case ContextComment:
+                break;
+            case ContextQuotedString:
+                parseLocalPart += QLatin1Char('\\');
+                parseLocalPart += token;
+                atomListLocalPart[elementCount] += QLatin1Char('\\');
+                atomListLocalPart[elementCount] += token;
+                elementLen += 2; // The maximum sizes specified by RFC 5321 are octet counts, so we must include the backslash
+                break;
+            case ComponentLiteral:
+                parseDomain += QLatin1Char('\\');
+                parseDomain += token;
+                atomListDomain[elementCount] += QLatin1Char('\\');
+                atomListDomain[elementCount] += token;
+                elementLen += 2; // The maximum sizes specified by RFC 5321 are octet counts, so we must include the backslash
+                break;
+            default:
+                returnStatus.push_back(ValidatorEmail::ErrorFatal);
+                qCCritical(C_VALIDATOR, "ValidatorEmail: Quoted pair logic invoked in an invalid context.");
+                break;
+            }
+        }
+            break;
+        //-------------------------------------------------------------
+        // Comment
+        //-------------------------------------------------------------
+        case ContextComment:
+        {
+            // https://tools.ietf.org/html/rfc5322#section-3.2.2
+            //   comment         =   "(" *([FWS] ccontent) [FWS] ")"
+            //
+            //   ccontent        =   ctext / quoted-pair / comment
+            if (token == QLatin1Char('(')) { // netsted comment
+                // nested comments are OK
+                contextStack.push_back(context);
+                context = ContextComment;
+            } else if (token == QLatin1Char(')')) {
+                contextPrior = context;
+                context = contextStack.takeLast();
+
+                // https://tools.ietf.org/html/rfc5322#section-3.2.2
+                //   Runs of FWS, comment, or CFWS that occur between lexical tokens in a
+                //   structured header field are semantically interpreted as a single
+                //   space character.
+                //
+                // is_email() author's note: This *cannot* mean that we must add a
+                // space to the address wherever CFWS appears. This would result in
+                // any addr-spec that had CFWS outside a quoted string being invalid
+                // for RFC 5321.
+//				if (($context === ISEMAIL_COMPONENT_LOCALPART) || ($context === ISEMAIL_COMPONENT_DOMAIN)) {
+//					$parsedata[$context]			.= ISEMAIL_STRING_SP;
+//					$atomlist[$context][$element_count]	.= ISEMAIL_STRING_SP;
+//					$element_len++;
+//				}
+            } else if (token == QLatin1Char('\\')) { // Quoted pair
+                contextStack.push_back(context);
+                context = ContextQuotedPair;
+            } else if ((token == QChar(QChar::CarriageReturn)) || (token == QChar(QChar::Space)) || (token == QChar(QChar::Tabulation))) { // Folding White Space
+                if ((token == QChar(QChar::CarriageReturn)) && ((++i == rawLength) || (email[i] != QChar(QChar::LineFeed)))) {
+                    returnStatus.push_back(ValidatorEmail::ErrorCRnoLF);
+                    break;
+                }
+
+                returnStatus.push_back(ValidatorEmail::CFWSFWS);
+                contextStack.push_back(context);
+                context = ContextFWS;
+                tokenPrior = token;
+            } else { // ctext
+                // https://tools.ietf.org/html/rfc5322#section-3.2.3
+                //   ctext           =   %d33-39 /          ; Printable US-ASCII
+                //                       %d42-91 /          ;  characters not including
+                //                       %d93-126 /         ;  "(", ")", or "\"
+                //                       obs-ctext
+                //
+                //   obs-ctext       =   obs-NO-WS-CTL
+                //
+                //   obs-NO-WS-CTL   =   %d1-8 /            ; US-ASCII control
+                //                       %d11 /             ;  characters that do not
+                //                       %d12 /             ;  include the carriage
+                //                       %d14-31 /          ;  return, line feed, and
+                //                       %d127              ;  white space characters
+
+                const ushort uni = token.unicode();
+
+                if ((uni > 127) || (uni == 0) || (uni == 10)) {
+                    returnStatus.push_back(ValidatorEmail::ErrorExpectingCText); // Fatal error
+                    break;
+                } else if ((uni < 32) || (uni == 127)) {
+                    returnStatus.push_back(ValidatorEmail::DeprecatedCText);
+                }
+            }
+        }
+            break;
+        //-------------------------------------------------------------
+        // Folding White Space
+        //-------------------------------------------------------------
+        case ContextFWS:
+        {
+            // https://tools.ietf.org/html/rfc5322#section-3.2.2
+            //   FWS             =   ([*WSP CRLF] 1*WSP) /  obs-FWS
+            //                                          ; Folding white space
+            // But note the erratum:
+            // https://www.rfc-editor.org/errata_search.php?rfc=5322&eid=1908:
+            //   In the obsolete syntax, any amount of folding white space MAY be
+            //   inserted where the obs-FWS rule is allowed.  This creates the
+            //   possibility of having two consecutive "folds" in a line, and
+            //   therefore the possibility that a line which makes up a folded header
+            //   field could be composed entirely of white space.
+            //
+            //   obs-FWS         =   1*([CRLF] WSP)
+            if (tokenPrior == QChar(QChar::CarriageReturn)) {
+                if (token == QChar(QChar::CarriageReturn)) {
+                    returnStatus.push_back(ValidatorEmail::ErrorFWSCRLFx2); // Fatal error
+                    break;
+                }
+
+                if (crlf_count > 0) {
+                    if (++crlf_count > 1) {
+                        returnStatus.push_back(ValidatorEmail::DeprecatedFWS); // Multiple folds = obsolete FWS
+                    }
+                } else {
+                    crlf_count = 1;
+                }
+            }
+
+            if (token == QChar(QChar::CarriageReturn)) {
+                if ((++i == rawLength) || (email[i] != QChar(QChar::LineFeed))) {
+                    returnStatus.push_back(ValidatorEmail::ErrorCRnoLF);
+                    break;
+                }
+            } else if ((token == QChar(QChar::Space)) || (token == QChar(QChar::Tabulation))) {
+
+            } else {
+                if (tokenPrior == QChar(QChar::CarriageReturn)) {
+                    returnStatus.push_back(ValidatorEmail::ErrorFWSCRLFEnd); // Fatal error
+                    break;
+                }
+
+                if (crlf_count > 0) {
+                    crlf_count = 0;
+                }
+
+                contextPrior = context;
+                context = contextStack.takeLast(); // End of FWS
+
+                // https://tools.ietf.org/html/rfc5322#section-3.2.2
+                //   Runs of FWS, comment, or CFWS that occur between lexical tokens in a
+                //   structured header field are semantically interpreted as a single
+                //   space character.
+                //
+                // is_email() author's note: This *cannot* mean that we must add a
+                // space to the address wherever CFWS appears. This would result in
+                // any addr-spec that had CFWS outside a quoted string being invalid
+                // for RFC 5321.
+//				if (($context === ISEMAIL_COMPONENT_LOCALPART) || ($context === ISEMAIL_COMPONENT_DOMAIN)) {
+//					$parsedata[$context]			.= ISEMAIL_STRING_SP;
+//					$atomlist[$context][$element_count]	.= ISEMAIL_STRING_SP;
+//					$element_len++;
+//				}
+
+                i--;	// Look at this token again in the parent context
+            }
+
+            tokenPrior = token;
+        }
+            break;
+        default:
+            returnStatus.push_back(ValidatorEmail::ErrorFatal);
+            qCCritical(C_VALIDATOR, "ValidatorEmail: Unknown context");
+            break;
+        }
+
+        if (static_cast<int>(*std::max_element(returnStatus.constBegin(), returnStatus.constEnd())) > static_cast<int>(ValidatorEmail::RFC5322)) {
+            break;
+        }
+    }
+
+    // Some simple final tests
+    if (static_cast<int>(*std::max_element(returnStatus.constBegin(), returnStatus.constEnd())) < static_cast<int>(ValidatorEmail::RFC5322)) {
+        if (context == ContextQuotedString) {
+            returnStatus.push_back(ValidatorEmail::ErrorUnclosedQuotedStr);
+        } else if (context == ContextQuotedPair) {
+            returnStatus.push_back(ValidatorEmail::ErrorBackslashEnd);
+        } else if (context == ContextComment) {
+            returnStatus.push_back(ValidatorEmail::ErrorUnclosedComment);
+        } else if (context == ComponentLiteral) {
+            returnStatus.push_back(ValidatorEmail::ErrorUnclosedDomLiteral);
+        } else if (token == QChar(QChar::CarriageReturn)) {
+            returnStatus.push_back(ValidatorEmail::ErrorFWSCRLFEnd);
+        } else if (parseDomain.isEmpty()) {
+            returnStatus.push_back(ValidatorEmail::ErrorNoDomain);
+        } else if (elementLen == 0) {
+            returnStatus.push_back(ValidatorEmail::ErrorDotEnd);
+        } else if (hypenFlag) {
+            returnStatus.push_back(ValidatorEmail::ErrorDomainHyphenEnd);
+        } else if (parseDomain.size() > 255) {
+            // https://tools.ietf.org/html/rfc5321#section-4.5.3.1.2
+            //   The maximum total length of a domain name or number is 255 octets.
+            returnStatus.push_back(ValidatorEmail::RFC5322DomainTooLong);
+        } else if ((parseLocalPart.size() + 1 + parseDomain.size()) > 254) {
+            // https://tools.ietf.org/html/rfc5321#section-4.1.2
+            //   Forward-path   = Path
+            //
+            //   Path           = "<" [ A-d-l ":" ] Mailbox ">"
+            //
+            // https://tools.ietf.org/html/rfc5321#section-4.5.3.1.3
+            //   The maximum total length of a reverse-path or forward-path is 256
+            //   octets (including the punctuation and element separators).
+            //
+            // Thus, even without (obsolete) routing information, the Mailbox can
+            // only be 254 characters long. This is confirmed by this verified
+            // erratum to RFC 3696:
+            //
+            // https://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690
+            //   However, there is a restriction in RFC 2821 on the length of an
+            //   address in MAIL and RCPT commands of 254 characters.  Since addresses
+            //   that do not fit in those fields are not normally useful, the upper
+            //   limit on address lengths should normally be considered to be 254.
+            returnStatus.push_back(ValidatorEmail::RFC5322TooLong);
+        } else if (elementLen > 63) {
+            returnStatus.push_back(ValidatorEmail::RFC5322LabelTooLong);
+        }
+    }
+
+    // Check DNS?
+    bool dnsChecked = false;
+
+    if (checkDNS && (static_cast<int>(*std::max_element(returnStatus.constBegin(), returnStatus.constEnd())) < static_cast<int>(threshold))) {
+        // https://tools.ietf.org/html/rfc5321#section-2.3.5
+        //   Names that can
+        //   be resolved to MX RRs or address (i.e., A or AAAA) RRs (as discussed
+        //   in Section 5) are permitted, as are CNAME RRs whose targets can be
+        //   resolved, in turn, to MX or address RRs.
+        //
+        // https://tools.ietf.org/html/rfc5321#section-5.1
+        //   The lookup first attempts to locate an MX record associated with the
+        //   name.  If a CNAME record is found, the resulting name is processed as
+        //   if it were the initial name. ... If an empty list of MXs is returned,
+        //   the address is treated as if it was associated with an implicit MX
+        //   RR, with a preference of 0, pointing to that host.
+
+        if (elementCount == 0) {
+            parseDomain += QLatin1Char('.');
+        }
+
+        QDnsLookup mxLookup(QDnsLookup::MX, parseDomain);
+        QEventLoop mxLoop;
+        QObject::connect(&mxLookup, &QDnsLookup::finished, &mxLoop, &QEventLoop::quit);
+        QTimer::singleShot(3100, &mxLookup, &QDnsLookup::abort);
+        mxLookup.lookup();
+        mxLoop.exec();
+
+        if ((mxLookup.error() == QDnsLookup::NoError) && !mxLookup.mailExchangeRecords().empty()) {
+            dnsChecked = true;
+        } else {
+            returnStatus.push_back(ValidatorEmail::DnsWarnNoMxRecord);
+            QDnsLookup aLookup(QDnsLookup::A, parseDomain);
+            QEventLoop aLoop;
+            QObject::connect(&aLookup, &QDnsLookup::finished, &aLoop, &QEventLoop::quit);
+            QTimer::singleShot(3100, &aLookup, &QDnsLookup::abort);
+            aLookup.lookup();
+            aLoop.exec();
+
+            if ((aLookup.error() == QDnsLookup::NoError) && !aLookup.hostAddressRecords().empty()) {
+                dnsChecked = true;
+            } else {
+                returnStatus.push_back(ValidatorEmail::DnsWarnNoRecord);
+            }
+        }
+    }
+
+    // Check for TLD addresses
+    // -----------------------
+    // TLD addresses are specifically allowed in RFC 5321 but they are
+    // unusual to say the least. We will allocate a separate
+    // status to these addresses on the basis that they are more likely
+    // to be typos than genuine addresses (unless we've already
+    // established that the domain does have an MX record)
+    //
+    // https://tools.ietf.org/html/rfc5321#section-2.3.5
+    //   In the case
+    //   of a top-level domain used by itself in an email address, a single
+    //   string is used without any dots.  This makes the requirement,
+    //   described in more detail below, that only fully-qualified domain
+    //   names appear in SMTP transactions on the public Internet,
+    //   particularly important where top-level domains are involved.
+    //
+    // TLD format
+    // ----------
+    // The format of TLDs has changed a number of times. The standards
+    // used by IANA have been largely ignored by ICANN, leading to
+    // confusion over the standards being followed. These are not defined
+    // anywhere, except as a general component of a DNS host name (a label).
+    // However, this could potentially lead to 123.123.123.123 being a
+    // valid DNS name (rather than an IP address) and thereby creating
+    // an ambiguity. The most authoritative statement on TLD formats that
+    // the author can find is in a (rejected!) erratum to RFC 1123
+    // submitted by John Klensin, the author of RFC 5321:
+    //
+    // https://www.rfc-editor.org/errata_search.php?rfc=1123&eid=1353
+    //   However, a valid host name can never have the dotted-decimal
+    //   form #.#.#.#, since this change does not permit the highest-level
+    //   component label to start with a digit even if it is not all-numeric.
+    if (!dnsChecked && (static_cast<int>(*std::max_element(returnStatus.constBegin(), returnStatus.constEnd())) < static_cast<int>(ValidatorEmail::DNSWarn))) {
+        if (elementCount == 0) {
+            returnStatus.push_back(ValidatorEmail::RFC5321TLD);
+        }
+
+        if (QStringLiteral("0123456789").contains(atomListDomain[elementCount][0])) {
+            returnStatus.push_back(ValidatorEmail::RFC5321TLDNumberic);
+        }
+    }
+
+    if (returnStatus.size() != 1) {
+        QList<ValidatorEmail::Diagnose> _rs;
+        for (int j = 0; j < returnStatus.size(); ++j) {
+            const ValidatorEmail::Diagnose dia = returnStatus.at(j);
+            if (!_rs.contains(dia) && (dia != ValidatorEmail::ValidAddress)) {
+                _rs.append(dia); // clazy:exclude=reserve-candidates
+            }
+        }
+        returnStatus = _rs;
+
+        std::sort(returnStatus.begin(), returnStatus.end(), std::greater<ValidatorEmail::Diagnose>());
+    }
+
+    const ValidatorEmail::Diagnose finalStatus = returnStatus.at(0);
+
+    if (diagnoseStruct) {
+        diagnoseStruct->finalStatus = finalStatus;
+        diagnoseStruct->returnStatus = returnStatus;
+        diagnoseStruct->localpart = parseLocalPart;
+        diagnoseStruct->domain = parseDomain;
+        diagnoseStruct->literal = parseLiteral;
+    }
+
+    ret = (static_cast<int>(finalStatus) < static_cast<int>(threshold));
+
+    return ret;
+}
+
+QString ValidatorEmail::diagnoseString(Context *c, Diagnose diagnose, const QString &label)
+{
+    QString ret;
+
+    if (label.isEmpty()) {
+        switch (diagnose) {
+        case ValidAddress:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address is valid. Please note that this does not mean the address actually exists, nor even that the domain actually exists. This address could be issued by the domain owner without breaking the rules of any RFCs.");
+            break;
+        case DnsWarnNoMxRecord:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Could not find an MX record for this address’ domain but an A record does exist.");
+            break;
+        case DnsWarnNoRecord:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Could neither find an MX record nor an A record for this address’ domain.");
+            break;
+        case RFC5321TLD:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address is valid but at a Top Level Domain.");
+            break;
+        case RFC5321TLDNumberic:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address is valid but the Top Level Domain begins with a number.");
+            break;
+        case RFC5321QuotedString:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address is valid but contains a quoted string.");
+            break;
+        case RFC5321AddressLiteral:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address is valid but uses an IP address instead of a domain name.");
+            break;
+        case RFC5321IPv6Deprecated:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address is valid but uses an IP address that contains a :: only eliding one zero group. All implementations must accept and be able to handle any legitimate RFC 4291 format.");
+            break;
+        case CFWSComment:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address contains comments.");
+            break;
+        case CFWSFWS:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address contains folding white spaces like line breaks.");
+            break;
+        case DeprecatedLocalpart:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The local part is in a deprecated form.");
+            break;
+        case DeprecatedFWS:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address contains an obsolete form of folding white spaces.");
+            break;
+        case DeprecatedQText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A quoted string contains a deprecated character.");
+            break;
+        case DeprecatedQP:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A quoted pair contains a deprecate character.");
+            break;
+        case DeprecatedComment:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address contains a comment in a position that is deprecated.");
+            break;
+        case DeprecatedCText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A comment contains a deprecated character.");
+            break;
+        case DeprecatedCFWSNearAt:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address contains a comment or folding white space around the @ sign.");
+            break;
+        case RFC5322Domain:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address is RFC 5322 compliant but contains domain charachters that are not allowed by DNS.");
+            break;
+        case RFC5322TooLong:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address is too long.");
+            break;
+        case RFC5322LocalTooLong:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The local part of the address is too long.");
+            break;
+        case RFC5322DomainTooLong:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The domain part is too long.");
+            break;
+        case RFC5322LabelTooLong:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The domain part contains an element that is too long.");
+            break;
+        case RFC5322DomainLiteral:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The domain literal is not a valid RFC 5321 address literal.");
+            break;
+        case RFC5322DomLitOBSDText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The domain literal is not a valid RFC 5321 domain literal and it contains obsolete characters.");
+            break;
+        case RFC5322IPv6GroupCount:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The IPv6 literal address contains the wrong number of groups.");
+            break;
+        case RFC5322IPv62x2xColon:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The IPv6 literal address contains too many :: sequences.");
+            break;
+        case RFC5322IPv6BadChar:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The IPv6 address contains an illegal group of characters.");
+            break;
+        case RFC5322IPv6MaxGroups:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The IPv6 address has too many groups.");
+            break;
+        case RFC5322IPv6ColonStart:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The IPv6 address starts with a single colon.");
+            break;
+        case RFC5322IPv6ColonEnd:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The IPv6 address ends with a single colon.");
+            break;
+        case ErrorExpectingDText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A domain literal contains a character that is not allowed.");
+            break;
+        case ErrorNoLocalPart:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address has no local part.");
+            break;
+        case ErrorNoDomain:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address has no domain part.");
+            break;
+        case ErrorConsecutiveDots:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address may not contain consecutive dots.");
+            break;
+        case ErrorATextAfterCFWS:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address contains text after a comment or folding white space.");
+            break;
+        case ErrorATextAfterQS:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address contains text after a quoted string.");
+            break;
+        case ErrorATextAfterDomLit:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Extra characters were found after the end of the domain literal.");
+            break;
+        case ErrorExpectingQpair:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The Address contains a character that is not allowed in a quoted pair.");
+            break;
+        case ErrorExpectingAText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address contains a character that is not allowed.");
+            break;
+        case ErrorExpectingQText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A quoted string contains a character that is not allowed.");
+            break;
+        case ErrorExpectingCText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A comment contains a character that is not allowed.");
+            break;
+        case ErrorBackslashEnd:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address can't end with a backslash.");
+            break;
+        case ErrorDotStart:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Neither part of the address may begin with a dot.");
+            break;
+        case ErrorDotEnd:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Neither part of the address may end with a dot.");
+            break;
+        case ErrorDomainHyphenStart:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A domain or subdomain can not begin with a hyphen.");
+            break;
+        case ErrorDomainHyphenEnd:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A domain or subdomain can not end with a hyphen.");
+            break;
+        case ErrorUnclosedQuotedStr:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Unclosed quoted string. (Missing double quotation mark)");
+            break;
+        case ErrorUnclosedComment:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Unclosed comment. (Missing closing parantheses)");
+            break;
+        case ErrorUnclosedDomLiteral:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Domain literal is missing its closing bracket.");
+            break;
+        case ErrorFWSCRLFx2:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Folding white space contains consecutive line break sequences (CRLF).");
+            break;
+        case ErrorFWSCRLFEnd:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Folding white space ends with a line break sequence (CRLF).");
+            break;
+        case ErrorCRnoLF:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address contains a carriage return (CR) that is not followed by a line feed (LF).");
+            break;
+        case ErrorFatal:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A fatal error occured while parsing the address.");
+            break;
+        default:
+            break;
+        }
+
+
+    } else {
+
+
+        switch (diagnose) {
+        case ValidAddress:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field is valid. Please note that this does not mean the address actually exists, nor even that the domain actually exists. This address could be issued by the domain owner without breaking the rules of any RFCs.").arg(label);
+            break;
+        case DnsWarnNoMxRecord:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Could not find an MX record for the address’ domain in the “%1” field but an A record does exist.").arg(label);
+            break;
+        case DnsWarnNoRecord:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Could neither find an MX record nor an A record for address’ domain in the “%1” field.").arg(label);
+            break;
+        case RFC5321TLD:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field is valid but at a Top Level Domain.").arg(label);
+            break;
+        case RFC5321TLDNumberic:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field is valid but the Top Level Domain begins with a number.").arg(label);
+            break;
+        case RFC5321QuotedString:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” is valid but contains a quoted string.").arg(label);
+            break;
+        case RFC5321AddressLiteral:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field is valid but uses an IP address instead of a domain name.").arg(label);
+            break;
+        case RFC5321IPv6Deprecated:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field is valid but uses an IP address that contains a :: only eliding one zero group. All implementations must accept and be able to handle any legitimate RFC 4291 format.").arg(label);
+            break;
+        case CFWSComment:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field contains comments.").arg(label);
+            break;
+        case CFWSFWS:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field contains folding white spaces like line breaks.").arg(label);
+            break;
+        case DeprecatedLocalpart:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The local part of the address in the “%1” field is in a deprecated form.").arg(label);
+            break;
+        case DeprecatedFWS:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field contains an obsolete form of folding white spaces.").arg(label);
+            break;
+        case DeprecatedQText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A quoted string in the address in the “%1” field contains a deprecated character.").arg(label);
+            break;
+        case DeprecatedQP:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A quoted pair in the address in the “%1” field contains a deprecate character.").arg(label);
+            break;
+        case DeprecatedComment:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field contains a comment in a position that is deprecated.").arg(label);
+            break;
+        case DeprecatedCText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A comment in the address in the “%1” field contains a deprecated character.").arg(label);
+            break;
+        case DeprecatedCFWSNearAt:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field contains a comment or folding white space around the @ sign.").arg(label);
+            break;
+        case RFC5322Domain:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field is RFC 5322 compliant but contains domain charachters that are not allowed by DNS.").arg(label);
+            break;
+        case RFC5322TooLong:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field is too long.").arg(label);
+            break;
+        case RFC5322LocalTooLong:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The local part of the address in the “%1” field is too long.").arg(label);
+            break;
+        case RFC5322DomainTooLong:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The domain part of the address in the “%1” field is too long.").arg(label);
+            break;
+        case RFC5322LabelTooLong:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The domain part of the address in the “%1” field contains an element that is too long.").arg(label);
+            break;
+        case RFC5322DomainLiteral:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The domain literal of the address in the “%1” field is not a valid RFC 5321 address literal.").arg(label);
+            break;
+        case RFC5322DomLitOBSDText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The domain literal of the address in the “%1” field is not a valid RFC 5321 domain literal and it contains obsolete characters.").arg(label);
+            break;
+        case RFC5322IPv6GroupCount:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The IPv6 literal of the address in the “%1” field contains the wrong number of groups.").arg(label);
+            break;
+        case RFC5322IPv62x2xColon:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The IPv6 literal of the address in the “%1” field contains too many :: sequences.").arg(label);
+            break;
+        case RFC5322IPv6BadChar:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The IPv6 address of the email address in the “%1” field contains an illegal group of characters.").arg(label);
+            break;
+        case RFC5322IPv6MaxGroups:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The IPv6 address of the email address in the “%1” field has too many groups.").arg(label);
+            break;
+        case RFC5322IPv6ColonStart:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The IPv6 address of the email address in the “%1” field starts with a single colon.").arg(label);
+            break;
+        case RFC5322IPv6ColonEnd:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The IPv6 address of the email address in the “%1” field ends with a single colon.").arg(label);
+            break;
+        case ErrorExpectingDText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A domain literal of the address in the “%1” field contains a character that is not allowed.").arg(label);
+            break;
+        case ErrorNoLocalPart:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field has no local part.").arg(label);
+            break;
+        case ErrorNoDomain:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field has no domain part.").arg(label);
+            break;
+        case ErrorConsecutiveDots:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field may not contain consecutive dots.").arg(label);
+            break;
+        case ErrorATextAfterCFWS:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field contains text after a comment or folding white space.").arg(label);
+            break;
+        case ErrorATextAfterQS:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field contains text after a quoted string.").arg(label);
+            break;
+        case ErrorATextAfterDomLit:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Extra characters were found after the end of the domain literal of the address in the “%1” field.").arg(label);
+            break;
+        case ErrorExpectingQpair:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field contains a character that is not allowed in a quoted pair.").arg(label);
+            break;
+        case ErrorExpectingAText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field contains a character that is not allowed.").arg(label);
+            break;
+        case ErrorExpectingQText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A quoted string in the address in the “%1” field contains a character that is not allowed.").arg(label);
+            break;
+        case ErrorExpectingCText:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A comment in the address in the “%1” field contains a character that is not allowed.").arg(label);
+            break;
+        case ErrorBackslashEnd:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field can't end with a backslash.").arg(label);
+            break;
+        case ErrorDotStart:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Neither part of the address in the “%1” field may begin with a dot.").arg(label);
+            break;
+        case ErrorDotEnd:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Neither part of the address in the “%1” field may end with a dot.").arg(label);
+            break;
+        case ErrorDomainHyphenStart:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A domain or subdomain of the address in the “%1” field can not begin with a hyphen.").arg(label);
+            break;
+        case ErrorDomainHyphenEnd:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A domain or subdomain of the address in the “%1” field can not end with a hyphen.").arg(label);
+            break;
+        case ErrorUnclosedQuotedStr:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Unclosed quoted string in the address in the “%1” field. (Missing double quotation mark)").arg(label);
+            break;
+        case ErrorUnclosedComment:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Unclosed comment in the address in the “%1” field. (Missing closing parantheses)").arg(label);
+            break;
+        case ErrorUnclosedDomLiteral:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Domain literal of the address in the “%1” field is missing its closing bracket.").arg(label);
+            break;
+        case ErrorFWSCRLFx2:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Folding white space in the address in the “%1” field contains consecutive line break sequences (CRLF).").arg(label);
+            break;
+        case ErrorFWSCRLFEnd:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Folding white space in the address in the “%1” field ends with a line break sequence (CRLF).").arg(label);
+            break;
+        case ErrorCRnoLF:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field contains a carriage return (CR) that is not followed by a line feed (LF).").arg(label);
+            break;
+        case ErrorFatal:
+            ret = c->translate("Cutelyst::ValidatorEmail", "A fatal error occured while parsing the address in the “%1” field.").arg(label);
+            break;
+        default:
+            break;
+        }
+    }
+
+    return ret;
+}
+
+QString ValidatorEmail::categoryString(Context *c, Category category, const QString &label)
+{
+    QString ret;
+    if (label.isEmpty()) {
+        switch(category) {
+        case Valid:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address is valid.");
+            break;
+        case DNSWarn:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address is valid but a dns check was not successful.");
+            break;
+        case RFC5321:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address is valid for SMTP but has unusual elements.");
+            break;
+        case CFWS:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address is valid within the message but can not be used unmodified for the envelope.");
+            break;
+        case Deprecated:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address contains deprecated elements but my still be valid in restricted contexts.");
+            break;
+        case RFC5322:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address is only valid according to the broad definition of RFC 5322. It is otherwise invalid.");
+            break;
+        default:
+            ret = c->translate("Cutelyst::ValidatorEmail", "Address is invalid for any purpose.");
+            break;
+        }
+    } else {
+        switch(category) {
+        case Valid:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field is valid.").arg(label);
+            break;
+        case DNSWarn:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field is valid but a dns check was not successful.").arg(label);
+            break;
+        case RFC5321:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field is valid for SMTP but has unusual elements.").arg(label);
+            break;
+        case CFWS:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field is valid within the message but can not be used unmodified for the envelope.").arg(label);
+            break;
+        case Deprecated:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field contains deprecated elements but my still be valid in restricted contexts.").arg(label);
+            break;
+        case RFC5322:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field is only valid according to the broad definition of RFC 5322. It is otherwise invalid.").arg(label);
+            break;
+        default:
+            ret = c->translate("Cutelyst::ValidatorEmail", "The address in the “%1” field is invalid for any purpose.").arg(label);
+            break;
+        }
+    }
+    return ret;
+}
+
+Cutelyst::ValidatorEmail::Category ValidatorEmail::category(Diagnose diagnose)
+{
+    Category cat = Error;
+
+    const quint8 diag = static_cast<quint8>(diagnose);
+
+    if (diag < static_cast<quint8>(Valid)) {
+        cat = Valid;
+    } else if (diag < static_cast<quint8>(DNSWarn)) {
+        cat = DNSWarn;
+    } else if (diag < static_cast<quint8>(RFC5321)) {
+        cat = RFC5321;
+    } else if (diag < static_cast<quint8>(CFWS)) {
+        cat = CFWS;
+    } else if (diag < static_cast<quint8>(Deprecated)) {
+        cat = Deprecated;
+    } else if (diag < static_cast<quint8>(RFC5322)) {
+        cat = RFC5322;
+    }
+
+    return cat;
+}
+
+QString ValidatorEmail::categoryString(Context *c, Diagnose diagnose, const QString &label)
+{
+    QString ret;
+    const Category cat = category(diagnose);
+    ret = categoryString(c, cat, label);
+    return ret;
+}
+
+bool ValidatorEmail::validate(const QString &email, Category threshold, bool checkDns, QList<Cutelyst::ValidatorEmail::Diagnose> *diagnoses)
+{
+    bool ret = false;
+
+    ValidatorEmailDiagnoseStruct diag;
+    ret = ValidatorEmailPrivate::checkEmail(email, checkDns, threshold, &diag);
+
+    if (diagnoses) {
+        *diagnoses = diag.returnStatus;
+    }
+
+    return ret;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
@@ -22,6 +22,7 @@
 #include <QDnsLookup>
 #include <QTimer>
 #include <QUrl>
+#include <functional>
 #include <algorithm>
 
 using namespace Cutelyst;

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
@@ -582,7 +582,7 @@ bool ValidatorEmailPrivate::checkEmail(const QString &email, bool checkDNS, Vali
 
                         if ((ipv6[0] == QLatin1Char(':')) && (ipv6[1] != QLatin1Char(':'))) {
                             returnStatus.push_back(ValidatorEmail::RFC5322IPv6ColonStart); // Address starts with a single colon
-                        } else if ((ipv6.rightRef(2)[1] == QLatin1Char(':')) && (ipv6.rightRef(2)[0] != QLatin1Char(':'))) {
+                        } else if ((ipv6.rightRef(2).at(1) == QLatin1Char(':')) && (ipv6.rightRef(2).at(0) != QLatin1Char(':'))) {
                             returnStatus.push_back(ValidatorEmail::RFC5322IPv6ColonEnd); // Address ends with a single colon
                         } else {
                             int unmatchedChars = 0;

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,53 +26,183 @@ namespace Cutelyst {
 class ValidatorEmailPrivate;
 
 /*!
- * \brief Checks if the value is a valid email address.
+ * \ingroup plugins-utils-validator-rules
+ * \brief Checks if the value is a valid email address according to specific RFCs.
  *
- * The \a field under validation must contain a valid email address.
+ * You can use a \link ValidatorEmail::Category Category\endlink as threshold to define which level of compliance you accpet as valid.
+ * The default threshold RFC5321 for example will only allow email addresses that can be sent without modification through SMTP. If
+ * the address would contain comments like <code>(main address)test\@example.com</code>, it would not be valid because the \link ValidatorEmail::CFWSComment
+ * CFWSComment\endlink diagnose is above the threshold. If it would contain a quoted string like <code>"main test address"\@example.com</code> it would be
+ * valid because the \link ValidatorEmail::RFC531QuotedString RFC5321QuotedString\endlink diagnose is under the threshold.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * The parser used to validate the email address is a reimplementation of Dominic Sayers’ <a href="https://github.com/dominicsayers/isemail">isemail</a> PHP parser.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \todo The current implementation uses the regular expression from https://regex101.com/library/gJ7pU0 to validate the email,
- * it might be more flexible to implement something like https://github.com/dominicsayers/isemail
- *
- * \todo Add optional DNS check
+ * \sa Validator for general usage of validators.
  */
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorEmail : public ValidatorRule
 {
+    Q_GADGET
 public:
+    /*!
+     * \brief Validation category, used as threshold to define valid addresses.
+     */
+    enum Category : quint8 {
+        Valid           = 1,    /**< Address is completely valid. */
+        DNSWarn         = 7,    /**< Address is valid but a DNS check was not successful. Diagnose in this category is only returned if \a checkDns ist set to \c true. */
+        RFC5321         = 15,   /**< Address is valid for SMTP according to <a href="https://tools.ietf.org/html/rfc5321">RFC 5321</a> but has unusual Elements. */
+        CFWS            = 31,   /**< Address is valid within the message but can not be used unmodified for the envelope. */
+        Deprecated      = 63,   /**< Address contains deprecated elements but may still be valid in restricted contexts. */
+        RFC5322         = 127,  /**< Address is only valid according to the broad definition of <a href="https://tools.ietf.org/html/rfc5322">RFC 5322</a>. It is otherwise invalid. */
+        Error           = 255   /**< Address is invalid for any purpose. */
+    };
+    Q_ENUM(Category)
+
+    /*!
+     * \brief Single diagnose values that show why an address is not valid.
+     */
+    enum Diagnose : quint8 {
+        // Address is valid
+        ValidAddress            = 0,    /**< Address is valid. Please note that this does not mean the address actually exists, nor even that the domain actually exists. This address could be issued by the domain owner without breaking the rules of any RFCs. */
+        // Address is valid but a DNS check was not successful
+        DnsWarnNoMxRecord       = 5,    /**< Couldn't find a MX record for this domain but an A-record does exist. */
+        DnsWarnNoRecord         = 6,    /**< Could neither find a MX record nor an A-record for this domain. */
+        // Address is valid for SMTP but has unusual Elements
+        RFC5321TLD              = 9,    /**< Address is valid but at a Top Level Domain. */
+        RFC5321TLDNumberic      = 10,   /**< Address is valid but the Top Level Domain begins with a number. */
+        RFC5321QuotedString     = 11,   /**< Address is valid but contains a quoted string. */
+        RFC5321AddressLiteral   = 12,   /**< Address is valid but a literal address not a domain. */
+        RFC5321IPv6Deprecated   = 13,   /**< Address is valid but contains a :: that only elides one zero group. All implementations must accept and be able to handle any legitimate <a href="https://tools.ietf.org/html/rfc4291">RFC 4291</a> format. */
+        // Address is valid within the message but cannot be used unmodified for the envelope
+        CFWSComment             = 17,   /**< Address contains comments. */
+        CFWSFWS                 = 18,   /**< Address contains Folding White Space. */
+        // Address contains deprecated elements but may still be valid in restricted contexts
+        DeprecatedLocalpart     = 33,   /**< The local part is in a deprecated form. */
+        DeprecatedFWS           = 34,   /**< Address contains an obsolete form of Folding White Space. */
+        DeprecatedQText         = 35,   /**< A quoted string contains a deprecated character. */
+        DeprecatedQP            = 36,   /**< A quoted pair contains a deprecated character. */
+        DeprecatedComment       = 37,   /**< Address contains a comment in a position that is deprecated. */
+        DeprecatedCText         = 38,   /**< A comment contains a deprecated character. */
+        DeprecatedCFWSNearAt    = 49,   /**< Address contains a comment or Folding White Space around the @ sign. */
+        // The address in only valid according to the broad definition of RFC 5322. It is otherwise invalid
+        RFC5322Domain           = 65,   /**< Address is <a href="https://tools.ietf.org/html/rfc5322">RFC 5322</a> compliant but contains domain characters that are not allowed by DNS. */
+        RFC5322TooLong          = 66,   /**< Address is too long. */
+        RFC5322LocalTooLong     = 67,   /**< The local part of the address is too long. */
+        RFC5322DomainTooLong    = 68,   /**< The domain part is too long. */
+        RFC5322LabelTooLong     = 69,   /**< The domain part contains an element that is too long. */
+        RFC5322DomainLiteral    = 70,   /**< The domain literal is not a valid <a href="https://tools.ietf.org/html/rfc5321">RFC 5321</a> address literal. */
+        RFC5322DomLitOBSDText   = 71,   /**< The domain literal is not a valid <a href="https://tools.ietf.org/html/rfc5321">RFC 5321</a> address literal and it contains obsolete characters. */
+        RFC5322IPv6GroupCount   = 72,   /**< The IPv6 literal address contains the wrong number of groups. */
+        RFC5322IPv62x2xColon    = 73,   /**< The IPv6 literal address contains too many :: sequences. */
+        RFC5322IPv6BadChar      = 74,   /**< The IPv6 address contains an illegal group of characters. */
+        RFC5322IPv6MaxGroups    = 75,   /**< The IPv6 address has too many groups. */
+        RFC5322IPv6ColonStart   = 76,   /**< IPv6 address starts with a single colon. */
+        RFC5322IPv6ColonEnd     = 77,   /**< IPv6 address ends with a single colon. */
+        // Address is invalid for any purpose
+        ErrorExpectingDText     = 129,  /**< A domain literal contains a character that is not allowed. */
+        ErrorNoLocalPart        = 130,  /**< Address has no local part. */
+        ErrorNoDomain           = 131,  /**< Address has no domain part. */
+        ErrorConsecutiveDots    = 132,  /**< The address may not contain consecutive dots. */
+        ErrorATextAfterCFWS     = 133,  /**< Address contains text after a comment or Folding White Space. */
+        ErrorATextAfterQS       = 134,  /**< Address contains text after a quoted string. */
+        ErrorATextAfterDomLit   = 135,  /**< Extra characters were found after the end of the domain literal. */
+        ErrorExpectingQpair     = 136,  /**< The address contains a character that is not allowed in a quoted pair. */
+        ErrorExpectingAText     = 137,  /**< Address contains a character that is not allowed. */
+        ErrorExpectingQText     = 138,  /**< A quoted string contains a character that is not allowed. */
+        ErrorExpectingCText     = 139,  /**< A comment contains a character that is not allowed. */
+        ErrorBackslashEnd       = 140,  /**< The address can't end with a backslash. */
+        ErrorDotStart           = 141,  /**< Neither part of the address may begin with a dot. */
+        ErrorDotEnd             = 142,  /**< Neither part of the address may end with a dot. */
+        ErrorDomainHyphenStart  = 143,  /**< A domain or subdomain cannot begin with a hyphen. */
+        ErrorDomainHyphenEnd    = 144,  /**< A domain or subdomain cannot end with a hyphen. */
+        ErrorUnclosedQuotedStr  = 145,  /**< Unclosed quoted string. */
+        ErrorUnclosedComment    = 146,  /**< Unclosed comment. */
+        ErrorUnclosedDomLiteral = 147,  /**< Domain literal is missing its closing bracket. */
+        ErrorFWSCRLFx2          = 148,  /**< Folding White Space contains consecutive CRLF sequences. */
+        ErrorFWSCRLFEnd         = 149,  /**< Folding White Space ends with a CRLF sequence. */
+        ErrorCRnoLF             = 150,  /**< Address contains a carriage return that is not followed by a line feed. */
+        ErrorFatal              = 254   /**< Fatal internal error while validating the address. */
+    };
+    Q_ENUM(Diagnose)
+
     /*!
      * \brief Constructs a new email validator.
      * \param field         Name of the input field to validate.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param checkDns      If \c true, a DNS lookup will be performed to check if there are MX records for the email domain.
+     * \param messages      Custom error messages if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorEmail(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorEmail(const QString &field, Category threshold = RFC5321, bool checkDns = false, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the email validator.
      */
     ~ValidatorEmail();
-    
+
     /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
+     * \brief Returns a descriptive and translated string for the \a diagnose.
+     * \param c         The current Context, used for translation.
+     * \param diagnose  The Diagnose to return the descriptive string for.
+     * \param label     Optional label used in the diagnose string.
+     * \return Descriptive and translated string for the \a diagnose.
      */
-    QString validate() const override;
+    static QString diagnoseString(Context *c, Diagnose diagnose, const QString &label = QString());
+
+    /*!
+     * \brief Returns a descriptive and translated string for the \a category.
+     * \param c         The current Context, used for translation.
+     * \param category  The Category to return the descriptive string for.
+     * \param label     Optional label used in the category string.
+     * \return Descriptive and translated string for the \a category.
+     */
+    static QString categoryString(Context *c, Category category, const QString &label = QString());
+
+    /*!
+     * \brief Returns the category the \a diagnose belongs to.
+     * \param diagnose  The Diagnose to get the Category for.
+     * \return The Category the \a diagnose belongs to.
+     */
+    static Category category(Diagnose diagnose);
+
+    /*!
+     * \brief Returns a descriptive and translated string for the Category the \a diagnose belongs to.
+     * \param c         The current context, used for translation.
+     * \param diagnose  The Diagnose to return the descriptive Category string for.
+     * \param label     Optional label used in the category string.
+     * \return Descriptive and translated string for the Category the \a diagnose belongs to.
+     */
+    static QString categoryString(Context *c, Diagnose diagnose, const QString &label = QString());
+
+    /*!
+     * \ingroup plugins-utils-validator-rules
+     * \brief Returns \c true if \a email is a valid address according to the Category given in the \a threshold.
+     * \param[in] email         The address to validate.
+     * \param[in] threshold     The threshold category that limits the diagnose that is accepted as valid.
+     * \param[in] checkDns      If \c true, a check for valid MX and A records of the address's domain will be performed.
+     * \param[out] diagnoses    If not a \c nullptr, this will contain a list of all issues found by the check, ordered from the highest to the lowest.
+     * \return \c true if \a email is a valid address according to the Category given in the \a threshold.
+     */
+    static bool validate(const QString &email, Category threshold = RFC5321, bool checkDns = false, QList<Diagnose> *diagnoses = nullptr);
     
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the cleaned up email address without any comments as QString.
+     * ValidatorReturnType::extra will contain a QList<Diagnose> list containing all issues found in the checked email, ordered from
+     * the highest to the lowest.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorEmail object with the given private class.
+     * \brief Returns a generic error if validation failed.
      */
-    ValidatorEmail(ValidatorEmailPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorEmail)

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,13 +22,38 @@
 #include "validatorrule_p.h"
 
 namespace Cutelyst {
+
+struct ValidatorEmailDiagnoseStruct {
+    ValidatorEmail::Diagnose finalStatus;
+    QList<ValidatorEmail::Diagnose> returnStatus;
+    QString localpart;
+    QString domain;
+    QString literal;
+};
     
 class ValidatorEmailPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorEmailPrivate(const QString &f, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e)
+    ValidatorEmailPrivate(const QString &f, ValidatorEmail::Category thresh, bool dns, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
+        threshold(thresh),
+        checkDns(dns)
     {}
+
+    enum EmailPart {
+        ComponentLocalpart  = 0,
+        ComponentDomain     = 1,
+        ComponentLiteral    = 2,
+        ContextComment      = 3,
+        ContextFWS          = 4,
+        ContextQuotedString = 5,
+        ContextQuotedPair   = 6
+    };
+
+    static bool checkEmail(const QString &email, bool checkDNS = false, ValidatorEmail::Category threshold = ValidatorEmail::RFC5321, ValidatorEmailDiagnoseStruct *diagnoseStruct = nullptr);
+
+    ValidatorEmail::Category threshold = ValidatorEmail::RFC5321;
+    bool checkDns = false;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorfilled.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorfilled.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,13 +20,8 @@
 
 using namespace Cutelyst;
 
-ValidatorFilled::ValidatorFilled(const QString &field, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorFilledPrivate(field, label, customError))
-{
-}
-
-ValidatorFilled::ValidatorFilled(ValidatorFilledPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorFilled::ValidatorFilled(const QString &field, const Cutelyst::ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(*new ValidatorFilledPrivate(field, messages, defValKey))
 {
 }
 
@@ -34,24 +29,32 @@ ValidatorFilled::~ValidatorFilled()
 {
 }
 
-QString ValidatorFilled::validate() const
+ValidatorReturnType ValidatorFilled::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
-    if (parameters().contains(field()) && value().isEmpty()) {
-        result = validationError();
+    if (params.contains(field())) {
+        const QString v = value(params);
+        if (!v.isEmpty()) {
+            result.value.setValue<QString>(v);
+        } else {
+            result.errorMessage = validationError(c);
+        }
+    } else {
+        defaultValue(c, &result, "ValidatorAfter");
     }
 
     return result;
 }
 
-QString ValidatorFilled::genericValidationError() const
+QString ValidatorFilled::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
-    if (label().isEmpty()) {
-        error = QStringLiteral("Must be filled.");
+    const QString _label = label(c);
+    if (_label.isEmpty()) {
+        error = c->translate("Cutelyst::ValidatorFilled", "Must be filled.");
     } else {
-        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+        error = c->translate("Cutelyst::ValidatorFilled", "You must fill in the “%1” field.");
     }
     return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorfilled.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorfilled.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,15 +26,16 @@ namespace Cutelyst {
 class ValidatorFilledPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief The field under validation must not be empty when it is present.
  *
  * The difference to the \link ValidatorRequired required validator \endlink is, that it will only be
  * checked for non emptyness, if it is available. If it is available, it is not allowed to be empty.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorPresent
  */
@@ -43,32 +44,28 @@ class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorFilled : public ValidatorR
 public:
     /*!
      * \brief Constructs a new filled validator.
-     * \param field         Name of the input field to validate.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param field     Name of the input field to validate.
+     * \param messages  Custom error message if validation fails.
      */
-    ValidatorFilled(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorFilled(const QString &field, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the filled validator.
      */
     ~ValidatorFilled();
-    
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-    
+     
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input parameter value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorFilled object with the given private class.
+     * \brief Creates a generic error message.
      */
-    ValidatorFilled(ValidatorFilledPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorFilled)

--- a/Cutelyst/Plugins/Utils/Validator/validatorfilled_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorfilled_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorFilledPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorFilledPrivate(const QString &f, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e)
+    ValidatorFilledPrivate(const QString &f, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk)
     {}
 };
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorin.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,16 +26,18 @@ namespace Cutelyst {
 class ValidatorInPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if the field value is one from a list of values.
  *
  * Validates if the \a field contains a value from the \a values list.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorNotIn
  */
@@ -46,36 +48,35 @@ public:
      * \brief Constructs a new in validator.
      * \param field         Name of the input field to validate.
      * \param values        List of values to compare against.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param cs            Defines if the comparison should be performed case sensitive or insensitive.
+     * \param messages      Custom error message if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorIn(const QString &field, const QStringList &values, const QString &label = QString(), const QString &customError = QString());
+    ValidatorIn(const QString &field, const QStringList &values, Qt::CaseSensitivity cs = Qt::CaseSensitive, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the in validator.
      */
     ~ValidatorIn();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the values to compare against.
-     */
-    void setValues(const QStringList &values);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorIn object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorIn(ValidatorInPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
+
+    /*!
+     * \brief Returns a generic error messages if the list of comparison values is empty.
+     */
+    QString genericValidationDataError(Context *c, const QVariant &errorData) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorIn)

--- a/Cutelyst/Plugins/Utils/Validator/validatorin_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorin_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,11 +27,13 @@ namespace Cutelyst {
 class ValidatorInPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorInPrivate(const QString &f, const QStringList &vs, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorInPrivate(const QString &f, const QStringList &vs, Qt::CaseSensitivity c, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
+        cs(c),
         values(vs)
     {}
 
+    Qt::CaseSensitivity cs = Qt::CaseSensitive;
     QStringList values;
 };
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorinteger.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorinteger.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -17,46 +17,107 @@
  */
 
 #include "validatorinteger_p.h"
-#include <QRegularExpression>
 
 using namespace Cutelyst;
 
-ValidatorInteger::ValidatorInteger(const QString &field, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorIntegerPrivate(field, label, customError))
+ValidatorInteger::ValidatorInteger(const QString &field, QMetaType::Type type, const Cutelyst::ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(*new ValidatorIntegerPrivate(field, type, messages, defValKey))
 {
 }
-
-
-ValidatorInteger::ValidatorInteger(ValidatorIntegerPrivate &dd) :
-    ValidatorRule(dd)
-{
-}
-
 
 ValidatorInteger::~ValidatorInteger()
 {
 }
 
-QString ValidatorInteger::validate() const
+ValidatorReturnType ValidatorInteger::validate(Cutelyst::Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
-    const QString v = value();
+    const QString v = value(params);
 
-    if (!v.isEmpty() && !v.contains(QRegularExpression(QStringLiteral("^-?\\d+$")))) {
-        result = validationError();
+    if (!v.isEmpty()) {
+        Q_D(const ValidatorInteger);
+        QVariant converted;
+
+        switch(d->type) {
+        case QMetaType::Short:
+        case QMetaType::Int:
+        case QMetaType::Long:
+        case QMetaType::LongLong:
+        case QMetaType::UShort:
+        case QMetaType::UInt:
+        case QMetaType::ULong:
+        case QMetaType::ULongLong:
+            converted = d->valueToNumber(c, v, d->type);
+            break;
+        default:
+            result.errorMessage = validationDataError(c);
+            qCWarning(C_VALIDATOR, "ValidatorInteger: Conversion type for field %s at %s::%s is not an integer type.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            break;
+        }
+
+        if (converted.isValid()) {
+            result.value = converted;
+        } else {
+            qCDebug(C_VALIDATOR, "ValidatorInteger: Validation failed for field %s at %s::%s: not an integer value.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            result.errorMessage = validationError(c);
+        }
+    } else {
+        defaultValue(c, &result, "ValidatorInteger");
     }
 
     return result;
 }
 
-QString ValidatorInteger::genericValidationError() const
+QString ValidatorInteger::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
-    if (label().isEmpty()) {
-        error = QStringLiteral("Has to be an integer (1,2,-3 etc).");
+    Q_UNUSED(errorData)
+    Q_D(const ValidatorInteger);
+    const QString _label = label(c);
+    QString min;
+    QString max;
+    switch (d->type) {
+    case QMetaType::Short:
+        min = c->locale().toString(std::numeric_limits<short>::min());
+        min = c->locale().toString(std::numeric_limits<short>::max());
+        break;
+    case QMetaType::Int:
+        min = c->locale().toString(std::numeric_limits<int>::min());
+        min = c->locale().toString(std::numeric_limits<int>::max());
+        break;
+    case QMetaType::Long:
+        min = c->locale().toString(static_cast<qlonglong>(std::numeric_limits<long>::min()));
+        min = c->locale().toString(static_cast<qlonglong>(std::numeric_limits<long>::max()));
+        break;
+    case QMetaType::LongLong:
+        min = c->locale().toString(std::numeric_limits<qlonglong>::min());
+        min = c->locale().toString(std::numeric_limits<qlonglong>::max());
+        break;
+    case QMetaType::UShort:
+        min = c->locale().toString(std::numeric_limits<ushort>::min());
+        min = c->locale().toString(std::numeric_limits<ushort>::max());
+        break;
+    case QMetaType::UInt:
+        min = c->locale().toString(std::numeric_limits<uint>::min());
+        min = c->locale().toString(std::numeric_limits<uint>::max());
+        break;
+    case QMetaType::ULong:
+        min = c->locale().toString(static_cast<qulonglong>(std::numeric_limits<ulong>::min()));
+        min = c->locale().toString(static_cast<qulonglong>(std::numeric_limits<ulong>::max()));
+        break;
+    case QMetaType::ULongLong:
+    default:
+        min = c->locale().toString(std::numeric_limits<qulonglong>::min());
+        min = c->locale().toString(std::numeric_limits<qulonglong>::max());
+        break;
+    }
+    if (_label.isEmpty()) {
+        //: %1 is the minimum numerical limit for the selected type, %2 is the maximum numeric limit
+        error = c->translate("ValidatorInteger", "Not a valid integer value between %1 and %2.").arg(min, max);
     } else {
-        error = QStringLiteral("You have to enter an integer (1,2,-3 etc.) into the “%1” field.").arg(label());
+        //: %2 is the minimum numerical limit for the selected type, %3 is the maximum numeric limit
+        error = c->translate("ValidatorInteger", "The value in the “%1“ field is not a valid integer between %2 and %3.").arg(_label, min, max);
     }
     return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorinteger.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorinteger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,16 +26,20 @@ namespace Cutelyst {
 class ValidatorIntegerPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if the value is an integer.
  *
- * This will simply perform a regular expression check if the input string in the \a field only contains digits and maybe have a minus sign at the beginning.
+ * Tries to convert the input parameter value into the integer \a type specified in the constructor.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Conversion of numeric input values is performed in the \c 'C' locale.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
+ *
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorNumeric
  */
@@ -45,31 +49,30 @@ public:
     /*!
      * \brief Constructs a new integer validator.
      * \param field         Name of the input field to validate.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param type          The type the integer value should fit in. Only integer types are supported, everything else will generate a validation data error.
+     * \param messages      Custom error message if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorInteger(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorInteger(const QString &field, QMetaType::Type type = QMetaType::ULongLong, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the integer validator.
      */
     ~ValidatorInteger();
-    
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-    
+       
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as the type set in the constructor.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorInteger object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorInteger(ValidatorIntegerPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorInteger)

--- a/Cutelyst/Plugins/Utils/Validator/validatorinteger_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorinteger_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,9 +26,12 @@ namespace Cutelyst {
 class ValidatorIntegerPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorIntegerPrivate(const QString &f, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e)
+    ValidatorIntegerPrivate(const QString &f, QMetaType::Type t, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
+        type(t)
     {}
+
+    QMetaType::Type type = QMetaType::ULongLong;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorip.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorip.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,13 +22,8 @@
 
 using namespace Cutelyst;
 
-ValidatorIp::ValidatorIp(const QString &field, Constraints constraints, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorIpPrivate(field, constraints, label, customError))
-{
-}
-
-ValidatorIp::ValidatorIp(ValidatorIpPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorIp::ValidatorIp(const QString &field, Constraints constraints, const Cutelyst::ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(*new ValidatorIpPrivate(field, constraints, messages, defValKey))
 {
 }
 
@@ -36,235 +31,242 @@ ValidatorIp::~ValidatorIp()
 {
 }
 
-QString ValidatorIp::validate() const
+ValidatorReturnType ValidatorIp::validate(Cutelyst::Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
     Q_D(const ValidatorIp);
 
-    const QString v = value();
+    const QString v = value(params);
 
     if (!v.isEmpty()) {
 
-        // simple check for an IPv4 address with four parts, because QHostAddress also tolerates addresses like 192.168.2 and fills them with 0 somewhere
-        if (!v.contains(QLatin1Char(':')) && !v.contains(QRegularExpression(QStringLiteral("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$")))) {
-
-            result = validationError();
-
+        if (ValidatorIp::validate(v, d->constraints)) {
+            result.value.setValue<QString>(v);
         } else {
-
-            bool valid = true;
-
-            // private IPv4 subnets
-            static const std::vector<QPair<QHostAddress,int>> ipv4Private({
-                                                                              // Used for local communications within a private network
-                                                                              // https://tools.ietf.org/html/rfc1918
-                                                                              {QHostAddress(QStringLiteral("10.0.0.0")), 8},
-
-                                                                              // Used for link-local addresses between two hosts on a single link when no IP address
-                                                                              // is otherwise specified, such as would have normally been retrieved from a DHCP server
-                                                                              // https://tools.ietf.org/html/rfc3927
-                                                                              {QHostAddress(QStringLiteral("169.254.0.0")), 16},
-
-                                                                              // Used for local communications within a private network
-                                                                              // https://tools.ietf.org/html/rfc1918
-                                                                              {QHostAddress(QStringLiteral("172.16.0.0")), 12},
-
-                                                                              // Used for local communications within a private network
-                                                                              // https://tools.ietf.org/html/rfc1918
-                                                                              {QHostAddress(QStringLiteral("192.168.0.0")), 12}
-                                                                          });
-
-            // reserved IPv4 subnets
-            static const std::vector<QPair<QHostAddress,int>> ipv4Reserved({
-                                                                               // Used for broadcast messages to the current ("this")
-                                                                               // https://tools.ietf.org/html/rfc1700
-                                                                               {QHostAddress(QStringLiteral("0.0.0.0")), 8},
-
-                                                                               // Used for communications between a service provider and its subscribers when using a carrier-grade NAT
-                                                                               // https://tools.ietf.org/html/rfc6598
-                                                                               {QHostAddress(QStringLiteral("100.64.0.0")), 10},
-
-                                                                               // Used for loopback addresses to the local host
-                                                                               // https://tools.ietf.org/html/rfc990
-                                                                               {QHostAddress(QStringLiteral("127.0.0.1")), 8},
-
-                                                                               // Used for the IANA IPv4 Special Purpose Address Registry
-                                                                               // https://tools.ietf.org/html/rfc5736
-                                                                               {QHostAddress(QStringLiteral("192.0.0.0")), 24},
-
-                                                                               // Assigned as "TEST-NET" for use in documentation and examples. It should not be used publicly.
-                                                                               // https://tools.ietf.org/html/rfc5737
-                                                                               {QHostAddress(QStringLiteral("192.0.2.0")), 24},
-
-                                                                               // Used by 6to4 anycast relays
-                                                                               // https://tools.ietf.org/html/rfc3068
-                                                                               {QHostAddress(QStringLiteral("192.88.99.0")), 24},
-
-                                                                               // Used for testing of inter-network communications between two separate subnets
-                                                                               // https://tools.ietf.org/html/rfc2544
-                                                                               {QHostAddress(QStringLiteral("198.18.0.0")), 15},
-
-                                                                               // Assigned as "TEST-NET-2" for use in documentation and examples. It should not be used publicly.
-                                                                               // https://tools.ietf.org/html/rfc5737
-                                                                               {QHostAddress(QStringLiteral("198.51.100.0")), 24},
-
-                                                                               // Assigned as "TEST-NET-3" for use in documentation and examples. It should not be used publicly.
-                                                                               // https://tools.ietf.org/html/rfc5737
-                                                                               {QHostAddress(QStringLiteral("203.0.113.0")), 24},
-
-                                                                               // Reserved for future use
-                                                                               // https://tools.ietf.org/html/rfc6890
-                                                                               {QHostAddress(QStringLiteral("240.0.0.0")), 4},
-
-                                                                               // Reserved for the "limited broadcast" destination address
-                                                                               // https://tools.ietf.org/html/rfc6890
-                                                                               {QHostAddress(QStringLiteral("255.255.255.255")), 32}
-                                                                           });
-
-
-            // private IPv6 subnets
-            static const std::vector<QPair<QHostAddress,int>> ipv6Private({
-                                                                              // unique local address
-                                                                              {QHostAddress(QStringLiteral("fc00::")), 7},
-
-                                                                              // link-local address
-                                                                              {QHostAddress(QStringLiteral("fe80::")), 10}
-                                                                          });
-
-            // reserved IPv6 subnets
-            static const std::vector<QPair<QHostAddress,int>> ipv6Reserved({
-                                                                               // unspecified address
-                                                                               {QHostAddress(QStringLiteral("::")), 128},
-
-                                                                               // loopback address to the loca host
-                                                                               {QHostAddress(QStringLiteral("::1")), 128},
-
-                                                                               // IPv4 mapped addresses
-                                                                               {QHostAddress(QStringLiteral("::ffff:0:0")), 96},
-
-                                                                               // discard prefix
-                                                                               // https://tools.ietf.org/html/rfc6666
-                                                                               {QHostAddress(QStringLiteral("100::")), 64},
-
-                                                                               // IPv4/IPv6 translation
-                                                                               // https://tools.ietf.org/html/rfc6052
-                                                                               {QHostAddress(QStringLiteral("64:ff9b::")), 96},
-
-                                                                               // Teredo tunneling
-                                                                               {QHostAddress(QStringLiteral("2001::")), 32},
-
-                                                                               // deprected (previously ORCHID)
-                                                                               {QHostAddress(QStringLiteral("2001:10::")), 28},
-
-                                                                               // ORCHIDv2
-                                                                               {QHostAddress(QStringLiteral("2001:20::")), 28},
-
-                                                                               // addresses used in documentation and example source code
-                                                                               {QHostAddress(QStringLiteral("2001:db8::")), 32},
-
-                                                                               // 6to4
-                                                                               {QHostAddress(QStringLiteral("2002::")), 16}
-                                                                           });
-
-            QHostAddress a;
-
-            if (a.setAddress(value())) {
-
-                if (!d->constraints.testFlag(NoConstraint)) {
-
-                    if (a.protocol() == QAbstractSocket::IPv4Protocol) {
-
-                        if (d->constraints.testFlag(IPv6Only)) {
-                            valid = false;
-                        }
-
-                        if (valid && (d->constraints.testFlag(NoPrivateRange) || d->constraints.testFlag(PublicOnly))) {
-
-                            for (const QPair<QHostAddress,int> &subnet : ipv4Private) {
-                                if (a.isInSubnet(subnet)) {
-                                    valid = false;
-                                    break;
-                                }
-                            }
-                        }
-
-                        if (valid && (d->constraints.testFlag(NoReservedRange) || d->constraints.testFlag(PublicOnly))) {
-
-                            for (const QPair<QHostAddress,int> &subnet : ipv4Reserved) {
-                                if (a.isInSubnet(subnet)) {
-                                    valid = false;
-                                    break;
-                                }
-                            }
-                        }
-
-                        if (valid && (d->constraints.testFlag(NoMultiCast) || d->constraints.testFlag(PublicOnly))) {
-                            if (a.isInSubnet(QHostAddress(QStringLiteral("224.0.0.0")), 4)) {
-                                valid = false;
-                            }
-                        }
-
-                    } else {
-
-                        if (d->constraints.testFlag(IPv4Only)) {
-                            valid = false;
-                        }
-
-                        if (valid && (d->constraints.testFlag(NoPrivateRange) || d->constraints.testFlag(PublicOnly))) {
-
-                            for (const QPair<QHostAddress,int> &subnet : ipv6Private) {
-                                if (a.isInSubnet(subnet)) {
-                                    valid = false;
-                                    break;
-                                }
-                            }
-                        }
-
-                        if (valid && (d->constraints.testFlag(NoReservedRange) || d->constraints.testFlag(PublicOnly))) {
-
-                            for (const QPair<QHostAddress,int> &subnet : ipv6Reserved) {
-                                if (a.isInSubnet(subnet)) {
-                                    valid = false;
-                                    break;
-                                }
-                            }
-                        }
-
-                        if (valid && (d->constraints.testFlag(NoMultiCast) || d->constraints.testFlag(PublicOnly))) {
-                            if (a.isInSubnet(QHostAddress(QStringLiteral("ff00::")), 8)) {
-                                valid = false;
-                            }
-                        }
-                    }
-                }
-
-            } else {
-                valid = false;
-            }
-
-            if (!valid) {
-                result = validationError();
-            }
+            result.errorMessage = validationError(c);
+            qCDebug(C_VALIDATOR, "ValidatorIp: Validation failed for field %s at %s::%s: not a valid IP address within the constraints.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
         }
+
+    } else {
+        defaultValue(c, &result, "ValidatorIp");
     }
 
     return result;
 }
 
-QString ValidatorIp::genericValidationError() const
+bool ValidatorIp::validate(const QString &value, Constraints constraints)
 {
-    QString error;
-    if (label().isEmpty()) {
-        error = QStringLiteral("IP address is invalid or not acceptable.");
+    bool valid = true;
+
+    // simple check for an IPv4 address with four parts, because QHostAddress also tolerates addresses like 192.168.2 and fills them with 0 somewhere
+    if (!value.contains(QLatin1Char(':')) && !value.contains(QRegularExpression(QStringLiteral("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$")))) {
+
+        valid = false;
+
     } else {
-        error = QStringLiteral("You have to enter a valid IP address into the “%1” field.").arg(label());
+
+        // private IPv4 subnets
+        static const std::vector<QPair<QHostAddress,int>> ipv4Private({
+                                                                          // Used for local communications within a private network
+                                                                          // https://tools.ietf.org/html/rfc1918
+                                                                          {QHostAddress(QStringLiteral("10.0.0.0")), 8},
+
+                                                                          // Used for link-local addresses between two hosts on a single link when no IP address
+                                                                          // is otherwise specified, such as would have normally been retrieved from a DHCP server
+                                                                          // https://tools.ietf.org/html/rfc3927
+                                                                          {QHostAddress(QStringLiteral("169.254.0.0")), 16},
+
+                                                                          // Used for local communications within a private network
+                                                                          // https://tools.ietf.org/html/rfc1918
+                                                                          {QHostAddress(QStringLiteral("172.16.0.0")), 12},
+
+                                                                          // Used for local communications within a private network
+                                                                          // https://tools.ietf.org/html/rfc1918
+                                                                          {QHostAddress(QStringLiteral("192.168.0.0")), 12}
+                                                                      });
+
+        // reserved IPv4 subnets
+        static const std::vector<QPair<QHostAddress,int>> ipv4Reserved({
+                                                                           // Used for broadcast messages to the current ("this")
+                                                                           // https://tools.ietf.org/html/rfc1700
+                                                                           {QHostAddress(QStringLiteral("0.0.0.0")), 8},
+
+                                                                           // Used for communications between a service provider and its subscribers when using a carrier-grade NAT
+                                                                           // https://tools.ietf.org/html/rfc6598
+                                                                           {QHostAddress(QStringLiteral("100.64.0.0")), 10},
+
+                                                                           // Used for loopback addresses to the local host
+                                                                           // https://tools.ietf.org/html/rfc990
+                                                                           {QHostAddress(QStringLiteral("127.0.0.1")), 8},
+
+                                                                           // Used for the IANA IPv4 Special Purpose Address Registry
+                                                                           // https://tools.ietf.org/html/rfc5736
+                                                                           {QHostAddress(QStringLiteral("192.0.0.0")), 24},
+
+                                                                           // Assigned as "TEST-NET" for use in documentation and examples. It should not be used publicly.
+                                                                           // https://tools.ietf.org/html/rfc5737
+                                                                           {QHostAddress(QStringLiteral("192.0.2.0")), 24},
+
+                                                                           // Used by 6to4 anycast relays
+                                                                           // https://tools.ietf.org/html/rfc3068
+                                                                           {QHostAddress(QStringLiteral("192.88.99.0")), 24},
+
+                                                                           // Used for testing of inter-network communications between two separate subnets
+                                                                           // https://tools.ietf.org/html/rfc2544
+                                                                           {QHostAddress(QStringLiteral("198.18.0.0")), 15},
+
+                                                                           // Assigned as "TEST-NET-2" for use in documentation and examples. It should not be used publicly.
+                                                                           // https://tools.ietf.org/html/rfc5737
+                                                                           {QHostAddress(QStringLiteral("198.51.100.0")), 24},
+
+                                                                           // Assigned as "TEST-NET-3" for use in documentation and examples. It should not be used publicly.
+                                                                           // https://tools.ietf.org/html/rfc5737
+                                                                           {QHostAddress(QStringLiteral("203.0.113.0")), 24},
+
+                                                                           // Reserved for future use
+                                                                           // https://tools.ietf.org/html/rfc6890
+                                                                           {QHostAddress(QStringLiteral("240.0.0.0")), 4},
+
+                                                                           // Reserved for the "limited broadcast" destination address
+                                                                           // https://tools.ietf.org/html/rfc6890
+                                                                           {QHostAddress(QStringLiteral("255.255.255.255")), 32}
+                                                                       });
+
+
+        // private IPv6 subnets
+        static const std::vector<QPair<QHostAddress,int>> ipv6Private({
+                                                                          // unique local address
+                                                                          {QHostAddress(QStringLiteral("fc00::")), 7},
+
+                                                                          // link-local address
+                                                                          {QHostAddress(QStringLiteral("fe80::")), 10}
+                                                                      });
+
+        // reserved IPv6 subnets
+        static const std::vector<QPair<QHostAddress,int>> ipv6Reserved({
+                                                                           // unspecified address
+                                                                           {QHostAddress(QStringLiteral("::")), 128},
+
+                                                                           // loopback address to the loca host
+                                                                           {QHostAddress(QStringLiteral("::1")), 128},
+
+                                                                           // IPv4 mapped addresses
+                                                                           {QHostAddress(QStringLiteral("::ffff:0:0")), 96},
+
+                                                                           // discard prefix
+                                                                           // https://tools.ietf.org/html/rfc6666
+                                                                           {QHostAddress(QStringLiteral("100::")), 64},
+
+                                                                           // IPv4/IPv6 translation
+                                                                           // https://tools.ietf.org/html/rfc6052
+                                                                           {QHostAddress(QStringLiteral("64:ff9b::")), 96},
+
+                                                                           // Teredo tunneling
+                                                                           {QHostAddress(QStringLiteral("2001::")), 32},
+
+                                                                           // deprected (previously ORCHID)
+                                                                           {QHostAddress(QStringLiteral("2001:10::")), 28},
+
+                                                                           // ORCHIDv2
+                                                                           {QHostAddress(QStringLiteral("2001:20::")), 28},
+
+                                                                           // addresses used in documentation and example source code
+                                                                           {QHostAddress(QStringLiteral("2001:db8::")), 32},
+
+                                                                           // 6to4
+                                                                           {QHostAddress(QStringLiteral("2002::")), 16}
+                                                                       });
+
+        QHostAddress a;
+
+        if (a.setAddress(value)) {
+
+            if (!constraints.testFlag(NoConstraint)) {
+
+                if (a.protocol() == QAbstractSocket::IPv4Protocol) {
+
+                    if (constraints.testFlag(IPv6Only)) {
+                        valid = false;
+                    }
+
+                    if (valid && (constraints.testFlag(NoPrivateRange) || constraints.testFlag(PublicOnly))) {
+
+                        for (const QPair<QHostAddress,int> &subnet : ipv4Private) {
+                            if (a.isInSubnet(subnet)) {
+                                valid = false;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (valid && (constraints.testFlag(NoReservedRange) || constraints.testFlag(PublicOnly))) {
+
+                        for (const QPair<QHostAddress,int> &subnet : ipv4Reserved) {
+                            if (a.isInSubnet(subnet)) {
+                                valid = false;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (valid && (constraints.testFlag(NoMultiCast) || constraints.testFlag(PublicOnly))) {
+                        if (a.isInSubnet(QHostAddress(QStringLiteral("224.0.0.0")), 4)) {
+                            valid = false;
+                        }
+                    }
+
+                } else {
+
+                    if (constraints.testFlag(IPv4Only)) {
+                        valid = false;
+                    }
+
+                    if (valid && (constraints.testFlag(NoPrivateRange) || constraints.testFlag(PublicOnly))) {
+
+                        for (const QPair<QHostAddress,int> &subnet : ipv6Private) {
+                            if (a.isInSubnet(subnet)) {
+                                valid = false;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (valid && (constraints.testFlag(NoReservedRange) || constraints.testFlag(PublicOnly))) {
+
+                        for (const QPair<QHostAddress,int> &subnet : ipv6Reserved) {
+                            if (a.isInSubnet(subnet)) {
+                                valid = false;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (valid && (constraints.testFlag(NoMultiCast) || constraints.testFlag(PublicOnly))) {
+                        if (a.isInSubnet(QHostAddress(QStringLiteral("ff00::")), 8)) {
+                            valid = false;
+                        }
+                    }
+                }
+            }
+
+        } else {
+            valid = false;
+        }
     }
-    return error;
+
+    return valid;
 }
 
-void ValidatorIp::setConstraints(Constraints constraints)
+QString ValidatorIp::genericValidationError(Context *c, const QVariant &errorData) const
 {
-    Q_D(ValidatorIp);
-    d->constraints = constraints;
+    QString error;
+    Q_UNUSED(errorData)
+    const QString _label = label(c);
+    if (!_label.isEmpty()) {
+        error = c->translate("Cutelyst::ValidatorIp", "IP address is invalid or not acceptable.");
+    } else {
+        error = c->translate("Cutelyst::ValidatorIp", "The IP address in the “%1” field is invalid or not acceptable.").arg(_label);
+    }
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorip.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorip.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,17 +26,19 @@ namespace Cutelyst {
 class ValidatorIpPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if the field value is a valid IP address.
  *
  * This uses QHostAddress internally to check if the \a field contains a valid IP address. You can
  * use the \a constraints flags to limit the validator to specific address ranges.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  */
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorIp : public ValidatorRule
 {
@@ -58,37 +60,39 @@ public:
     /*!
      * \brief Constructs a new ip validator.
      * \param field         Name of the input field to validate.
-     * \param constraints    Optional validation constraints.
-     * \param label         Human readable input field label, used for error messages.
-     * \param customError   Custom errror message if validation fails.
+     * \param constraints   Optional validation constraints.
+     * \param messages      Custom error message if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorIp(const QString &field, Constraints constraints = NoConstraint, const QString &label = QString(), const QString &customError = QString());
+    ValidatorIp(const QString &field, Constraints constraints = NoConstraint, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the ip validator.
      */
     ~ValidatorIp();
-    
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
 
     /*!
-     * \brief Sets optional validation contraints.
+     * \ingroup plugins-utils-validator-rules
+     * \brief Returns \c true if \a value is a valid IP address within the \a constraints.
+     * \param value         The value to validate.
+     * \param constraints   Optional validation constraints.
+     * \return \c true if \a value is a valid IP address within the \a constraints.
      */
-    void setConstraints(Constraints constraints);
-    
+    static bool validate(const QString &value, Constraints constraints = NoConstraint);
+        
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorIp object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorIp(ValidatorIpPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorIp)

--- a/Cutelyst/Plugins/Utils/Validator/validatorip_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorip_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorIpPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorIpPrivate(const QString &f, ValidatorIp::Constraints c, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorIpPrivate(const QString &f, ValidatorIp::Constraints c, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
         constraints(c)
     {}
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorjson.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorjson.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,16 +26,18 @@ namespace Cutelyst {
 class ValidatorJsonPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if the inut data is valid JSON.
  *
  * This tries to load the input \a field string into a QJsonDocument and checks if it is not null and not empty.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  */
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorJson : public ValidatorRule
 {
@@ -43,31 +45,31 @@ public:
     /*!
      * \brief Constructs a new json validator.
      * \param field         Name of the input field to validate.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param messages      Custom error message if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorJson(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorJson(const QString &field, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the json validator.
      */
     ~ValidatorJson();
-    
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-    
+       
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value converted into a QJsonDocument.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorJson object with the given private class.
+     * \brief Returns a generic error message if validation failed.
+     * \param c         The current context, used for translations.
+     * \param errorData Will contain the error string from QJsonParseError.
      */
-    ValidatorJson(ValidatorJsonPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorJson)

--- a/Cutelyst/Plugins/Utils/Validator/validatorjson_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorjson_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorJsonPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorJsonPrivate(const QString &f, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e)
+    ValidatorJsonPrivate(const QString &f, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk)
     {}
 };
     

--- a/Cutelyst/Plugins/Utils/Validator/validatormax.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatormax.cpp
@@ -20,13 +20,8 @@
 
 using namespace Cutelyst;
 
-ValidatorMax::ValidatorMax(const QString &field, QMetaType::Type type, double max, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorMaxPrivate(field, type, max, label, customError))
-{
-}
-
-ValidatorMax::ValidatorMax(ValidatorMaxPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorMax::ValidatorMax(const QString &field, QMetaType::Type type, const QVariant &max, const Cutelyst::ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(*new ValidatorMaxPrivate(field, type, max, messages, defValKey))
 {
 }
 
@@ -34,88 +29,240 @@ ValidatorMax::~ValidatorMax()
 {
 }
 
-QString ValidatorMax::validate() const
+ValidatorReturnType ValidatorMax::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
-    const QString v = value();
+    const QString v = value(params);
 
     if (!v.isEmpty()) {
         Q_D(const ValidatorMax);
+        bool ok = false;
+        bool valid = false;
 
-        if (d->type == QMetaType::Int) {
-            qlonglong val = v.toLongLong();
-            qlonglong max = (qlonglong)d->max;
-            if (val > max) {
-                result = validationError();
+        switch (d->type) {
+        case QMetaType::Short:
+        case QMetaType::Int:
+        case QMetaType::Long:
+        case QMetaType::LongLong:
+        {
+            const qlonglong val = c->locale().toLongLong(v, &ok);
+            if (Q_UNLIKELY(!ok)) {
+                result.errorMessage = parsingError(c);
+                qCWarning(C_VALIDATOR, "ValidatorMax: Failed to parse value of field %s into number at %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            } else {
+                const qlonglong max = d->extractLongLong(c, params, d->max, &ok);
+                if (Q_UNLIKELY(!ok)) {
+                    result.errorMessage = validationDataError(c, 1);
+                    qCWarning(C_VALIDATOR, "ValidatorMax: Invalid maximum comparison value for field %s in %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                } else {
+                    if (val > max) {
+                        result.errorMessage = validationError(c, QVariantMap{
+                                                                  {QStringLiteral("val"), val},
+                                                                  {QStringLiteral("max"), max}
+                                                              });
+                        qCDebug(C_VALIDATOR, "ValidatorMax: Validation failed for field %s in %s::%s: %lli is not smaller than %lli.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), val, max);
+                    } else {
+                        valid = true;
+                    }
+                }
             }
-        } else if (d->type == QMetaType::UInt) {
-            qulonglong val = v.toULongLong();
-            qulonglong max = (qulonglong)d->max;
-            if (val > max) {
-                result = validationError();
-            }
-        } else if (d->type == QMetaType::Float) {
-            double val = v.toDouble();
-            if (val > d->max) {
-                result = validationError();
-            }
-        } else if (d->type == QMetaType::QString) {
-            int val = v.length();
-            int max = (int)d->max;
-            if (val > max) {
-                result = validationError();
-            }
-        } else {
-            result = validationDataError();
         }
+            break;
+        case QMetaType::UShort:
+        case QMetaType::UInt:
+        case QMetaType::ULong:
+        case QMetaType::ULongLong:
+        {
+            const qulonglong val = v.toULongLong(&ok);
+            if (Q_UNLIKELY(!ok)) {
+                result.errorMessage = parsingError(c);
+                qCWarning(C_VALIDATOR, "ValidatorMax: Failed to parse value of field %s into number at %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            } else {
+                const qulonglong max = d->extractULongLong(c, params, d->max, &ok);
+                if (Q_UNLIKELY(!ok)) {
+                    result.errorMessage = validationDataError(c, 1);
+                    qCWarning(C_VALIDATOR, "ValidatorMax: Invalid maximum comparison value for field %s in %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                } else {
+                    if (val > max) {
+                        result.errorMessage = validationError(c, QVariantMap{
+                                                                  {QStringLiteral("val"), val},
+                                                                  {QStringLiteral("max"), max}
+                                                              });
+                        qCDebug(C_VALIDATOR, "ValidatorMax: Validation failed for field %s in %s::%s: %llu is not smaller than %llu.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), val, max);
+                    } else {
+                        valid = true;
+                    }
+                }
+            }
+        }
+            break;
+        case QMetaType::Float:
+        case QMetaType::Double:
+        {
+            const double val = v.toDouble(&ok);
+            if (Q_UNLIKELY(!ok)) {
+                result.errorMessage = parsingError(c);
+                qCWarning(C_VALIDATOR, "ValidatorMax: Failed to parse value of field %s into number at %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            } else {
+                const double max = d->extractDouble(c, params, d->max, &ok);
+                if (Q_UNLIKELY(!ok)) {
+                    result.errorMessage = validationDataError(c, 1);
+                    qCWarning(C_VALIDATOR, "ValidatorMax: Invalid maximum comparison value for field %s in %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+                } else {
+                    if (val > max) {
+                        result.errorMessage = validationError(c, QVariantMap{
+                                                                  {QStringLiteral("val"), val},
+                                                                  {QStringLiteral("max"), max}
+                                                              });
+                        qCDebug(C_VALIDATOR, "ValidatorMax: Validation failed for field %s in %s::%s: %f is not smaller than %f.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), val, max);
+                    } else {
+                        valid = true;
+                    }
+                }
+            }
+        }
+            break;
+        case QMetaType::QString:
+        {
+            const qlonglong val = static_cast<qlonglong>(v.length());
+            const qlonglong max = d->extractLongLong(c, params, d->max, &ok);
+            if (Q_UNLIKELY(!ok)) {
+                result.errorMessage = validationDataError(c, 1);
+                qCWarning(C_VALIDATOR, "ValidatorMax: Invalid maximum comparison value for field %s in %s::%s.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            } else {
+                if (val > max) {
+                    result.errorMessage = validationError(c, QVariantMap{
+                                                              {QStringLiteral("val"), val},
+                                                              {QStringLiteral("max"), max}
+                                                          });
+                    qCDebug(C_VALIDATOR, "ValidatorMax: Validation failed for field %s in %s::%s: string length %lli is not smaller than %lli.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), val, max);
+                } else {
+                    valid = true;
+                }
+            }
+        }
+            break;
+        default:
+            qCWarning(C_VALIDATOR, "ValidatorMax: The comparison type with ID %i for field %s at %s::%s is not supported.", static_cast<int>(d->type), qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            result.errorMessage = validationDataError(c, 0);
+            break;
+        }
+
+        if (valid) {
+            if (d->type != QMetaType::QString) {
+                const QVariant _v = d->valueToNumber(c, v, d->type);
+                if (_v.isValid()) {
+                    result.value = _v;
+                } else {
+                    result.errorMessage = parsingError(c);
+                }
+            } else {
+                result.value.setValue<QString>(v);
+            }
+        }
+    } else {
+        defaultValue(c, &result, "ValidatorMax");
     }
 
     return result;
 }
 
-QString ValidatorMax::genericValidationError() const
+QString ValidatorMax::genericValidationError(Cutelyst::Context *c, const QVariant &errorData) const
 {
     QString error;
 
     Q_D(const ValidatorMax);
 
+    const QVariantMap map = errorData.toMap();
     QString max;
-    if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::QString) {
-        max = QString::number(d->max, 'f', 0);
-    } else {
-        max = QString::number(d->max);
+    switch (d->type) {
+    case QMetaType::Short:
+    case QMetaType::Int:
+    case QMetaType::Long:
+    case QMetaType::LongLong:
+    case QMetaType::QString:
+        max = c->locale().toString(map.value(QStringLiteral("max")).toLongLong());
+        break;
+    case QMetaType::UShort:
+    case QMetaType::UInt:
+    case QMetaType::ULong:
+    case QMetaType::ULongLong:
+        max = c->locale().toString(map.value(QStringLiteral("max")).toULongLong());
+        break;
+    case QMetaType::Float:
+    case QMetaType::Double:
+        max = c->locale().toString(map.value(QStringLiteral("max")).toDouble());
+        break;
+    default:
+        error = validationDataError(c);
+        return error;
     }
 
-    if (label().isEmpty()) {
-        if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::Float) {
-            error = QStringLiteral("Has to be lower than or equal to %1.").arg(max);
-        } else if (d->type == QMetaType::QString) {
-            error = QStringLiteral("Has to be shorter than or equal to %1.").arg(max);
+    const QString _label = label(c);
+
+    if (_label.isEmpty()) {
+        if (d->type == QMetaType::QString) {
+            error = c->translate("Cutelyst::ValidatorMax", "The text must be shorter than %1 characters.").arg(max);
         } else {
-            error = validationDataError();
+            error = c->translate("Cutelyst::ValidatorMax", "The value must be lower than %1.").arg(max);
         }
     } else {
-        if (d->type == QMetaType::Int || d->type == QMetaType::UInt || d->type == QMetaType::Float) {
-            error = QStringLiteral("The value of the “%1” field has to be lower than or equal to %2.").arg(label(), max);
-        } else if (d->type == QMetaType::QString) {
-            error = QStringLiteral("The length of the “%1” field has to be shorter than or equal to %2.").arg(label(), max);
+        if (d->type == QMetaType::QString) {
+            error = c->translate("Cutelyst::ValidatorMax", "The text in the “%1“ field must be shorter than %2 characters.").arg(_label, max);
         } else {
-            error = validationDataError();
+            error = c->translate("Cutelyst::ValidatorMax", "The value in the “%1” field must be lower than %2.").arg(_label, max);
         }
     }
 
     return error;
 }
 
-void ValidatorMax::setType(QMetaType::Type type)
+QString ValidatorMax::genericValidationDataError(Context *c, const QVariant &errorData) const
 {
-    Q_D(ValidatorMax);
-    d->type = type;
+    QString error;
+
+    int field = errorData.toInt();
+    const QString _label = label(c);
+
+    if (field == 0) {
+        Q_D(const ValidatorMax);
+        if (_label.isEmpty()) {
+            error = c->translate("Cutelyst::ValidatorMax", "The comparison type with ID %1 is not supported.").arg(static_cast<int>(d->type));
+        } else {
+            error = c->translate("Cutelyst::ValidatorMax", "The comparison type with ID %1 for the “%2” field is not supported.").arg(QString::number(static_cast<int>(d->type)), _label);
+        }
+    } else if (field == 1) {
+        if (_label.isEmpty()) {
+            error = c->translate("Cutelyst::ValidatorMax", "The maximum comparison value is not valid.");
+        } else {
+            error = c->translate("Cutelyst::ValidatorMax", "The maximum comparison value for the “%1” field is not valid.").arg(_label);
+        }
+    }
+
+    return error;
 }
 
-void ValidatorMax::setMax(double max)
+QString ValidatorMax::genericParsingError(Context *c, const QVariant &errorData) const
 {
-    Q_D(ValidatorMax);
-    d->max = max;
+    QString error;
+    Q_UNUSED(errorData)
+    Q_D(const ValidatorMax);
+
+    const QString _label = label(c);
+    if ((d->type == QMetaType::Float) || (d->type == QMetaType::Double)) {
+        if (_label.isEmpty()) {
+            error = c->translate("Cutelyst::ValidatorMax", "Failed to parse the input value into a floating point number.");
+        } else {
+            error = c->translate("Cutelyst::ValidatorMax", "Failed to parse the input value for the “%1” field into a floating point number.").arg(_label);
+        }
+    } else {
+        if (_label.isEmpty()) {
+            error = c->translate("Cutelyst::ValidatorMax", "Failed to parse the input value into an integer number.");
+        } else {
+            error = c->translate("Cutelyst::ValidatorMax", "Failed to parse the input value for the “%1” field into an integer number.").arg(_label);
+        }
+    }
+
+    return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatormax.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatormax.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,24 +26,26 @@ namespace Cutelyst {
 class ValidatorMaxPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if a value is not bigger or longer than a maximum value.
  *
  * This works for floating point, integer and QString types, where for numeric types it will check the value itself while for QString it will check the string length.
  * Use \a max to define the maximum value and \a type to set the type to check against. \a max will internally converted into a comparative value (qlonglong for QMetaType::Int,
- * qulonglong for QMetaType::UInt and int for QMetaType::QString. Allowed types for the \a type specifier are QMetaType::Int, QMetaType::UInt, QMetaType::Float and QMetaType::QString.
- * Any other type will lead to an validation data error. These types can be seen as base types:
+ * qulonglong for QMetaType::UInt and int for QMetaType::QString. Allowed types for the \a type specifier are all numeric types and QMetaType::QString.
+ * Any other type will result in a validation data error.
  *
- * \li QMetaType::UInt for all unsigned integer types, converted into qulonglong
- * \li QMetaType::Int for all signed integer types, converted into qlonglong
- * \li QMetaType::Float for all floating point types, converted into double
- * \li QMetaType::QString for what the name says, converted into int
+ * If you set a string to the \a max value, this will neither be interpreted as a number nor as string length, but will
+ * be used to get the comparison number value from the \link Context::stash() stash\endlink.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Conversion of numeric input values is performed in the \c 'C' locale.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
+ *
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorMin, ValidatorSize, ValidatorBetween
  */
@@ -54,42 +56,44 @@ public:
      * \brief Constructs a new max validator.
      * \param field         Name of the input field to validate.
      * \param type          The type to compare.
-     * \param max           Maximum value.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param max           Maximum value. Will be converted into comparable value. If it is a QString, it will try to get the comparison value from the stash.
+     * \param messages      Custom error message if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorMax(const QString &field, QMetaType::Type type, double max, const QString &label = QString(), const QString &customError = QString());
+    ValidatorMax(const QString &field, QMetaType::Type type, const QVariant &max, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the max validator.
      */
     ~ValidatorMax();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the type to validate.
-     */
-    void setType(QMetaType::Type type);
-
-    /*!
-     * \brief Sets the maximum value.
-     */
-    void setMax(double max);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input parameter value
+     * converted into the \a type specified in the constructor.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorMax object with the given private class.
+     * \brief Returns a generic error message.
+     * \param c         The current context, used for translations.
+     * \param errorData Will contain a QVariantMap with "val" containing the value and "max" containing the comparison value.
      */
-    ValidatorMax(ValidatorMaxPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
+
+    /*!
+     * \brief Returns a generic error message for validation data errors.
+     * \param c         The current context, used for translations.
+     * \param errorData Will contain either 1 if comparison value is invalid or 0 if the \a type is not supported.
+     */
+    QString genericValidationDataError(Context *c, const QVariant &errorData) const override;
+
+    /*!
+     * \brief Returns a generic error message for input value parsing errors.
+     */
+    QString genericParsingError(Context *c, const QVariant &errorData) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorMax)

--- a/Cutelyst/Plugins/Utils/Validator/validatormax_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatormax_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,14 +26,14 @@ namespace Cutelyst {
 class ValidatorMaxPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorMaxPrivate(const QString &f, QMetaType::Type t, double m, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorMaxPrivate(const QString &f, QMetaType::Type t, const QVariant &m, const ValidatorMessages &msgs, const QString &dvk) :
+        ValidatorRulePrivate(f, msgs, dvk),
         type(t),
         max(m)
     {}
 
     QMetaType::Type type;
-    double max;
+    QVariant max;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatormin.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatormin.cpp
@@ -116,7 +116,7 @@ ValidatorReturnType ValidatorMin::validate(Context *c, const ParamsMultiMap &par
                                                                   {QStringLiteral("val"), val},
                                                                   {QStringLiteral("min"), min}
                                                               });
-                        qCDebug(C_VALIDATOR, "ValidatorMin: Validation failed for field %s in %s::%s: %f is not greater than %f and %f.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), val, min);
+                        qCDebug(C_VALIDATOR, "ValidatorMin: Validation failed for field %s in %s::%s: %f is not greater than %f.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), val, min);
                     } else {
                         valid = true;
                     }

--- a/Cutelyst/Plugins/Utils/Validator/validatormin.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatormin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,24 +26,26 @@ namespace Cutelyst {
 class ValidatorMinPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if a value is not smaller or shorter than a maximum value.
  *
  * This works for floating point, integer and QString types, where for numeric types it will check the value itself while for QString it will check the string length.
  * Use \a min to define the minimum value and \a type to set the type to check against. \a min will internally converted into a comparative value (qlonglong for QMetaType::Int,
- * qulonglong for QMetaType::UInt and int for QMetaType::QString. Allowed types for the \a type specifier are QMetaType::Int, QMetaType::UInt, QMetaType::Float and QMetaType::QString.
- * Any other type will lead to an validation data error. These types can be seen as base types:
+ * qulonglong for QMetaType::UInt and int for QMetaType::QString. Allowed types for the \a type specifier are all numeric types and QMetaType::QString.
+ * Any other type will result in a validation data error.
  *
- * \li QMetaType::UInt for all unsigned integer types, converted into qulonglong
- * \li QMetaType::Int for all signed integer types, converted into qlonglong
- * \li QMetaType::Float for all floating point types, converted into double
- * \li QMetaType::QString for what the name says, converted into int
+ * If you set a string to the \a min value, this will neither be interpreted as a number nor as string length, but will
+ * be used to get the comparison number value from the \link Context::stash() stash\endlink.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Conversion of numeric input values is performed in the \c 'C' locale.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
+ *
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorMax, ValidatorBetween, ValidatorSize
  */
@@ -54,42 +56,44 @@ public:
      * \brief Constructs a new min validator.
      * \param field         Name of the input field to validate.
      * \param type          The type to compare.
-     * \param min           Minimum value.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param min           Minimum value. Will be converted into comparable value. If it is a QString, it will try to get the comparison value from the stash.
+     * \param messages      Custom error message if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorMin(const QString &field, QMetaType::Type type, double min, const QString &label = QString(), const QString &customError = QString());
+    ValidatorMin(const QString &field, QMetaType::Type type, const QVariant &min, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the min validator.
      */
     ~ValidatorMin();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the type to validate.
-     */
-    void setType(QMetaType::Type type);
-
-    /*!
-     * \brief Sets the maximum value.
-     */
-    void setMin(double min);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input parameter value
+     * converted into the \a type specified in the constructor.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorMin object with the given private class.
+     * \brief Returns a generic error message.
+     * \param c         The current context, used for translations.
+     * \param errorData Will contain a QVariantMap with "val" containing the value and "min" containing the comparison value.
      */
-    ValidatorMin(ValidatorMinPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
+
+    /*!
+     * \brief Returns a generic error message for validation data errors.
+     * \param c         The current context, used for translations.
+     * \param errorData Will contain either -1 if comparison value is invalid or 0 if the \a type is not supported.
+     */
+    QString genericValidationDataError(Context *c, const QVariant &errorData) const override;
+
+    /*!
+     * \brief Returns a generic error message for input value parsing errors.
+     */
+    QString genericParsingError(Context *c, const QVariant &errorData) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorMin)

--- a/Cutelyst/Plugins/Utils/Validator/validatormin_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatormin_p.h
@@ -26,14 +26,14 @@ namespace Cutelyst {
 class ValidatorMinPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorMinPrivate(const QString &f, QMetaType::Type t, double m, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorMinPrivate(const QString &f, QMetaType::Type t, const QVariant &m, const ValidatorMessages &msgs, const QString &dvk) :
+        ValidatorRulePrivate(f, msgs, dvk),
         type(t),
         min(m)
     {}
 
     QMetaType::Type type;
-    double min;
+    QVariant min;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatornotin.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatornotin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,16 +27,18 @@ namespace Cutelyst {
 class ValidatorNotInPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if the field value is not one from a list of values.
  *
  * This validator checks if the value of the \a field is not one from a list of \a values.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorIn
  */
@@ -47,36 +49,35 @@ public:
      * \brief Constructs a new not in validator.
      * \param field         Name of the input field to validate.
      * \param values        List of values to compare against.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param cs            Case sensitivity when comparing the values.
+     * \param messages      Custom error message if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorNotIn(const QString &field, const QStringList &values, const QString &label = QString(), const QString &customError = QString());
+    ValidatorNotIn(const QString &field, const QStringList &values, Qt::CaseSensitivity cs = Qt::CaseSensitive, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the validator.
      */
     ~ValidatorNotIn();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the values to compare against.
-     */
-    void setValues(const QStringList &values);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorNotIn object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorNotIn(ValidatorNotInPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
+
+    /*!
+     * \brief Returns a generic error messages if the list of comparison values is empty.
+     */
+    QString genericValidationDataError(Context *c, const QVariant &errorData) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorNotIn)

--- a/Cutelyst/Plugins/Utils/Validator/validatornotin_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatornotin_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,11 +26,13 @@ namespace Cutelyst {
 class ValidatorNotInPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorNotInPrivate(const QString &f, const QStringList &v, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorNotInPrivate(const QString &f, const QStringList &v, Qt::CaseSensitivity s, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
+        cs(s),
         values(v)
     {}
 
+    Qt::CaseSensitivity cs;
     QStringList values;
 };
     

--- a/Cutelyst/Plugins/Utils/Validator/validatornumeric.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatornumeric.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,17 +26,22 @@ namespace Cutelyst {
 class ValidatorNumericPrivate;
 
 /*!
- * \brief Checks if the field under validation cold be casted into a numeric value.
+ * \ingroup plugins-utils-validator-rules
+ * \brief Checks if the field under validation could be casted into a numeric value.
  *
  * Checks for signed and unsigned integers as well as floats (also with exponential e) together with minus signs in the input \a field. *
- * Valid values are in format 3, -3.54, 8.89234e12 etc.
+ * Valid values are in format 3, -3.54, 8.89234e12 etc. Internally this will simply try to convert the parameter value from
+ * a QString into a double.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Conversion of numeric input values is performed in the \c 'C' locale.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
+ *
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorInteger
  */
@@ -46,31 +51,29 @@ public:
     /*!
      * \brief Constructs a new numeric validator.
      * \param field         Name of the input field to validate.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param messages      Custom error message if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorNumeric(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorNumeric(const QString &field, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the numeric validator.
      */
     ~ValidatorNumeric();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value converted into a double.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorNumeric object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorNumeric(ValidatorNumericPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorNumeric)

--- a/Cutelyst/Plugins/Utils/Validator/validatornumeric_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatornumeric_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorNumericPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorNumericPrivate(const QString &f, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e)
+    ValidatorNumericPrivate(const QString &f,const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk)
     {}
 };
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorpresent.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpresent.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,13 +20,8 @@
 
 using namespace Cutelyst;
 
-ValidatorPresent::ValidatorPresent(const QString &field, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorPresentPrivate(field, label, customError))
-{
-}
-
-ValidatorPresent::ValidatorPresent(ValidatorPresentPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorPresent::ValidatorPresent(const QString &field, const Cutelyst::ValidatorMessages &messages) :
+    ValidatorRule(*new ValidatorPresentPrivate(field, messages))
 {
 }
 
@@ -34,24 +29,29 @@ ValidatorPresent::~ValidatorPresent()
 {
 }
 
-QString ValidatorPresent::validate() const
+ValidatorReturnType ValidatorPresent::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
-    if (!parameters().contains(field())) {
-        result = validationError();
+    if (!params.contains(field())) {
+        result.errorMessage = validationError(c);
+        qCDebug(C_VALIDATOR, "ValidatorPresent: Validation failed for field %s at %s::%s: field was not found in the input data", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+    } else {
+        result.value.setValue<QString>(value(params));
     }
 
     return result;
 }
 
-QString ValidatorPresent::genericValidationError() const
+QString ValidatorPresent::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
-    if (label().isEmpty()) {
-        error = QStringLiteral("Has to be present in input data.");
+    Q_UNUSED(errorData)
+    const QString _label = label(c);
+    if (_label.isEmpty()) {
+        error = c->translate("Cutelyst::ValidatorPresent", "Has to be present in input data.");
     } else {
-        error = QStringLiteral("The “%1” field was not found in the input data.").arg(label());
+        error =  c->translate("Cutelyst::ValidatorPresent", "The “%1” field was not found in the input data.").arg(_label);
     }
     return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorpresent.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpresent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,12 +26,13 @@ namespace Cutelyst {
 class ValidatorPresentPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief The field under validation must be present in input data but can be empty.
  *
  * This validator checks if the \a field is present in the input data, but not if it contains any content.
  * If you want to check the fields presence and require it to have content, use one of the \link ValidatorRequired required validators \endlink.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorFilled, ValidatorRequired
  */
@@ -41,31 +42,28 @@ public:
     /*!
      * \brief Constructs a new present validator.
      * \param field         Name of the input field to validate.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param messages      Custom error message if validation fails.
      */
-    ValidatorPresent(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorPresent(const QString &field, const ValidatorMessages &messages = ValidatorMessages());
     
     /*!
      * \brief Deconstructs the present validator.
      */
     ~ValidatorPresent();
-    
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-    
+        
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorPresent object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorPresent(ValidatorPresentPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorPresent)

--- a/Cutelyst/Plugins/Utils/Validator/validatorpresent_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpresent_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorPresentPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorPresentPrivate(const QString &f, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e)
+    ValidatorPresentPrivate(const QString &f, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString())
     {}
 };
     

--- a/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,13 +20,8 @@
 
 using namespace Cutelyst;
 
-ValidatorRegularExpression::ValidatorRegularExpression(const QString &field, const QRegularExpression &regex, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorRegularExpressionPrivate(field, regex, label, customError))
-{
-}
-
-ValidatorRegularExpression::ValidatorRegularExpression(ValidatorRegularExpressionPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorRegularExpression::ValidatorRegularExpression(const QString &field, const QRegularExpression &regex, const ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(*new ValidatorRegularExpressionPrivate(field, regex, messages, defValKey))
 {
 }
 
@@ -34,32 +29,42 @@ ValidatorRegularExpression::~ValidatorRegularExpression()
 {
 }
 
-QString ValidatorRegularExpression::validate() const
+ValidatorReturnType ValidatorRegularExpression::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
     Q_D(const ValidatorRegularExpression);
 
-    if (!value().isEmpty() && !value().contains(d->regex)) {
-        result = validationError();
+    const QString v = value(params);
+
+    if (d->regex.isValid()) {
+        if (!v.isEmpty()) {
+            if (v.contains(d->regex)) {
+                result.value.setValue<QString>(v);
+            } else {
+                result.errorMessage = validationError(c);
+                qCDebug(C_VALIDATOR, "ValidatorRegularExpression: Validation failed for field %s at %s::%s because value does not match the following regular expression: %s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), qPrintable(d->regex.pattern()));
+            }
+        } else {
+            defaultValue(c, &result, "ValidatorRegularExpression");
+        }
+    } else {
+        result.errorMessage = validationDataError(c);
+        qCWarning(C_VALIDATOR, "ValidatorRegularExpression: the regular expression for the field %s at %s::%s is not valid: %s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), qPrintable(d->regex.errorString()));
     }
 
     return result;
 }
 
-QString ValidatorRegularExpression::genericValidationError() const
+QString ValidatorRegularExpression::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
-    if (label().isEmpty()) {
-        error = QStringLiteral("Does not match desired format.");
+    Q_UNUSED(errorData);
+    const QString _label = label(c);
+    if (_label.isEmpty()) {
+        error = c->translate("Cutelyst::ValidatorRegularExpression", "Does not match the desired format.");
     } else {
-        error = QStringLiteral("The “%1” field does not match the desired format.").arg(label());
+        error = c->translate("Cutelyst::ValidatorRegularExpression", "The “%1” field does not match the desired format.").arg(_label);
     }
     return error;
-}
-
-void ValidatorRegularExpression::setRegex(const QRegularExpression &regex)
-{
-    Q_D(ValidatorRegularExpression);
-    d->regex = regex;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorregularexpression.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,16 +27,18 @@ namespace Cutelyst {
 class ValidatorRegularExpressionPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief The field under validation must match the given regular expression.
  *
  * Checks if the \a regex matches the content of the \a field.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  */
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorRegularExpression : public ValidatorRule
 {
@@ -45,36 +47,29 @@ public:
      * \brief Constructs a new regex validator.
      * \param field         Name of the input field to validate.
      * \param regex         The regular expression to check against.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom errror message if validation fails.
+     * \param messages      Custom error message if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorRegularExpression(const QString &field, const QRegularExpression &regex, const QString &label = QString(), const QString &customError = QString());
+    ValidatorRegularExpression(const QString &field, const QRegularExpression &regex, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the regex validator.
      */
     ~ValidatorRegularExpression();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the regular expression to check.
-     */
-    void setRegex(const QRegularExpression &regex);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorRegularExpression object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorRegularExpression(ValidatorRegularExpressionPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorRegularExpression)

--- a/Cutelyst/Plugins/Utils/Validator/validatorregularexpression_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorregularexpression_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorRegularExpressionPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorRegularExpressionPrivate(const QString &f, const QRegularExpression &r, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorRegularExpressionPrivate(const QString &f, const QRegularExpression &r, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
         regex(r)
     {}
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequired.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequired.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,13 +20,8 @@
 
 using namespace Cutelyst;
 
-ValidatorRequired::ValidatorRequired(const QString &field, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorRequiredPrivate(field, label, customError))
-{
-}
-
-ValidatorRequired::ValidatorRequired(ValidatorRequiredPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorRequired::ValidatorRequired(const QString &field, const Cutelyst::ValidatorMessages &messages) :
+    ValidatorRule(*new ValidatorRequiredPrivate(field, messages))
 {
 }
 
@@ -34,24 +29,29 @@ ValidatorRequired::~ValidatorRequired()
 {
 }
 
-QString ValidatorRequired::validate() const
+ValidatorReturnType ValidatorRequired::validate(Cutelyst::Context *c, const Cutelyst::ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
-    if (value().isEmpty()) {
-        result = validationError();
+    const QString v = value(params);
+    if (Q_LIKELY(!v.isEmpty())) {
+        result.value.setValue<QString>(v);
+    } else {
+        result.errorMessage = validationError(c);
     }
 
     return result;
 }
 
-QString ValidatorRequired::genericValidationError() const
+QString ValidatorRequired::genericValidationError(Cutelyst::Context *c, const QVariant &errorData) const
 {
     QString error;
-    if (label().isEmpty()) {
-        error = QStringLiteral("This is required.");
+    Q_UNUSED(errorData);
+    const QString _label = label(c);
+    if (_label.isEmpty()) {
+        error = c->translate("Cutelyst::ValidatorRequired", "This is required.");
     } else {
-        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+        error = c->translate("Cutelyst::ValidatorRequired", "The “%1” field is required.").arg(_label);
     }
     return error;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequired.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequired.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,15 +26,16 @@ namespace Cutelyst {
 class ValidatorRequiredPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if a field is available and not empty.
  *
  * The \a field under validation must be present in the input data and not empty.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. So, fields that only contain whitespaces
- * will be treated as empty and are invalid.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * So, fields that only contain whitespaces will be treated as empty and are invalid.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorRequiredIf, ValidatorRequiredUnless, ValidatorRequiredWith, ValidatorRequiredWithAll, ValidatorRequiredWithout, ValidatorRequiredWithoutAll
  */
@@ -43,32 +44,29 @@ class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorRequired : public Validato
 public:
     /*!
      * \brief Constructs a new required validator.
-     * \param field         Name of the input field to validate.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     *
+     * \param field     Name of the input field that is required.
+     * \param messages  Custom error message if validation fails.
      */
-    ValidatorRequired(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorRequired(const QString &field, const ValidatorMessages &messages = ValidatorMessages());
 
     /*!
      * \brief Deconstructs the required validator.
      */
     ~ValidatorRequired();
 
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
 protected:
+    /*!
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input parameter value as QString.
+     */
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
      * \brief Returns a generic error message.
      */
-    QString genericValidationError() const override;
-
-    /*!
-     * Constructs a new ValidatorRequired object with the given private class.
-     */
-    ValidatorRequired(ValidatorRequiredPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
 
 private:
     Q_DECLARE_PRIVATE(ValidatorRequired)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequired_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequired_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorRequiredPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorRequiredPrivate(const QString &f, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e)
+    ValidatorRequiredPrivate(const QString &f, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString())
     {}
 };
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,13 +20,8 @@
 
 using namespace Cutelyst;
 
-ValidatorRequiredIf::ValidatorRequiredIf(const QString &field, const QString &otherField, const QStringList &otherValues, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorRequiredIfPrivate(field, otherField, otherValues, label, customError))
-{
-}
-
-ValidatorRequiredIf::ValidatorRequiredIf(ValidatorRequiredIfPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorRequiredIf::ValidatorRequiredIf(const QString &field, const QString &otherField, const QStringList &otherValues, const Cutelyst::ValidatorMessages &messages) :
+    ValidatorRule(*new ValidatorRequiredIfPrivate(field, otherField, otherValues, messages))
 {
 }
 
@@ -34,40 +29,44 @@ ValidatorRequiredIf::~ValidatorRequiredIf()
 {
 }
 
-QString ValidatorRequiredIf::validate() const
+ValidatorReturnType ValidatorRequiredIf::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
     Q_D(const ValidatorRequiredIf);
 
     if (d->otherField.isEmpty() || d->otherValues.empty()) {
-        result = validationDataError();
-    } else if (d->otherValues.contains(d->parameters.value(d->otherField)) && value().isEmpty()) {
-        result = validationError();
+        result.errorMessage = validationDataError(c);
+        qCWarning(C_VALIDATOR, "ValidatorRequiredIf: invalid validation data for field %s at %s::%s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+    } else {
+        const QString v = value(params);
+        const QString ov = trimBefore() ? params.value(d->otherField).trimmed() : params.value(d->otherField);
+        if (d->otherValues.contains(ov)) {
+            if (v.isEmpty()) {
+                result.errorMessage = validationError(c);
+                qCDebug(C_VALIDATOR, "ValidatorRequiredIf: Validation failed for field %s at %s::%s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            } else {
+                result.value.setValue<QString>(v);
+            }
+        } else {
+            if (!v.isEmpty()) {
+                result.value.setValue<QString>(v);
+            }
+        }
     }
 
     return result;
 }
 
-QString ValidatorRequiredIf::genericValidationError() const
+QString ValidatorRequiredIf::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
-    if (label().isEmpty()) {
-        error = QStringLiteral("This is required.");
+    Q_UNUSED(errorData);
+    const QString _label = label(c);
+    if (_label.isEmpty()) {
+        error = c->translate("Cutelyst::ValidatorRequiredIf", "This is required.");
     } else {
-        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+        error = c->translate("Cutelyst::ValidatorRequiredIf", "You must fill in the “%1” field.").arg(_label);
     }
     return error;
-}
-
-void ValidatorRequiredIf::setOtherField(const QString &otherField)
-{
-    Q_D(ValidatorRequiredIf);
-    d->otherField = otherField;
-}
-
-void ValidatorRequiredIf::setOtherValues(const QStringList &otherValues)
-{
-    Q_D(ValidatorRequiredIf);
-    d->otherValues = otherValues;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredif.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,16 +27,17 @@ namespace Cutelyst {
 class ValidatorRequiredIfPrivate;
 
 /*!
- * \brief The field under validation must be present and not empty if the other field is equal to any value in the list.
+ * \ingroup plugins-utils-validator-rules
+ * \brief The field under validation must be present and not empty if the other field is equal to any value in a list.
  *
  * If the other field specified as \a otherField contains \b any of the values defined in the \a otherValues list, the
- * field under validation must be present and not empty.
+ * field under validation must be present and not empty. This validator is the opposite of ValidatorRequiredUnless.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. So, fields that only contain whitespaces
- * will be treated as empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation. So, fields that only contain
+ * whitespaces will be treated as empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorRequired, ValidatorRequiredUnless, ValidatorRequiredWith, ValidatorRequiredWithAll, ValidatorRequiredWithout, ValidatorRequiredWithoutAll
  */
@@ -47,43 +48,29 @@ public:
      * \brief Constructs a new required if validator.
      * \param field         Name of the input field to validate.
      * \param otherField    Name of the other input field to validate.
-     * \param otherValues   Values in the other field from which one must match the field content to require the main field.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param otherValues   Values in the other field from which one must match the other field's content to require the main field.
+     * \param messages      Custom error messages if validation fails.
      */
-    ValidatorRequiredIf(const QString &field, const QString &otherField, const QStringList &otherValues, const QString &label = QString(), const QString &customError = QString());
+    ValidatorRequiredIf(const QString &field, const QString &otherField, const QStringList &otherValues, const ValidatorMessages &messages = ValidatorMessages());
     
     /*!
      * \brief Deconstructs the required if validator.
      */
     ~ValidatorRequiredIf();
-    
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the name of the other field.
-     */
-    void setOtherField(const QString &otherField);
-
-    /*!
-     * \brief Sets the values that have to be in the other field.
-     */
-    void setOtherValues(const QStringList &otherValues);
-
-    
+       
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorRequiredIf object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorRequiredIf(ValidatorRequiredIfPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorRequiredIf)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredif_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredif_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorRequiredIfPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorRequiredIfPrivate(const QString &f, const QString &of, const QStringList &ov, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorRequiredIfPrivate(const QString &f, const QString &of, const QStringList &ov, const Cutelyst::ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString()),
         otherField(of),
         otherValues(ov)
     {}

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,16 +26,17 @@ namespace Cutelyst {
 class ValidatorRequiredUnlessPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief The field under validation must be present and not empty unless the other field is equal to any value in the list.
  *
- * If the other field specified as \a otherField does \b not conaint \b any of the values specified in the \a otherValues list, the
- * \a field under validation must be present and not empty.
+ * If the other field specified as \a otherField does \b not contain \b any of the values specified in the \a otherValues list, the
+ * \a field under validation must be present and not empty. This validator is the opposite of ValidatorRequiredIf.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. So, fields that only contain whitespaces
- * will be treated as empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation. So, fields that only contain
+ * whitespaces will be treated as empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorRequired, ValidatorRequiredIf, ValidatorRequiredWith, ValidatorRequiredWithAll, ValidatorRequiredWithout, ValidatorRequiredWithoutAll
  */
@@ -47,41 +48,28 @@ public:
      * \param field         Name of the input field to validate.
      * \param otherField    Name of the other input field to validate.
      * \param otherValues   List of values that are not allowed to be in the other field to require the main field.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param messages      Custom error messages if validation fails.
      */
-    ValidatorRequiredUnless(const QString &field, const QString &otherField, const QStringList &otherValues, const QString &label = QString(), const QString &customError = QString());
+    ValidatorRequiredUnless(const QString &field, const QString &otherField, const QStringList &otherValues, const ValidatorMessages &messages = ValidatorMessages());
     
     /*!
      * \brief Deconstructs the required unless validator.
      */
     ~ValidatorRequiredUnless();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the name of the other field.
-     */
-    void setOtherField(const QString &otherField);
-
-    /*!
-     * \brief Sets the comparative values for the other field.
-     */
-    void setOtherValues(const QStringList &otherValues);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorRequiredUnless object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorRequiredUnless(ValidatorRequiredUnlessPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorRequiredUnless)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredunless_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorRequiredUnlessPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorRequiredUnlessPrivate(const QString &f, const QString &of, const QStringList &ov, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorRequiredUnlessPrivate(const QString &f, const QString &of, const QStringList &ov, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString()),
         otherField(of),
         otherValues(ov)
     {}

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,13 +20,8 @@
 
 using namespace Cutelyst;
 
-ValidatorRequiredWith::ValidatorRequiredWith(const QString &field, const QStringList &otherFields, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorRequiredWithPrivate(field, otherFields, label, customError))
-{
-}
-
-ValidatorRequiredWith::ValidatorRequiredWith(ValidatorRequiredWithPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorRequiredWith::ValidatorRequiredWith(const QString &field, const QStringList &otherFields, const Cutelyst::ValidatorMessages &messages) :
+    ValidatorRule(*new ValidatorRequiredWithPrivate(field, otherFields, messages))
 {
 }
 
@@ -34,47 +29,54 @@ ValidatorRequiredWith::~ValidatorRequiredWith()
 {
 }
 
-QString ValidatorRequiredWith::validate() const
+ValidatorReturnType ValidatorRequiredWith::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
     Q_D(const ValidatorRequiredWith);
 
     if (d->otherFields.empty()) {
-        result = validationDataError();
+        result.errorMessage = validationDataError(c);
+        qCWarning(C_VALIDATOR, "ValidatorRequiredWith: invalid validation data for field %s at %s::%s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
     } else {
         bool containsOther = false;
+        const QString v = value(params);
 
         const QStringList ofc = d->otherFields;
 
         for (const QString &other : ofc)  {
-            if (parameters().contains(other)) {
+            if (params.contains(other)) {
                 containsOther = true;
                 break;
             }
         }
 
-        if (containsOther && value().isEmpty()) {
-            result = validationError();
+        if (containsOther) {
+            if (!v.isEmpty()) {
+                result.value.setValue<QString>(v);
+            } else {
+                result.errorMessage = validationError(c);
+                qCDebug(C_VALIDATOR, "ValidatorRequiredWith: Validation failed for field %s at %s::%s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            }
+        } else {
+            if (!v.isEmpty()) {
+                result.value.setValue<QString>(v);
+            }
         }
     }
 
     return result;
 }
 
-QString ValidatorRequiredWith::genericValidationError() const
+QString ValidatorRequiredWith::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
-    if (label().isEmpty()) {
-        error = QStringLiteral("This is required.");
+    Q_UNUSED(errorData);
+    const QString _label = label(c);
+    if (_label.isEmpty()) {
+        error = c->translate("Cutelyst::ValidatorRequiredWith", "This is required.");
     } else {
-        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+        error = c->translate("Cutelyst::ValidatorRequiredWith", "You must fill in the “%1” field.").arg(_label);
     }
     return error;
-}
-
-void ValidatorRequiredWith::setOtherFields(const QStringList &otherFields)
-{
-    Q_D(ValidatorRequiredWith);
-    d->otherFields = otherFields;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -28,16 +28,17 @@ class ValidatorRequiredWithPrivate;
 
 
 /*!
- * \brief The field under validation must be present and not empty only if any of the other specified fields are present.
+ * \ingroup plugins-utils-validator-rules
+ * \brief The field under validation must be present and not empty only if any of the other specified fields is present.
  *
  * If \b any of the fields defined in the \a otherFields list is present in the input data, the \a field under validation must
  * be present and not empty. For the other fields only their presence in the input data will be checked, not their content.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. So, fields that only contain whitespaces
- * will be treated as empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation. So, fields that only contain
+ * whitespaces will be treated as empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorRequired, ValidatorRequiredIf, ValidatorRequiredUnless, ValidatorRequiredWithAll, ValidatorRequiredWithout, ValidatorRequiredWithoutAll
  */
@@ -48,36 +49,28 @@ public:
      * \brief Constructs a new required with validator.
      * \param field         Name of the input field to validate.
      * \param otherFields   List of other fields from which one must be present in the input data to require the field.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param messages      Custom error messages if validation fails.
      */
-    ValidatorRequiredWith(const QString &field, const QStringList &otherFields, const QString &label = QString(), const QString &customError = QString());
+    ValidatorRequiredWith(const QString &field, const QStringList &otherFields, const ValidatorMessages &messages = ValidatorMessages());
     
     /*!
      * \brief Deconstructs the required with validator.
      */
     ~ValidatorRequiredWith();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the list of other fields.
-     */
-    void setOtherFields(const QStringList &otherFields);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorRequiredWith object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorRequiredWith(ValidatorRequiredWithPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorRequiredWith)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwith_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorRequiredWithPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorRequiredWithPrivate(const QString &f, const QStringList &o, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorRequiredWithPrivate(const QString &f, const QStringList &o, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString()),
         otherFields(o)
     {}
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,16 +27,17 @@ namespace Cutelyst {
 class ValidatorRequiredWithAllPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief The field under validation must be present and not empty only if all of the other specified fields are present.
  *
  * If \b all of the fields defined in the \a otherFields list are present in the input data, the \a field under validation must
  * be present and not empty. For the other fields only their presence will be checked, not their content.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. So, fields that only contain whitespaces
- * will be treated as empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation. So, fields that only contain
+ * whitespaces will be treated as empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorRequired, ValidatorRequiredIf, ValidatorRequiredUnless, ValidatorRequiredWith, ValidatorRequiredWithout, ValidatorRequiredWithoutAll
  */
@@ -47,36 +48,28 @@ public:
      * \brief Constructs a new required with all validator.
      * \param field         Name of the input field to validate.
      * \param otherFields   List of fields that mus all be present in the input data to require the field.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param messages      Custom error messages if validation fails.
      */
-    ValidatorRequiredWithAll(const QString &field, const QStringList &otherFields, const QString &label = QString(), const QString &customError = QString());
+    ValidatorRequiredWithAll(const QString &field, const QStringList &otherFields, const ValidatorMessages &messages = ValidatorMessages());
     
     /*!
      * \brief Deconstructs the required with all validator.
      */
     ~ValidatorRequiredWithAll();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the list of other fields.
-     */
-    void setOtherFields(const QStringList &otherFields);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorRequiredWithAll object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorRequiredWithAll(ValidatorRequiredWithAllPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorRequiredWithAll)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithall_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorRequiredWithAllPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorRequiredWithAllPrivate(const QString &f, const QStringList &of, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorRequiredWithAllPrivate(const QString &f, const QStringList &of, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString()),
         otherFields(of)
     {}
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,13 +20,8 @@
 
 using namespace Cutelyst;
 
-ValidatorRequiredWithout::ValidatorRequiredWithout(const QString &field, const QStringList &otherFields, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorRequiredWithoutPrivate(field, otherFields, label, customError))
-{
-}
-
-ValidatorRequiredWithout::ValidatorRequiredWithout(ValidatorRequiredWithoutPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorRequiredWithout::ValidatorRequiredWithout(const QString &field, const QStringList &otherFields, const Cutelyst::ValidatorMessages &messages) :
+    ValidatorRule(*new ValidatorRequiredWithoutPrivate(field, otherFields, messages))
 {
 }
 
@@ -34,14 +29,15 @@ ValidatorRequiredWithout::~ValidatorRequiredWithout()
 {
 }
 
-QString ValidatorRequiredWithout::validate() const
+ValidatorReturnType ValidatorRequiredWithout::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
     Q_D(const ValidatorRequiredWithout);
 
     if (d->otherFields.isEmpty()) {
-        result = validationDataError();
+        result.errorMessage = validationDataError(c);
+        qCWarning(C_VALIDATOR, "ValidatorRequiredWithout: invalid validation data for field %s at %s::%s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
     } else {
 
         bool otherMissing = false;
@@ -49,33 +45,41 @@ QString ValidatorRequiredWithout::validate() const
         const QStringList ofc = d->otherFields;
 
         for (const QString &other : ofc) {
-            if (!d->parameters.contains(other)) {
+            if (!params.contains(other)) {
                 otherMissing = true;
                 break;
             }
         }
 
-        if (otherMissing && value().isEmpty()) {
-            result = validationError();
+        const QString v = value(params);
+
+        if (otherMissing) {
+            if (!v.isEmpty()) {
+                result.value.setValue<QString>(v);
+            } else {
+                result.errorMessage = validationError(c);
+                qCDebug(C_VALIDATOR, "ValidatorRequiredWithout: Validation failed for field %s at %s::%s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            }
+        } else {
+            if (!v.isEmpty()) {
+                result.value.setValue<QString>(v);
+            }
         }
     }
 
     return result;
 }
 
-QString ValidatorRequiredWithout::genericValidationError() const
+QString ValidatorRequiredWithout::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
-    if (label().isEmpty()) {
-        error = QStringLiteral("This is required.");
-    } else {
-        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+    Q_UNUSED(errorData)
+    const QString _label = label(c);
+    if (_label.isEmpty()) {
+        error = c->translate("Cutelyst::ValidatorRequiredWithout", "This is required.");
+    } else {        
+        error = c->translate("Cutelyst::ValidatorRequiredWithout", "You must fill in the “%1” field.").arg(_label);
     }
     return error;
 }
 
-void ValidatorRequiredWithout::setOtherFields(const QStringList &otherFields)
-{
-    Q_D(ValidatorRequiredWithout);
-    d->otherFields = otherFields;
-}

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,16 +27,17 @@ namespace Cutelyst {
 class ValidatorRequiredWithoutPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief The field under validation must be present and not empty only when any of the other specified fields are not present.
  *
  * If \b any of the fields in the \a otherFields list is \b not part of the input parameters, the \a field under validation must be present and not empty.
  * For the other fields it will only be checked if they are not present in the input parameters, not their content.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. So, fields that only contain whitespaces
- * will be treated as empty and are invalid.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation. So, fields that only contain
+ * whitespaces will be treated as empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorRequired, ValidatorRequiredIf, ValidatorRequiredUnless, ValidatorRequiredWith, ValidatorRequiredWithAll, ValidatorRequiredWithoutAll
  */
@@ -47,36 +48,28 @@ public:
      * \brief Constructs a new required with validator.
      * \param field         Name of the input field to validate.
      * \param otherFields   List of other fields from which one has to be missing in the input to require the field.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param messages      Custom error messages if validation fails.
      */
-    ValidatorRequiredWithout(const QString &field, const QStringList &otherFields, const QString &label = QString(), const QString &customError = QString());
+    ValidatorRequiredWithout(const QString &field, const QStringList &otherFields, const ValidatorMessages &messages = ValidatorMessages());
     
     /*!
      * \brief Deconstructs the required with validator.
      */
     ~ValidatorRequiredWithout();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the list of other fields.
-     */
-    void setOtherFields(const QStringList &otherFields);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorRequiredWithout object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorRequiredWithout(ValidatorRequiredWithoutPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorRequiredWithout)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithout_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorRequiredWithoutPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorRequiredWithoutPrivate(const QString &f, const QStringList &of, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorRequiredWithoutPrivate(const QString &f, const QStringList &of, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString()),
         otherFields(of)
     {}
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,13 +20,8 @@
 
 using namespace Cutelyst;
 
-ValidatorRequiredWithoutAll::ValidatorRequiredWithoutAll(const QString &field, const QStringList &otherFields, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorRequiredWithoutAllPrivate(field, otherFields, label, customError))
-{
-}
-
-ValidatorRequiredWithoutAll::ValidatorRequiredWithoutAll(ValidatorRequiredWithoutAllPrivate &dd) :
-    ValidatorRule(dd)
+ValidatorRequiredWithoutAll::ValidatorRequiredWithoutAll(const QString &field, const QStringList &otherFields, const Cutelyst::ValidatorMessages &messages) :
+    ValidatorRule(*new ValidatorRequiredWithoutAllPrivate(field, otherFields, messages))
 {
 }
 
@@ -34,14 +29,15 @@ ValidatorRequiredWithoutAll::~ValidatorRequiredWithoutAll()
 {
 }
 
-QString ValidatorRequiredWithoutAll::validate() const
+ValidatorReturnType ValidatorRequiredWithoutAll::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
     Q_D(const ValidatorRequiredWithoutAll);
 
     if (d->otherFields.empty()) {
-        result = validationDataError();
+        result.errorMessage = validationDataError(c);
+        qCWarning(C_VALIDATOR, "ValidatorRequiredWithoutAll: invalid validation data for field %s at %s::%s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
     } else {
 
         const QStringList ofc = d->otherFields;
@@ -49,33 +45,40 @@ QString ValidatorRequiredWithoutAll::validate() const
         bool withoutAll = true;
 
         for (const QString &other : ofc) {
-            if (d->parameters.contains(other)) {
+            if (params.contains(other)) {
                 withoutAll = false;
                 break;
             }
         }
 
-        if (withoutAll && value().isEmpty()) {
-            result = validationError();
+        const QString v = value(params);
+
+        if (withoutAll) {
+            if (!v.isEmpty()) {
+                result.value.setValue<QString>(v);
+            } else {
+                result.errorMessage = validationError(c);
+                qCDebug(C_VALIDATOR, "ValidatorRequiredWithoutAll: Validation failed for field %s at %s::%s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            }
+        } else {
+            if (!v.isEmpty()) {
+                result.value.setValue<QString>(v);
+            }
         }
     }
 
     return result;
 }
 
-QString ValidatorRequiredWithoutAll::genericValidationError() const
+QString ValidatorRequiredWithoutAll::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
-    if (label().isEmpty()) {
-        error = QStringLiteral("This is required.");
+    Q_UNUSED(errorData);
+    const QString _label = label(c);
+    if (_label.isEmpty()) {
+        error = c->translate("Cutelyst::ValidatorRequiredWithoutAll", "This is required.");
     } else {
-        error = QStringLiteral("You must fill in the “%1” field.").arg(label());
+        error = c->translate("Cutelyst::ValidatorRequiredWithoutAll", "You must fill in the “%1” field.").arg(_label);
     }
     return error;
-}
-
-void ValidatorRequiredWithoutAll::setOtherFields(const QStringList &otherFields)
-{
-    Q_D(ValidatorRequiredWithoutAll);
-    d->otherFields = otherFields;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall.h
@@ -27,16 +27,17 @@ namespace Cutelyst {
 class ValidatorRequiredWithoutAllPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief The field under validation must be present and not empty only when all of the other specified fields are not present.
  *
  * If \b all of the fields specified in the \a otherFields list are \b not present in the input data, the \a field under validation
  * must be present and not empty. For the other fields it will only be checked if they are not part of the input data, not their content.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. So, fields that only contain whitespaces
- * will be treated as empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation. So, fields that only contain
+ * whitespaces will be treated as empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorRequired, ValidatorRequiredIf, ValidatorRequiredUnless, ValidatorRequiredWith, ValidatorRequiredWithAll, ValidatorRequiredWithout
  */
@@ -47,36 +48,28 @@ public:
      * \brief Constructs a new required without all validator.
      * \param field         Name of the input field to validate.
      * \param otherFields   List of field names that are not allowed to be present to require the field.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param messages      Custom error messages if validation fails.
      */
-    ValidatorRequiredWithoutAll(const QString &field, const QStringList &otherFields, const QString &label = QString(), const QString &customError = QString());
+    ValidatorRequiredWithoutAll(const QString &field, const QStringList &otherFields, const ValidatorMessages &messages = ValidatorMessages());
     
     /*!
      * \brief Deconstructs the required without all validator.
      */
     ~ValidatorRequiredWithoutAll();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the list of other fields.
-     */
-    void setOtherFields(const QStringList &otherFields);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorRequiredWithoutAll object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorRequiredWithoutAll(ValidatorRequiredWithoutAllPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorRequiredWithoutAll)

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredwithoutall_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorRequiredWithoutAllPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorRequiredWithoutAllPrivate(const QString &f, const QStringList &o, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorRequiredWithoutAllPrivate(const QString &f, const QStringList &o, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString()),
         otherFields(o)
     {}
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -49,7 +49,6 @@ bool ValidatorResult::isValid() const
 
 void ValidatorResult::addError(const QString &field, const QString &message)
 {
-    d->errorStrings.append(message);
     QStringList fieldErrors = d->errors.value(field);
     fieldErrors.append(message);
     d->errors.insert(field, fieldErrors);
@@ -57,7 +56,15 @@ void ValidatorResult::addError(const QString &field, const QString &message)
 
 QStringList ValidatorResult::errorStrings() const
 {
-    return d->errorStrings;
+    QStringList strings;
+
+    auto i = d->errors.constBegin();
+    while (i != d->errors.constEnd()) {
+        strings.append(i.value());
+        ++i;
+    }
+
+    return strings;
 }
 
 QHash<QString, QStringList> ValidatorResult::errors() const
@@ -65,12 +72,17 @@ QHash<QString, QStringList> ValidatorResult::errors() const
     return d->errors;
 }
 
+bool ValidatorResult::hasErrors(const QString &field) const
+{
+    return d->errors.contains(field);
+}
+
 QJsonObject ValidatorResult::errorsJsonObject() const
 {
     QJsonObject json;
 
     if (!d->errors.empty()) {
-        QHash<QString,QStringList>::const_iterator i = d->errors.constBegin();
+        auto i = d->errors.constBegin();
         while (i != d->errors.constEnd()) {
             json.insert(i.key(), QJsonValue(QJsonArray::fromStringList(i.value())));
             ++i;
@@ -83,4 +95,34 @@ QJsonObject ValidatorResult::errorsJsonObject() const
 QStringList ValidatorResult::failedFields() const
 {
     return QStringList(d->errors.keys());
+}
+
+QVariantHash ValidatorResult::values() const
+{
+    return d->values;
+}
+
+QVariant ValidatorResult::value(const QString &field) const
+{
+    return d->values.value(field);
+}
+
+void ValidatorResult::addValue(const QString &field, const QVariant &value)
+{
+    d->values.insert(field, value);
+}
+
+QVariantHash ValidatorResult::extras() const
+{
+    return d->extras;
+}
+
+QVariant ValidatorResult::extra(const QString &field) const
+{
+    return d->extras.value(field);
+}
+
+void ValidatorResult::addExtra(const QString &field, const QVariant &extra)
+{
+    d->extras.insert(field, extra);
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorresult.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -30,30 +30,48 @@ namespace Cutelyst {
 class ValidatorResultPrivate;
 
 /*!
- * \brief Contains the result of Validator.
+ * \ingroup plugins-utils-validator
+ * \brief Provides information about performed validations.
  *
- * %ValidatorResult will be returned by Validator when calling Validator::validate(). It contains information
- * about occured validation errors, like the error strings of each failed validator and a list of fields where
- * validation failed.
+ * %ValidatorResult will be returned by Validator when calling \link Validator::validate() validate()\endlink on it.
+ * It contains information about occured validation errors, like the error strings of each failed validator and a
+ * list of fields where validation failed.
+ *
+ * Additionally to the error messages that occure if validation fails for one or more fields, %ValidatorResult will
+ * also contain the extracted values from the input parameters. Use values() to return all values or value() to
+ * return the value for a single field. Because there will be only one value stored for each field, you should order
+ * your validators in a way that a validater for a field comes last that converts the input QString into the
+ * wanted type. See the documentation for the specific validtor to learn what type of data it returns.
+ *
+ * Some validators might even return more details about the validation result. This extra data can be returned with
+ * the extras() method for all input parameters or with extra() for a single one.
  *
  * Beside the isValid() function, that returns \c true if the complete validation process was successful and \c false
- * if any of the validators failed, it provides a bool operator that makes it usable in \c if statements.
+ * if any of the validators failed, %ValidatorResult provides a bool operator that makes it usable in \c if statements.
  *
  * \code{.cpp}
- * static Validator v(c, {new ValidatorRequired(QStringLiteral("required_field")});
- * ValidatorResult r = v.validate();
- * if (r) {
- *      // do stuff if validation was successful
- * } else {
- *      // do other stuff if validation failed
- * }
+ * void MyController:do_form(Context *c)
+ * {
+ *     static Validator v({
+ *                          new ValidatorRequired(QStringLiteral("birthday"),
+ *                          new ValidatorDate(QStringLiteral("birthday")
+ *                       });
+ *     ValidatorResult r = v.validate(c);
+ *     if (r) {
+ *         // do stuff if validation was successful
+ *         auto extractedValues = r.values();
+ *     } else {
+ *         // do other stuff if validation failed
+ *         auto errors = r.errors();
+ *     }
  *
  *
- * // you can also compare the boolen value of the result directly
- * // for example together with the Validator::FillStashOnError flag
- * // to automatically fill the stash with error information and input values
- * if (v.validate(Validator::FillStashOnError)) {
- *      // do stuff if validation was successful
+ *     // you can also compare the boolen value of the result directly
+ *     // for example together with the Validator::FillStashOnError flag
+ *     // to automatically fill the stash with error information and input values
+ *     if (v.validate(Validator::FillStashOnError)) {
+ *         // do stuff if validation was successful
+ *     }
  * }
  * \endcode
  *
@@ -64,8 +82,8 @@ public:
     /*!
      * \brief Constructs a new %ValidatorResult.
      *
-     * A newly constructed %ValidatorResult willl be valid by default, because it
-     * does not cotain any error information.
+     * A newly constructed %ValidatorResult willl be \link isValid() valid\endlink by default,
+     * because it does not contain any error information.
      */
     ValidatorResult();
 
@@ -75,7 +93,7 @@ public:
     ValidatorResult(const ValidatorResult &other);
 
     /*!
-     * \brief Assigns \a other to this object.
+     * \brief Assigns \a other to this %ValidatorResult.
      */
     ValidatorResult& operator =(const ValidatorResult &other);
 
@@ -93,40 +111,58 @@ public:
 
     /*!
      * \brief Adds new error information to the internal QHash.
-     * \param field     Name of the input field that has input errors.
+     * \param field     Name of the input \link Request::parameters() parameter\endlink that has validation errors.
      * \param message   Error message shown to the user.
+     * \sa errorString() errors() hasErrors()
      */
     void addError(const QString &field, const QString &message);
 
     /*!
-     * \brief Returns a list of error messages.
-     *
-     * Returns a list of all error messages from every failed ValidatorRule.
+     * \brief Returns a list of all error messages.
+     * \return A list of all error messages from every failed ValidatorRule.
      */
     QStringList errorStrings() const;
 
     /*!
      * \brief Returns a dictionary containing fields with errors.
-     *
-     * Returns a dictionary that contains the fields that have validation errors
-     * together with the errors strings. The \a key will be the field name, the \a value
-     * will be the list of errors for that field.
+     * \return A QHash containing the name of the input \link Request::parameters() parameter\endlink as key and
+     * a list of validation errors for this parameter in a QStringList as value.
      */
     QHash<QString,QStringList> errors() const;
 
     /*!
+     * \brief Returns a list of all error messages for an input \a field.
+     * \param field Name of the field to return error messages for.
+     * \return List of error message strings. If there were no errors for the \a field, the
+     * returned list will be empty.
+     * \sa errorStrings()
+     */
+    QStringList errors(const QString &field) const;
+
+    /*!
+     * \brief Returns \c true if the \a field has validation errors.
+     * \param field Name of the input field to check.
+     * \return \c true if the \a field has error messages, \c false otherwise.
+     * \sa \link errors(const QString &field) errors()\endlink
+     * \since Cutelyst 2.0.0
+     */
+    bool hasErrors(const QString &field) const;
+
+    /*!
      * \brief Returns the dictionray containing fields with errors as JSON object.
      *
-     * This returns the same data as errors() does but converted into a JSON object
-     * that has the field names as \a keys and the values will be a JSON array of
+     * This returns the same data as errors() but converted into a JSON object
+     * that has the field names as keys and the values will be a JSON array of
      * strings containing the errors for the field.
      *
+     * \sa errors() errorStrings()
      * \since Cutelyst 1.12.0
      */
     QJsonObject errorsJsonObject() const;
 
     /*!
      * \brief Returns a list of fields with errors.
+     * \return A list of of  input \link Request::parameters() parameter\endlink names that have validation errors.
      * \since Cutelyst 1.12.0
      */
     QStringList failedFields() const;
@@ -139,6 +175,66 @@ public:
     explicit operator bool() const {
         return isValid();
     }
+
+    /*!
+     * \brief Returns the values that have been extracted by the validators.
+     * \return A QVariantHash where the key is the name of the input \link Request::parameters() parameter\endlink and
+     * the value contains the value extracted from the input parameter. Have a look at the documentation of the specific
+     * validator to see what kind of extracted value they will provide.
+     * \sa value() addValue()
+     * \since Cutelyst 2.0.0
+     */
+    QVariantHash values() const;
+
+    /*!
+     * \brief Returns the extracted value for the input \a field.
+     * \param field Name of the input \link Request::parameters() parameter\endlink to get the value for.
+     * \return The extracted value in a QVariant. If there is no value for the \a field, the returned QVariant will
+     * be default constructed. Have a look at the documentation of the specific validator to see what kind of extracted
+     * value they will provide.
+     * \sa values() addValue()
+     * \since Cutelyst 2.0.0
+     */
+    QVariant value(const QString &field) const;
+
+    /*!
+     * \brief Adds a new \a value extracted from the specified input \a field.
+     * \param field Name of the input \link Request::parameters() parameter\endlink the value has been extracted from.
+     * \param value Value as it has been extracted and maybe converted by the validator.
+     * \sa values() value()
+     * \since Cutelyst 2.0.0
+     */
+    void addValue(const QString &field, const QVariant &value);
+
+    /*!
+     * \brief Returns all extra data that has been extracted by the validators.
+     * \return A QVariantHash where the key is the name of the input \link Request::parameters() parameter\endlink
+     * and the value contains the extra data for that field.Have a look at the documentation of the specific
+     * validators to see what kind of extra data they might generate.
+     * \sa extra() addExtra()
+     * \since Cutelyst 2.0.0
+     */
+    QVariantHash extras() const;
+
+    /*!
+     * \brief Returns the extra data for the input \a field.
+     * \param field Name of the input \link Request::parameters() parameter\endlink to get the extra data for.
+     * \return A QVariant containing extra data generated by the validators. If the \a field does not have any
+     * extra data, a default constructed QVariant will be returned. Have a look at the documentation of the
+     * specific validators to see what kind of extra data they might generate.
+     * \sa extras() addExtra()
+     * \since Cutelyst 2.0.0
+     */
+    QVariant extra(const QString &field) const;
+
+    /*!
+     * \brief Adds new \a extra data that came up when validating the input \a field.
+     * \param field Name of the input \link Request::parameters() parameter\endlink the extra data occured for.
+     * \param extra The additional validation data.
+     * \sa extras() extra()
+     * \since Cutelyst 2.0.0
+     */
+    void addExtra(const QString &field, const QVariant &extra);
 
 private:
     QSharedDataPointer<ValidatorResultPrivate> d;

--- a/Cutelyst/Plugins/Utils/Validator/validatorresult_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -30,14 +30,16 @@ public:
 
     ValidatorResultPrivate(const ValidatorResultPrivate &other) :
         QSharedData(other),
-        errorStrings(other.errorStrings),
-        errors(other.errors)
+        errors(other.errors),
+        values(other.values),
+        extras(other.extras)
     {}
 
     ~ValidatorResultPrivate() {}
 
-    QStringList errorStrings;
     QHash<QString,QStringList> errors;
+    QVariantHash values;
+    QVariantHash extras;
 };
 
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorrule.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,35 +19,176 @@
 #define CUTELYSTVALIDATORRULE_H
 
 #include <Cutelyst/cutelyst_global.h>
-#include <Cutelyst/ParamsMultiMap>
+#include <Cutelyst/paramsmultimap.h>
 
 #include <QScopedPointer>
+#include <QVariant>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(C_VALIDATOR)
 
 namespace Cutelyst {
+
+/*!
+ * \ingroup plugins-utils-validator
+ * \defgroup plugins-utils-validator-rules Rules
+ * \brief Classes providing rules to validate input data.
+ *
+ * All validator rule classes are derived from ValidatorRule and are meant to be used as part of
+ * Validator. Read the documentation of Validator to learn more about how to use the Validator and
+ * the rules. If you want to write your own validator rule, create a new class that is derived from
+ * ValidatorRule and reimplement the validate function.
+ *
+ * There are three constructor arguments that are common to almos all validator rules: the name of the
+ * field to validate (mandatory), a struct containing translatable ValidatorMessages (optional) and
+ * a \link Context::stash() stash\endlink key name that contains a default value if the input field
+ * is not available (optional available where it makes sense).
+ *
+ * Some validators export their validation logic in a <a href="#func-members">static member function</a>
+ * so that it can be used without creating a Validator.
+ */
+
+class Context;
+
+/*!
+ * \ingroup plugins-utils-validator
+ * \brief Contains the result of a single input parameter validation.
+ *
+ * For information about the possible values of \link ValidatorReturnType::value value\endlink and
+ * \link ValidatorReturnType::extra extra\endlink see the documentation of the respective
+ * \link plugins-utils-validator-rules validator rule\endlink.
+ */
+struct CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorReturnType {
+    QString errorMessage;   /**< Contains a human readable error message if validation failed that should provide information about the reason the validation failed. If QString::isNull() returns \c true for this, the validation has succeeded and isValid() will alsor return \c true. */
+    QVariant value;         /**< Might contain the extracted and possibly converted value of the \link ValidatorRule::value() input parameter\endlink if validation succeeded. For information about the possible values see the documentation of the respective \link plugins-utils-validator-rules validator\endlink. */
+    QVariant extra;         /**< Might contain extra data provided by the validator. For information about the possible values see the documentation of the respective \link plugins-utils-validator-rules validator\endlink. */
+
+    /*!
+     * \brief Returns \c true if validation succeeded.
+     * \return \c true if \link ValidatorReturnType::errorMessage errorMessage\endlink is a \link QString::isNull() null string\endlink,
+     * indicating that the validation has succeeded.
+     */
+    explicit operator bool() const {
+        return errorMessage.isNull();
+    }
+
+    /*!
+     * \brief Returns \c true if validation succeeded.
+     * \return \c true if \link ValidatorReturnType::errorMessage errorMessage\endlink is a \link QString::isNull() null string\endlink,
+     * indicating that the validation has succeeded.
+     */
+    bool isValid() const {
+        return errorMessage.isNull();
+    }
+};
+
+/*!
+ * \ingroup plugins-utils-validator
+ * \brief Stores custom error messages and the input field label.
+ *
+ * This struct is used by ValidatorRule derived classes to store custom error messages
+ * that are also translatable. To make the messages translatable, use QT_TRANSLATE_NOOP() so
+ * that the message can be dynamically translated by the current \link Context::translate() Context \endlink.
+ * If you want to omit a custom message, simply use a \c nullptr for it. For custom messages that are
+ * not set, the ValidatorRule class will return a generic message that will also be translated if
+ * %Cutelyst has a translation file for the \link Context::locale() current language in the context\endlink.
+ *
+ * The translation context used in the QT_TRANSLATE_NOOP() definition has to be the same that has been set
+ * on the Validator contstructor. If you dont want to use translation for the messages and the label, simply
+ * don't use QT_TRANSLATE_NOOP() when adding the string but simply use a C string literal and also leave the
+ * translation context on the Validator constructor empty.
+ *
+ * <h3>Usage example</h3>
+ * \code{.cpp}
+ * void MyController::do_form(Context *c)
+ * {
+ *     static Validator v1({
+ *                         new ValidatorAccepted(QStringLiteral("usage_terms"),
+ *                                               // empty label and translatable validation error message
+ *                                               ValidatorMessages(nullptr, QT_TRANSLATE_NOOP("MyController", "Please accept our terms of usage to finish your registration.")),
+ *
+ *                         new ValidatorEmail(QStringLiteral("email"), false, ValidatorEmail::Valid,
+ *                                            // only the label will be translated and inserted into generic error messages of the validator rule
+ *                                            ValidatorMessages(QT_TRANSLATE_NOOP("MyController", "Your Email Address"))
+ *
+ *                         new ValidatorDate(QStringLiteral("birthday"),
+ *                                           // here we also use a translatable version of the date format
+ *                                           QT_TRANSLATE_NOOP("MyControler", "yyyy-MM-dd"),
+ *                                           // this one will use a translated label for generic parsing and validation data
+ *                                           // error messages and a custom translatable error message for failed validations
+ *                                           ValidatorMessages(QT_TRANSLATE_NOOP("MyController", "You day of birth"),
+ *                                                             QT_TRANSLATE_NOOP("MyController", "Please enter a valid date of birth"))
+ *
+ *                         // this uses a default constructed ValidatorMessages struct where
+ *                         // no custom messages have been set, so all error messages will come
+ *                         // from the generic validator messages without a label
+ *                         new ValidatorRequired(QStringLiteral("password"));
+ *
+ *                          // this is the context that will be used to obtain translations,
+ *                          // it has to be the same one you use in your validator messages
+ *                          // QT_TRANSLATE_NOOP()
+ *                        }, QLatin1String("MyController"));
+ *
+ *
+ *     // this validator does not specify a translation context and will therefore not translate error messages,
+ *     // even if they were added with QT_TRANSLATE_NOOP()
+ *     static Validator v2({
+ *                         new ValidatorRequired(QStringLiteral("required_field"),
+ *                                               ValidatorMessages("Required Field", "This field is required, please enter data."))
+ *                        });
+ * }
+ * \endcode
+ */
+struct CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorMessages {
+    /*!
+     * \brief Constructs a default %ValidatorMessages object with all custom messages disabled.
+     */
+    ValidatorMessages() {}
+    /*!
+     * \brief Constructs a new %ValidatorMessages object with the given parameters.
+     *
+     * \param customLabel               User visible label for the input field. Should be the same as used on the frontend visible to the user. Will be used by generic error messages if set.
+     * \param customValidationError     Custom error message if the validation fails.
+     * \param customParsingError        Custom error message if the input value could not be parsed.
+     * \param customValidationDataError Custom error message if validation data is missing or invalid.
+     */
+    ValidatorMessages(const char *customLabel, const char *customValidationError = nullptr, const char *customParsingError = nullptr, const char *customValidationDataError = nullptr) :
+        label(customLabel),
+        validationError(customValidationError),
+        parsingError(customParsingError),
+        validationDataError(customValidationDataError)
+    {}
+    const char *label = nullptr; /**< Field label used for generating generic error messages. */
+    const char *validationError = nullptr;  /**< Custom validation error messages. */
+    const char *parsingError = nullptr; /**< Custom parsing error message. */
+    const char *validationDataError = nullptr;  /**< Custom validation data error message. */
+};
 
 class ValidatorRulePrivate;
 
 /*!
- * \brief Base class for all validators.
+ * \ingroup plugins-utils-validator
+ * \brief Base class for all validator \link plugins-utils-validator-rules rules\endlink.
  *
  * This class can not be used on it's own, you have to create a derived class from it that implements your
- * validator logic. Or use one of the already existing derived classes.
+ * validator logic. Or use one of the \link plugins-utils-validator-rules already existing derived validator rules\endlink.
  *
  * \par Writing a custom validator
  *
- * If you want to implement your own validator logic to use with Valiadtor, you have to create a class that
- * derives from ValidatorRule. The simplest implementation only needs a constructor an a reimplementation
- * of the validate() funciton. But for more comfort and usability, you should also reimplement validationError().
+ * If you want to implement your own validator logic to use with Validator, you have to create a class that
+ * derives from ValidatorRule. The simplest implementation only needs a constructor and a reimplementation
+ * of the validate() function. But for more comfort and usability, you should also reimplement genericValidationError().
  * If your validator parses the input into a specific type to validate it and/or if you are using additional parameters,
- * you may also want to reimplement parsingError() and validationDataError() to return more appropriate generic error
- * messages.
+ * you may also want to reimplement genericParsingError() and genericValidationDataError() to return more appropriate
+ * generic error messages.
  *
- * The most important parameter for every validator is the name of the \a field to validate. So your own validator should
- * require that field in the constructor. For better error messages you should also add an optional paramter to set
- * a \a label and maybe a \a customError message if validation fails.
+ * The most important parameter for every validator rule is the name of the \a field to validate. So your own validator
+ * should require that field in the constructor. For better error messages you should also add an optional paramter to set
+ * custom ValidatorMessages if validation fails.
  *
- * In the validation logic you have to return an empty QString if validation succeeded. Everything else will be treeted
- * as an error message and that the validation has been failed.
+ * In the validation logic implemented in the validate() function you have to return a ValidatorReturnType struct that contains
+ * information about the validation. It has three members, \link ValidatorReturnType::errorMessages errorMessages\endlink
+ * is the most important one. If that returns \c true for QString::isNull(), the validation has succeeded.
  *
  * So lets implement a custom validator that can check for a specific value to be set. (Maybe not a realistic example, but
  * it should be enough for demonstration.)
@@ -55,33 +196,41 @@ class ValidatorRulePrivate;
  * \code{.cpp}
  * #include <Cutelyst/Plugins/Utils/ValidatorRule>
  *
- * class MyValidator : public Cutelyst::ValidatorRule
+ * namespace Cutelyst {
+ *
+ * class MyValidator : public ValidatorRule
  * {
  * public:
  *     // field: name of the input field
  *     // compareValue: our custom value we want compare
- *     // label: an optional human readable label for generic error messages
- *     // customError: a custom error message that is shown if validation fails instead of genericValidationError()
- *     MyValidator::MyValidator(const QString &field, const QString &compareValue, const QString &label = QString(), const QString &customError = QString())
+ *     // messages: struct containing custom messages
+ *     // defValKey: name of a stash key containing a default value if input field is empty
+ *     MyValidator::MyValidator(const QString &field,
+ *                              const QString &compareValue,
+ *                              const ValidatorMessages &messages = ValidatorMessages(),
+ *                              const QString &defValKey = QString());
  *
  *     ~MyValidator();
  *
- *     // this will contain the validation logic
- *     // and should return an empty QString on success
- *     QString validate() const override;
+ *     // this will contain the validation logic and should return
+ *     // a ValidatorResult with a null errorMessage string on success
+ *     ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
  *
  * protected:
  *     // we want to have a generic error message
- *     QString validationError() const override;
+ *     QString validationError(Context *c) const override;
  *
  * private:
  *     // storing our comparison value
  *     QString m_compareValue;
+ * };
+ *
  * }
  *
+ * using namespace Cutelyst;
  *
- * MyValidator::MyValidator(const QString &field, const QString &compareValue, const QString &label, const QString &customError) :
- *     Cutelyst::ValidatorRule(field, label, customError), m_compareValue(compareValue)
+ * MyValidator::MyValidator(const QString &field, const QString &compareValue, const ValidatorMessages &messages, const QString &defValKey) :
+ *     Cutelyst::ValidatorRule(field, messages, defValKey), m_compareValue(compareValue)
  * {
  * }
  *
@@ -89,20 +238,20 @@ class ValidatorRulePrivate;
  * {
  * }
  *
- * // when reimplementing the validate function, keep in mind, that
- * // an empty returned string is seen as successful validation, everything
+ * // when reimplementing the validate function, keep in mind, that a null errorMessage
+ * // string in the ValidatorReturnType is seen as successful validation, everything
  * // else will be seen as an error
- * QString MyValidator::validate() const
+ * ValidatorReturnType MyValidator::validate(Context *c, const ParamsMultiMap &params) const
  * {
- *     QString result;
+ *     ValidatorReturnType result;
  *
  *     // lets get the field value
- *     const QString v = value();
+ *     const QString v = value(params);
  *
  *     // if our comparision value is empty, the validation should fail and we want
  *     // to return an error message according to this situation
  *     if (m_compareValue.isEmpty()) {
- *         result = validationDataError();
+ *         result.errorMessage = validationDataError(c);
  *     } else {
  *
  *         // if the value is empty or the field is missing, the validation should succeed,
@@ -110,222 +259,294 @@ class ValidatorRulePrivate;
  *         // than we will compare our values and if they are not the same, we
  *         // will return an error string
  *         if (!v.isEmpty() && (m_compareValue != v)) {
- *              result = validationError();
+ *              result.errorMessage = validationError(c);
+ *         } else {
+ *              result.value.setValue(v);
  *         }
  *     }
  *
- *     // now let's return our result, if it is empty, validation was successfull
+ *     // now let's return our result, if the errorMessage member is null, validation was successfull
  *     return result;
  * }
  *
  *
- * QString MyValidator::genericValidationError() const
+ * QString MyValidator::genericValidationError(Context *c) const
  * {
  *     QString error;
+ *     const QString _label = label(c);
  *     // if no label is set, we will return a shorter error message
- *     if (label().isEmpty()) {
- *          error = tr("Must contain this value: %1).arg(m_compareValue);
+ *     if (_label.isEmpty()) {
+ *          c->translate("MyValidator", "Must contain this value: %1").arg(m_compareValue);
  *     } else {
- *          error = tr("The %1 field must contain the following value: %2").arg(label(), m_compareValue);
+ *          c->translate("MyValidator", "The %1 field must contain the following value: %2").arg(_label, m_compareValue);
  *     }
  *     return error;
  * }
  * \endcode
  *
- * That's it. Now you can use your own validator in the main Validator.
+ * That's it. Now you can use your own validator rule in the main Validator.
  */
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorRule
 {
 public:
     /*!
-     * \brief Constructs a new ValidatorRule with given parameters and \a parent.
+     * \brief Constructs a new ValidatorRule with the given parameters.
      * \param field         Name of the field to validate.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Human readable custom error message if validation fails.
+     * \param messages      Custom error messages if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorRule(const QString &field, const QString &label = QString(), const QString &customError = QString());
+    ValidatorRule(const QString &field, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
 
     /*!
      * \brief Deconstructs the ValidatorRule.
      */
     ~ValidatorRule();
 
+protected:
+    const QScopedPointer<ValidatorRulePrivate> d_ptr;
     /*!
-     * \brief Returns an empty string on success, otherwise a string containing the error message.
+     * \internal
+     * \brief Constructs a new ValidatorRule object with the given private class.
+     */
+    ValidatorRule(ValidatorRulePrivate &dd);
+
+    /*!
+     * \brief Starts the validation and returns the result.
      *
-     * This is the main function to reimplement when writing a custom validator. When reimplementing
-     * this function in a class derived from ValidatorRule, you have to return an empty string if
-     * validation succeeded and the corresponding error if it fails. There are currently three error
-     * functions that should be used for different error cases:
+     * This is the main function to reimplement when writing a custom validator. When reimplementing this function in a class
+     * derived from ValidatorRule, you have to return an empty \link ValidatorReturnType::errorMessage errorMessage\endlink
+     * if validation succeeded and the corresponding error if it fails. There are currently three error functions that should
+     * be used for different error cases:
      *
      * \li validationError() - if validation itself fails
      * \li validationDataError() - if there is a problem with missing or invalid validation data, like comparison values
-     * \li parsingError() - if the parsing of an input data fails in a valiator that not originally checks the parsing, but the parsing result
+     * \li parsingError() - if the parsing of an input data fails in a validator that not originally checks the parsing, but
+     * the parsed result
      *
-     * \par Example
+     * If validation succeeded, you should put the extracted and validated value into the ValidatorReturnType::value.
+     * After the validation you can get the extracted values from ValidatorResult::values().
      *
+     * <h3>Example</h3>
      * \code{.cpp}
-     * QString MyValidator::validate() const
+     * ValidatorReturnType MyValidator::validate(Context *c, const ParamsMultiMap &params) const
      * {
-     *      QString result;
+     *     ValidatorReturnType result;
      *
-     *      if (m_myComparisonValue.isEmpty()) {
-     *          result = validationDataError();
-     *      } else {
-     *          if (m_myComparisonValue != value()) {
-     *              result = validationError();
-     *          }
-     *      }
+     *     if (!m_myComparisonDate.isValid()) {
+     *         result.errorMessage = validationDataError(c);
+     *     } else {
+     *         const QString v = value(params);
+     *         const QDate inputDate = QDate::fromString(v, Qt::ISODate);
+     *         if (!inputDate.isValie()) {
+     *             result.errorMessage = parsingError(c);
+     *         } else {
+     *             if (inputDate > m_myComparisonDate) {
+     *                 result.value.setValue<QDate>(inputDate);
+     *             } else {
+     *                 result.errorMessage = validationError(c);
+     *             }
+     *         }
+     *     }
      *
-     *      return result;
+     *     return result;
      * }
      * \endcode
      */
-    virtual QString validate() const = 0;
+    virtual ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const = 0;
 
     /*!
      * \brief Returns the name of the field to validate.
-     * \sa setField()
+     * \return The name of the field to validate that has been set in the constructor.
      */
     QString field() const;
 
     /*!
      * \brief Returns the human readable field label used for generic error messages.
-     * \sa setLabel()
+     * The label can be set in the ValidatorMessages on the constructor.
+     * \return Human readable field label used for generic error messages.
      */
-    QString label() const;
+    QString label(Context *c) const;
 
     /*!
-     * \brief Returns the field value.
+     * \brief Returns the value of the field from the input \a params.
      */
-    QString value() const;
+    QString value(const ParamsMultiMap &params) const;
 
     /*!
-     * \brief Returns true if field value should be trimmed before validation.
+     * \brief Returns true if the field value should be trimmed before validation.
      *
      * By default, this will return \c true and all input values will be trimmed before validation to
      * remove whitespaces from the beginning and the end.
-     *
-     * \sa setTrimBefore()
      */
     bool trimBefore() const;
 
-
-
     /*!
-     * \brief Sets the name of the field to validate.
-     * \sa field()
+     * \brief Returns a descriptive error message if validation failed.
+     *
+     * This will either return the \a customValidationError message provided via the ValidatorMessages
+     * in the \a messages argument of the constructor or the message returned by genericValidationError()
+     * if there is no \a customValidationError message availabe.
+     *
+     * When writing a new ValidatorRule, use this in your reimplementaion of validate() if validation
+     * failed.
+     *
+     * The pointer to the current Context \a c will be used to \link ValidatorMessages translate error strings\endlink.
+     * If you have some more data to use for the error messages, put them into \a errorData.
      */
-    void setField(const QString &field);
+    QString validationError(Context *c, const QVariant &errorData = QVariant()) const;
 
     /*!
-     * \brief Sets human readable field label for generic error messages.
-     * \sa label()
+     * \brief Returns a generic error mesage if validation failed.
+     *
+     * If you want to have a more specifc generic validation error message for your validator
+     * if validation fails, reimplment this your derived class. The default implementation simply
+     * returns a maybe translated version of \c "The input data in the “%1” field is not acceptable."
+     * if there has been a \link label() label\endlink set or \c "The input data is not acceptable."
+     * if the \link label() label\endlink is empty.
+     *
+     * The pointer to the current Context \a c can be used to \link ValidatorMessages translate error strings\endlink.
+     * If you have some more data to use for the error messages, put them into \a errorData.
+     *
+     * <h3>Example implementation</h3>
+     * \code{.cpp}
+     * QString MyValidator::genericValidationError(Context *c) const
+     * {
+     *     QString error;
+     *     const QString _label = label(c);
+     *     // if no label is set, we will return a shorter error message
+     *     if (_label.isEmpty()) {
+     *          c->translate("MyValidator", "Must contain this value: %1").arg(m_compareValue);
+     *     } else {
+     *          c->translate("MyValidator", "The %1 field must contain the following value: %2").arg(_label, m_compareValue);
+     *     }
+     *     return error;
+     * }
+     * \endcode
      */
-    void setLabel(const QString &label);
+    virtual QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const;
 
     /*!
-     * \brief Sets the request parameters to validate.
-     * \sa parameters()
+     * \brief Returns an error message if an error occured while parsing input.
+     *
+     * This will either return the \a customParsingError message provided via the ValidatorMessages
+     * in the \a messages argument of the constructor or the message returned by genericValidationError()
+     * if there is no \a customParsingError message availabe.
+     *
+     * When writing a new ValidatorRule, use this in your reimplementation of validate() if parsing of
+     * input data fails.
+     *
+     * The pointer to the current Context \a c will be used to \link ValidatorMessages translate error strings\endlink.
+     * If you have some more data to use for the error messages, put them into \a errorData.
      */
-    void setParameters(const ParamsMultiMap &params);
+    QString parsingError(Context *c, const QVariant &errorData = QVariant()) const;
 
     /*!
-     * \brief Returns the parameters to validate.
-     * \sa setParameters()
+     * \brief Returns a generic error message if an error occures while parsing input.
+     *
+     * If you want to have a more specific generic parsing error message for your validator
+     * if parsing of input data failes, reimplement this in your derived class. The default implementation simply
+     * returns a maybe translated version of \c "The input data in the “%1“ field could not be parsed."
+     * if there has been a \link label() label\endlink set or \c "The input data could not be parsed."
+     * if the \link label() label\endlink is empty.
+     *
+     * The pointer to the current Context \a c can be used to \link ValidatorMessages translate error strings\endlink.
+     * If you have some more data to use for the error messages, put them into \a errorData.
+     *
+     * <h3>Example implementation</h3>
+     * \code{.cpp}
+     * QString MyValidator::genericParsingError(Context *c) const
+     * {
+     *     QString error;
+     *     const QString _label = label(c);
+     *     // if no label is set, we will return a shorter error message
+     *     if (_label.isEmpty()) {
+     *          c->translate("MyValidator", "Could not be parsed into a valid date.");
+     *     } else {
+     *          c->translate("MyValidator", "The value of the %1 field could not be parsed into a valid date.").arg(_label);
+     *     }
+     *     return error;
+     * }
+     * \endcode
      */
-    ParamsMultiMap parameters() const;
+    virtual QString genericParsingError(Context *c, const QVariant &errorData = QVariant()) const;
 
     /*!
-     * \brief Sets a cutom error returned with errorMessage()
-     * \sa validationError()
+     * \brief Returns an error message if any validation data is missing or invalid.
+     *
+     * This will either return the \a customValidationDataError message provided via the ValidatorMessages
+     * in the \a messages argument of the contstructor or the message returned by genericValidationDataError()
+     * if there is no \a customValidationDataError message available.
+     *
+     * When writing a new ValidatorRule, use this in your reimplementation of validate() if validation
+     * data like compare values are missing or invalid.
+     *
+     * The pointer to the current Context \a c will be used to \link ValidatorMessages translate error strings\endlink.
+     * If you have some more data to use for the error messages, put them into \a errorData.
      */
-    void setCustomError(const QString &customError);
+    QString validationDataError(Context *c, const QVariant &errorData = QVariant()) const;
 
     /*!
-     * \brief Sets a custom error message that is shown if parsing of input data fails.
-     * \sa parsingError()
+     * \brief Returns a generic error message if any validation data is missing or invalid.
+     *
+     * If you want to have a more specific generic validation data error message for your validator
+     * if data needed for the validation is missing or invalid, reimplement this in your derived class.
+     * The default implementation simply returns a maybe translated version of \c "Missing or invalid validation data for the “%1” field."
+     * if there has been a \link label() label\endlink set or \c "Missing or invalid validation data."
+     * if the \link label() label\endlink is empty.
+     *
+     * The pointer to the current Context \a c can be used to \link ValidatorMessages translate error strings\endlink.
+     * If you have some more data to use for the error messages, put them into \a errorData.
+     *
+     * <h3>Example implementation</h3>
+     * \code{.cpp}
+     * QString MyValidator::genericValidationDataError(Context *c) const
+     * {
+     *     QString error;
+     *     const QString _label = label(c);
+     *     // if no label is set, we will return a shorter error message
+     *     if (_label.isEmpty()) {
+     *          c->translate("MyValidator", "There is no value to compare against.");
+     *     } else {
+     *          c->translate("MyValidator", "For the “%1” field there is no value to compare against.").arg(_label);
+     *     }
+     *     return error;
+     * }
+     * \endcode
      */
-    void setCustomParsingError(const QString &custom);
+    virtual QString genericValidationDataError(Context *c, const QVariant &errorData = QVariant()) const;
 
     /*!
-     * \brief Sets a custom error message if validation data is invalid or missing.
-     * \sa validationDataError()
+     * \brief I a \a defValKey has been set in the constructor, this will try to get the default value from the stash and put it into the result.
+     * \param c             Current Context to get the default value from.
+     * \param result        The result struct to put the default value in.
+     * \param validatorName Name of the validator used for logging.
      */
-    void setCustomValidationDataError(const QString &custom);
+    void defaultValue(Context *c, ValidatorReturnType *result, const char *validatorName) const;
+
+private:
+    Q_DECLARE_PRIVATE(ValidatorRule)
+    Q_DISABLE_COPY(ValidatorRule)
 
     /*!
+     * \internal
+     * \brief Sets the translation context used for custom messages.
+     * \param trContext The name of the context.
+     */
+    void setTranslationContext(QLatin1String trContext);
+
+    /*!
+     * \internal
      * \brief Set to \c false to not trim input value before validation.
      *
-     * By default, this value is set to \c true and all input values will be QString::trimmed() trimmed before validation to
-     * remove whitespaces from the beginning and the end.
+     * By default, this value is set to \c true and all input values will be \link QString::trimmed() trimmed\endlink
+     * before validation to remove whitespaces from the beginning and the end.
      *
      * \sa trimBefore()
      */
     void setTrimBefore(bool trimBefore);
 
-protected:
-    const QScopedPointer<ValidatorRulePrivate> d_ptr;
-    /*!
-     * Constructs a new ValidatorRule object with the given private class.
-     */
-    ValidatorRule(ValidatorRulePrivate &dd);
-
-    /*!
-     * \brief Returns a descriptive error message if validation failed.
-     *
-     * This will either return the custom error message set via setCustomError() or the message
-     * returned by genericValidationError(). When writing a new ValidatorRule, use this in your
-     * reimplementaion of validate() if validation failed.
-     */
-    QString validationError() const;
-
-    /*!
-     * \brief Returns a generic error mesage if validation failed.
-     *
-     * If you want to have a more specifc generic validation error message for your validator,
-     * reimplment this in a subclass.
-     */
-    virtual QString genericValidationError() const;
-
-    /*!
-     * \brief Returns an error message if an error occured while parsing input.
-     *
-     * This will either return the custom parsing error message set via setCustomParsingError() or
-     * the message returned by genericParsingError(). When writing a new ValidatorRule, use this
-     * in your reimplementation of validate() if parsing of input data fails.
-     */
-    QString parsingError() const;
-
-    /*!
-     * \brief Returns a generic error message if an error occures while parsing input.
-     *
-     * If you want to have a more specific generic parsing error message for your validator,
-     * reimplement this in a subclass.
-     */
-    virtual QString genericParsingError() const;
-
-    /*!
-     * \brief Returns an error message if any validation data is missing or invalid.
-     *
-     * Reimplement this in your sublcass to return an error message in case the validation data is missing
-     * or invalid. The default implementation returns a generic message unless a custom one is set via setCustomValidationDataError().
-     *
-     * When reimplementing this function take into account that there might be a custom validation data error message set by the user.
-     */
-    QString validationDataError() const;
-
-    /*!
-     * \brief Returns a generic error message if any validation data is missing or invalid.
-     *
-     * If you want to have a more specific generic validation data error message for your validator,
-     * reimplement this in a subclass.
-     */
-    virtual QString genericValidationDataError() const;
-
-private:
-    Q_DECLARE_PRIVATE(ValidatorRule)
-    Q_DISABLE_COPY(ValidatorRule)
+    friend class Validator;
+    friend class ValidatorPrivate;
 };
 
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorrule_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrule_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,39 +22,53 @@
 #include <QDate>
 #include <QTime>
 #include <QDateTime>
+#include <QTimeZone>
+#include <QLocale>
+#include <Cutelyst/Context>
+#include <limits>
 
 namespace Cutelyst {
 
 class ValidatorRulePrivate
 {
+    Q_DISABLE_COPY(ValidatorRulePrivate)
 public:
-    ValidatorRulePrivate() :
-        trimBefore(true)
-    {}
+    ValidatorRulePrivate() {}
 
-    ValidatorRulePrivate(const QString f, const QString &l, const QString &e) :
+    ValidatorRulePrivate(const QString &f, const ValidatorMessages &m, const QString &dvk) :
         field(f),
-        label(l),
-        customError(e),
-        trimBefore(true)
+        defValKey(dvk),
+        messages(m)
     {}
 
     virtual ~ValidatorRulePrivate() {}
 
-    QDate extractDate(const QString &date, const QString &format = QString()) const
+    QDate extractDate(Context *c, const QString &date, const char *format = nullptr) const
     {
         QDate d;
 
-        if (!format.isEmpty()) {
-            d = QDate::fromString(date, format);
+        Q_ASSERT(c);
+
+        if (format) {
+            const QString _format = translationContext.size() ? c->translate(translationContext.data(), format) : QString::fromUtf8(format);
+            d = QDate::fromString(date, _format);
+            if (d.isValid()) {
+                return d;
+            }
+            d = c->locale().toDate(date, _format);
             if (d.isValid()) {
                 return d;
             }
         }
 
-        const QList<Qt::DateFormat> fs({Qt::ISODate, Qt::RFC2822Date, Qt::TextDate});
+        for (QLocale::FormatType f : {QLocale::ShortFormat, QLocale::LongFormat}) {
+            d = c->locale().toDate(date, f);
+            if (d.isValid()) {
+                return d;
+            }
+        }
 
-        for (Qt::DateFormat f : fs) {
+        for (Qt::DateFormat f : {Qt::ISODate, Qt::RFC2822Date, Qt::TextDate}) {
             d = QDate::fromString(date, f);
             if (d.isValid()) {
                 return d;
@@ -65,20 +79,32 @@ public:
     }
 
 
-    QTime extractTime(const QString &time, const QString &format = QString()) const
+    QTime extractTime(Context *c, const QString &time, const char *format = nullptr) const
     {
         QTime t;
 
-        if (!format.isEmpty()) {
-            t = QTime::fromString(time, format);
+        Q_ASSERT(c);
+
+        if (format) {
+            const QString _format = translationContext.size() ? c->translate(translationContext.data(), format) : QString::fromUtf8(format);
+            t = QTime::fromString(time, _format);
+            if (t.isValid()) {
+                return t;
+            }
+            t = c->locale().toTime(time, _format);
             if (t.isValid()) {
                 return t;
             }
         }
 
-        const QList<Qt::DateFormat> fs({Qt::ISODate, Qt::RFC2822Date, Qt::TextDate});
+        for (QLocale::FormatType f : {QLocale::ShortFormat, QLocale::LongFormat}) {
+            t = c->locale().toTime(time, f);
+            if (t.isValid()) {
+                return t;
+            }
+        }
 
-        for (Qt::DateFormat f : fs) {
+        for (Qt::DateFormat f : {Qt::ISODate, Qt::RFC2822Date, Qt::TextDate}) {
             t = QTime::fromString(time, f);
             if (t.isValid()) {
                 return t;
@@ -89,22 +115,47 @@ public:
     }
 
 
-    QDateTime extractDateTime(const QString &dateTime, const QString &format) const
+    QDateTime extractDateTime(Context *c, const QString &dateTime, const char *format = nullptr, const QTimeZone &tz = QTimeZone()) const
     {
         QDateTime dt;
 
-        if (!format.isEmpty()) {
-            dt = QDateTime::fromString(dateTime, format);
+        Q_ASSERT(c);
+
+        if (format) {
+            const QString _format = translationContext.size() ? c->translate(translationContext.data(), format) : QString::fromUtf8(format);
+            dt = QDateTime::fromString(dateTime, _format);
             if (dt.isValid()) {
+                if (tz.isValid()) {
+                    dt.setTimeZone(tz);
+                }
+                return dt;
+            }
+
+            dt = c->locale().toDateTime(dateTime, _format);
+            if (dt.isValid()) {
+                if (tz.isValid()) {
+                    dt.setTimeZone(tz);
+                }
                 return dt;
             }
         }
 
-        const QList<Qt::DateFormat> fs({Qt::ISODate, Qt::RFC2822Date, Qt::TextDate});
+        for (QLocale::FormatType f : {QLocale::ShortFormat, QLocale::LongFormat}) {
+            dt = c->locale().toDateTime(dateTime, f);
+            if (dt.isValid()) {
+                if (tz.isValid()) {
+                    dt.setTimeZone(tz);
+                }
+                return dt;
+            }
+        }
 
-        for (Qt::DateFormat f : fs) {
+        for (Qt::DateFormat f : {Qt::ISODate, Qt::RFC2822Date, Qt::TextDate}) {
             dt = QDateTime::fromString(dateTime, f);
             if (dt.isValid()) {
+                if (tz.isValid()) {
+                    dt.setTimeZone(tz);
+                }
                 return dt;
             }
         }
@@ -112,13 +163,307 @@ public:
         return dt;
     }
 
+    QVariant extractOtherDateTime(Context *c, const ParamsMultiMap &params, const QString &field, const QTimeZone &tz = QTimeZone(), const char *format = nullptr) const
+    {
+        QVariant var;
+
+        Q_ASSERT(c);
+
+        int sepPos = field.indexOf(QLatin1Char('|'));
+        if (sepPos > -1) {
+            const QString fieldName = field.left(sepPos);
+            const QString value = params.value(fieldName);
+            if (!value.isEmpty()) {
+                const QStringRef type = field.midRef(sepPos + 1);
+                if (type.startsWith(QLatin1String("dt"))) {
+                    QDateTime dt = extractDateTime(c, value, format);
+                    if (dt.isValid()) {
+                        if (tz.isValid()) {
+                            dt.setTimeZone(tz);
+                        }
+                        var.setValue<QDateTime>(dt);
+                    }
+                } else if (type.startsWith(QLatin1Char('t'))) {
+                    const QTime t = extractTime(c, value, format);
+                    if (t.isValid()) {
+                        var.setValue<QTime>(t);
+                    }
+                } else if (type.startsWith(QLatin1Char('d'))) {
+                    const QDate d = extractDate(c, value, format);
+                    if (d.isValid()) {
+                        var.setValue<QDate>(d);
+                    }
+                }
+            }
+        } else {
+            var = c->stash(field);
+        }
+
+        return var;
+    }
+
+    QTimeZone extractTimeZone(Context *c, const ParamsMultiMap &params, const QString &field) const
+    {
+        QTimeZone tz;
+
+        Q_ASSERT(c);
+        Q_UNUSED(params)
+
+        tz = QTimeZone(field.toLatin1());
+
+        if (!tz.isValid()) {
+            const QString tzString = params.value(field, c->stash(field).toString());
+//            const QString tzString = c->stash(field).toString();
+            if (!tzString.isEmpty()) {
+                tz = QTimeZone(tzString.toLatin1());
+                if (!tz.isValid()) {
+                    tz = QTimeZone(tzString.toInt());
+                }
+            }
+        }
+
+        return tz;
+    }
+
+    qlonglong extractLongLong(Context *c, const ParamsMultiMap &params, const QVariant &value, bool *ok) const
+    {
+        qlonglong val = 0;
+
+        Q_ASSERT(c);
+        Q_ASSERT(ok);
+        Q_UNUSED(params)
+
+        if (value.type() == QVariant::String) {
+            const QString field = value.toString();
+/*            if (params.contains(field)) {
+                const QString v = params.value(field);
+                val = v.toLongLong(ok);
+//                if (!*ok) {
+//                    val = c->locale().toLongLong(v, ok);
+//                }
+            } else */if (c->stash().contains(field)) {
+                val = c->stash(field).toLongLong(ok);
+            } else {
+                *ok = false;
+            }
+        } else {
+            val = value.toLongLong(ok);
+        }
+
+        return val;
+    }
+
+    qulonglong extractULongLong(Context *c, const ParamsMultiMap &params, const QVariant &value, bool *ok) const
+    {
+        qulonglong val = 0;
+
+        Q_ASSERT(c);
+        Q_ASSERT(ok);
+        Q_UNUSED(params)
+
+        if (value.type() == QVariant::String) {
+            const QString field = value.toString();
+/*            if (params.contains(field)) {
+                const QString v = params.value(field);
+                val = v.toULongLong(ok);
+//                if (!*ok) {
+//                    val = c->locale().toULongLong(v, ok);
+//                }
+            } else */if (c->stash().contains(field)) {
+                val = c->stash(field).toULongLong(ok);
+            } else {
+                *ok = false;
+            }
+        } else {
+            val = value.toULongLong(ok);
+        }
+
+        return val;
+    }
+
+    double extractDouble(Context *c, const ParamsMultiMap &params, const QVariant &value, bool *ok) const
+    {
+        double val = 0.0;
+
+        Q_ASSERT(c);
+        Q_ASSERT(ok);
+        Q_UNUSED(params)
+
+        if (value.type() == QVariant::String) {
+            const QString field = value.toString();
+/*            if (params.contains(field)) {
+                const QString v = params.value(field);
+                val = v.toDouble(ok);
+//                if (!*ok) {
+//                    val = c->locale().toDouble(v, ok);
+//                }
+            } else*/ if (c->stash().contains(field)) {
+                val = c->stash(field).toDouble(ok);
+            } else {
+                *ok = false;
+            }
+        } else {
+            val = value.toDouble(ok);
+        }
+
+        return val;
+    }
+
+    int extractInt(Context *c, const ParamsMultiMap &params, const QVariant &value, bool *ok) const
+    {
+        int val = 0;
+
+        Q_ASSERT(c);
+        Q_ASSERT(ok);
+        Q_UNUSED(params)
+
+        if (value.type() == QVariant::String) {
+            const QString field = value.toString();
+/*            if (params.contains(field)) {
+                const QString _val = params.value(field);
+                val = _val.toInt(ok);
+//                if (!*ok) {
+//                    val = c->locale().toInt(_val, ok);
+//                }
+            } else*/ if (c->stash().contains(field)) {
+                val = c->stash(field).toInt(ok);
+            } else {
+                *ok = false;
+            }
+        } else {
+            val = value.toInt(ok);
+        }
+
+        return val;
+    }
+
+    QVariant valueToNumber(Context *c, const QString &value, QMetaType::Type type) const
+    {
+        QVariant var;
+
+        Q_UNUSED(c);
+
+        bool ok = false;
+
+        switch (type) {
+        case QMetaType::Short:
+        {
+//            const short v = c->locale().toShort(value, &ok);
+            const short v = value.toShort(&ok);
+            if (ok) {
+                var.setValue<short>(v);
+            }
+        }
+            break;
+        case QMetaType::Int:
+        {
+//            const int v = c->locale().toInt(value, &ok);
+            const int v = value.toInt(&ok);
+            if (ok) {
+                var.setValue<short>(v);
+            }
+        }
+            break;
+        case QMetaType::Long:
+        {
+            const long v = value.toLong(&ok);
+            if (ok) {
+                var.setValue<long>(v);
+            }
+        }
+            break;
+        case QMetaType::LongLong:
+        {
+//            const qlonglong v = c->locale().toLongLong(value, &ok);
+//            if (ok) {
+//                if (type == QMetaType::Long) {
+//                    if (v < static_cast<qlonglong>(std::numeric_limits<long>::max())) {
+//                        var.setValue<long>(static_cast<long>(v));
+//                    }
+//                } else {
+//                    var.setValue<qlonglong>(v);
+//                }
+//            }
+            const qlonglong v = value.toLongLong(&ok);
+            if (ok) {
+                var.setValue<qlonglong>(v);
+            }
+        }
+            break;
+        case QMetaType::UShort:
+        {
+//            const ushort v = c->locale().toUShort(value, &ok);
+            const ushort v = value.toUShort(&ok);
+            if (ok) {
+                var.setValue<ushort>(v);
+            }
+        }
+            break;
+        case QMetaType::UInt:
+        {
+//            const uint v = c->locale().toUInt(value, &ok);
+            const uint v = value.toUInt(&ok);
+            if (ok) {
+                var.setValue<uint>(v);
+            }
+        }
+            break;
+        case QMetaType::ULong:
+        {
+            const ulong v = value.toULong(&ok);
+            if (ok) {
+                var.setValue<ulong>(v);
+            }
+        }
+            break;
+        case QMetaType::ULongLong:
+        {
+//            const qulonglong v = c->locale().toULongLong(value, &ok);
+//            if (ok) {
+//                if (type == QMetaType::ULong) {
+//                    if ((v > static_cast<qulonglong>(std::numeric_limits<ulong>::min())) && (v < static_cast<qulonglong>(std::numeric_limits<ulong>::max()))) {
+//                        var.setValue<ulong>(static_cast<ulong>(v));
+//                    }
+//                } else {
+//                    var.setValue<qulonglong>(v);
+//                }
+//            }
+            const qulonglong v = value.toULongLong(&ok);
+            if (ok) {
+                var.setValue<qulonglong>(v);
+            }
+        }
+            break;
+        case QMetaType::Float:
+        {
+//            const float v = c->locale().toFloat(value, &ok);
+            const float v = value.toFloat(&ok);
+            if (ok) {
+                var.setValue<float>(v);
+            }
+        }
+            break;
+        case QMetaType::Double:
+        {
+//            const double v = c->locale().toDouble(value, &ok);
+            const double v = value.toDouble(&ok);
+            if (ok) {
+                var.setValue<double>(v);
+            }
+        }
+            break;
+        default:
+            break;
+        }
+
+        return var;
+    }
+
+    QLatin1String translationContext;
     QString field;
-    QString label;
-    QString customError;
-    ParamsMultiMap parameters;
-    QString customParsingError;
-    QString customValidationDataError;
-    bool trimBefore;
+    QString defValKey;
+    ValidatorMessages messages;
+    bool trimBefore = true;
 };
 
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorsame.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsame.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,13 +20,8 @@
 
 using namespace Cutelyst;
 
-ValidatorSame::ValidatorSame(const QString &field, const QString &otherField, const QString &label, const QString &otherLabel, const QString &customError) :
-    ValidatorRule(*new ValidatorSamePrivate(field, otherField, label, otherLabel, customError))
-{
-}
-
-ValidatorSame::ValidatorSame(ValidatorSamePrivate &dd) :
-    ValidatorRule(dd)
+ValidatorSame::ValidatorSame(const QString &field, const QString &otherField, const char *otherLabel, const Cutelyst::ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(*new ValidatorSamePrivate(field, otherField, otherLabel, messages, defValKey))
 {
 }
 
@@ -34,38 +29,48 @@ ValidatorSame::~ValidatorSame()
 {
 }
 
-QString ValidatorSame::validate() const
+ValidatorReturnType ValidatorSame::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
     Q_D(const ValidatorSame);
 
-    const QString v = value();
+    const QString v = value(params);
 
-    if (!v.isEmpty() && (v != d->parameters.value(d->otherField))) {
-        result = validationError();
+    if (!v.isEmpty()) {
+        const QString ov = trimBefore() ? params.value(d->otherField).trimmed() : params.value(d->otherField);
+        if (v != ov) {
+            result.errorMessage = validationError(c);
+            qCDebug(C_VALIDATOR, "ValidatorSame: Validation failed for field %s at %s::%s: value is not the same as in the field %s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), qPrintable(d->otherField));
+        } else {
+            result.value.setValue<QString>(v);
+        }
+    } else {
+        defaultValue(c, &result, "ValidatorSame");
     }
 
     return result;
 }
 
-QString ValidatorSame::genericValidationError() const
+QString ValidatorSame::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
 
     Q_D(const ValidatorSame);
-
-    if (label().isEmpty()) {
-        error = QStringLiteral("Must be the same as in the “%1” field.").arg(!d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
+    Q_UNUSED(errorData);
+    const QString _label = label(c);
+    QString _olabel;
+    if (d->otherLabel) {
+        _olabel = d->translationContext.size() ? c->translate(d->translationContext.data(), d->otherLabel) : QString::fromUtf8(d->otherLabel);
     } else {
-        error = QStringLiteral("The “%1” field must have the same value as the “%2” field.").arg(label(), !d->otherLabel.isEmpty() ? d->otherLabel : d->otherField);
+        _olabel = d->otherField;
+    }
+
+    if (_label.isEmpty()) {
+        error = QStringLiteral("Must be the same as in the “%1” field.").arg(_olabel);
+    } else {
+        error = QStringLiteral("The “%1” field must have the same value as the “%2” field.").arg(_label, _olabel);
     }
 
     return error;
-}
-
-void ValidatorSame::setOtherField(const QString &otherField)
-{
-    Q_D(ValidatorSame);
-    d->otherField = otherField;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorsame.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsame.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,16 +26,30 @@ namespace Cutelyst {
 class ValidatorSamePrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief The given field must match the field under validation.
  *
  * The \a field under validation must have the same content as \a otherField.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \par Example
+ * \code{.cpp}
+ * void MyController::do_form(Context *c)
+ * {
+ *     Validator v({new ValidatorSame(QStringLiteral("field"),
+ *                                    QStringLiteral("other_field"),
+ *                                    QT_TRANSLATE_NOOP("MyController", "Other Field"),
+ *                                    ValidatorMessages(QT_TRANSLATE_NOOP("MyController", "Field")))},
+ *                  QLatin1String("MyController"));
+ * }
+ * \endcode
+ *
+ * \sa Validator for general usage of validators.
  */
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorSame : public ValidatorRule
 {
@@ -44,37 +58,30 @@ public:
      * \brief Constructs a new same validator.
      * \param field         Name of the input field to validate.
      * \param otherField    Name of the other field that must have the same input.
-     * \param label         Human readable input field label, used for generic error messages.
      * \param otherLabel    Human readable other field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param messages      Custom error messages if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorSame(const QString &field, const QString &otherField, const QString &label = QString(), const QString &otherLabel = QString(), const QString &customError = QString());
+    ValidatorSame(const QString &field, const QString &otherField, const char *otherLabel = nullptr, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the same validator.
      */
     ~ValidatorSame();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets the name of the other field.
-     */
-    void setOtherField(const QString &otherField);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorSame object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorSame(ValidatorSamePrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorSame)

--- a/Cutelyst/Plugins/Utils/Validator/validatorsame_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsame_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,14 +26,14 @@ namespace Cutelyst {
 class ValidatorSamePrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorSamePrivate(const QString &f, const QString &o, const QString &l, const QString &ol, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
-        otherField(o),
-        otherLabel(ol)
+    ValidatorSamePrivate(const QString &f, const QString &o, const char *ol, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
+        otherLabel(ol),
+        otherField(o)
     {}
 
+    const char * otherLabel = nullptr;
     QString otherField;
-    QString otherLabel;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorsize_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorsize_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,14 +26,14 @@ namespace Cutelyst {
 class ValidatorSizePrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorSizePrivate(const QString &f, QMetaType::Type t, double s, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorSizePrivate(const QString &f, QMetaType::Type t, const QVariant &s, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
         type(t),
         size(s)
     {}
 
     QMetaType::Type type;
-    double size;
+    QVariant size;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatortime.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatortime.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,13 +21,8 @@
 
 using namespace Cutelyst;
 
-ValidatorTime::ValidatorTime(const QString &field, const QString &format, const QString &label, const QString &customError) :
-    ValidatorRule(*new ValidatorTimePrivate(field, format, label, customError))
-{
-}
-
-ValidatorTime::ValidatorTime(ValidatorTimePrivate &dd) :
-    ValidatorRule(dd)
+ValidatorTime::ValidatorTime(const QString &field, const char *format, const Cutelyst::ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(*new ValidatorTimePrivate(field, format, messages, defValKey))
 {
 }
 
@@ -35,45 +30,57 @@ ValidatorTime::~ValidatorTime()
 {
 }
 
-QString ValidatorTime::validate() const
+ValidatorReturnType ValidatorTime::validate(Context *c, const ParamsMultiMap &params) const
 {
-    QString result;
+    ValidatorReturnType result;
 
     Q_D(const ValidatorTime);
 
-    const QString v = value();
+    const QString v = value(params);
 
     if (!v.isEmpty()) {
-        const QTime date = d->extractTime(v, d->format);
-        if (!date.isValid()) {
-            result = validationError();
+        const QTime time = d->extractTime(c, v, d->format);
+
+        if (!time.isValid()) {
+            result.errorMessage = validationError(c);
+            qCDebug(C_VALIDATOR, "ValidatorTime: Validation failed for value \"%s\" in field %s at %s::%s: not a valid time", qPrintable(v), qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+        } else {
+            result.value.setValue<QTime>(time);
         }
+
+    } else {
+        defaultValue(c, &result, "ValidatorTime");
     }
 
     return result;
 }
 
-QString ValidatorTime::genericValidationError() const
+QString ValidatorTime::genericValidationError(Context *c, const QVariant &errorData) const
 {
     QString error;
 
     Q_D(const ValidatorTime);
 
-    if (label().isEmpty()) {
-        error = QStringLiteral("Not a valid time.");
-    } else {
-        if (!d->format.isEmpty()) {
-            error = QStringLiteral("The data in the “%1” field can not be interpreted as time of this schema: “%2”").arg(label(), d->format);
+    Q_UNUSED(errorData)
+
+    const QString _label = label(c);
+
+    if (_label.isEmpty()) {
+
+        if (d->format) {
+            error = c->translate("Cutelyst::ValidatorTime", "Not a valid time according to the following date format: %1").arg(c->translate(d->translationContext.data(), d->format));
         } else {
-            error = QStringLiteral("The data in the “%1” field can not be interpreted as time.").arg(label());
+            error = c->translate("Cutelyst::ValidatorTime", "Not a valid time.");
+        }
+
+    } else {
+
+        if (d->format) {
+            error = c->translate("Cutelyst::ValidatorTime", "The value in the “%1” field can not be parsed as time according to the following scheme: %2").arg(_label, c->translate(d->translationContext.data(), d->format));
+        } else {
+            error = c->translate("Cutelyst::ValidatorTime", "The value in the “%1” field can not be parse as time.").arg(_label);
         }
     }
 
    return error;
-}
-
-void ValidatorTime::setFormat(const QString &format)
-{
-    Q_D(ValidatorTime);
-    d->format = format;
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatortime.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatortime.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,18 +26,22 @@ namespace Cutelyst {
 class ValidatorTimePrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief Checks if the input data is a valid time.
  *
  * This validator checks if the input \a field can be parsed into a QTime, it will check the parsing ability but will not convert the
  * input data into a QTime. If a custom \a format is given, the validator will at first try to parse the date according to that \a format.
- * If that fails, it will try to parse the date based on standard formats in the following order: Qt::ISODate, Qt::RFC2822Date, Qt::TextDate
+ * If that fails or if there is no custom \a inputFormat set, it will try to parse the date based on standard formats in the following order:
+ * \link Context::locale() Context locale's \endlink \link QLocale::toDate() toDate() \endlink with QLocale::ShortFormat and QLocale::LongFormat,
+ * Qt::ISODate, Qt::RFC2822Date, Qt::TextDate
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  *
  * \sa ValidatorDateTime, ValidatorDate
  */
@@ -47,37 +51,29 @@ public:
     /*!
      * \brief Constructs a new time validator.
      * \param field         Name of the input field to validate.
-     * \param format        Optional time format for input parsing.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param format        Optional time format for input parsing, can be translatable.
+     * \param messages      Custom error messages if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorTime(const QString &field, const QString &format = QString(), const QString &label = QString(), const QString &customError = QString());
+    ValidatorTime(const QString &field, const char *format = nullptr, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs time the validator.
      */
     ~ValidatorTime();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets an optional date format.
-     */
-    void setFormat(const QString &format);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramater value converted into a QTime.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorTime object with the given private class.
+     * \brief Returns a generic error if validation failed.
      */
-    ValidatorTime(ValidatorTimePrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorTime)

--- a/Cutelyst/Plugins/Utils/Validator/validatortime_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatortime_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,12 +26,12 @@ namespace Cutelyst {
 class ValidatorTimePrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorTimePrivate(const QString &f, const QString &fo, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorTimePrivate(const QString &f, const char *fo, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
         format(fo)
     {}
 
-    QString format;
+    const char *format = nullptr;
 };
     
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatorurl.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorurl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,16 +26,18 @@ namespace Cutelyst {
 class ValidatorUrlPrivate;
 
 /*!
+ * \ingroup plugins-utils-validator-rules
  * \brief The field under validation must be a valid URL.
  *
  * Checks if the \a field contains a valid URL by loading it into a QUrl and testing it's validity.
  *
- * If ValidatorRule::trimBefore() is set to \c true (the default), whitespaces will be removed from
- * the beginning and the end of the input value before validation. If the \a field's value is empty or if
- * the \a field is missing in the input data, the validation will succeed without performing the validation itself.
- * Use one of the \link ValidatorRequired required validators \endlink to require the field to be present and not empty.
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
  *
- * \link Validator See Validator for general usage of validators. \endlink
+ * \sa Validator for general usage of validators.
  */
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorUrl : public ValidatorRule
 {
@@ -57,41 +59,29 @@ public:
      * \param field         Name of the input field to validate.
      * \param constraints   Constraints for parsing and validating the URL.
      * \param schemes       List of allowed schemes for a valid URL.
-     * \param label         Human readable input field label, used for generic error messages.
-     * \param customError   Custom error message if validation fails.
+     * \param messages      Custom error messages if validation fails.
+     * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorUrl(const QString &field, Constraints constraints = NoConstraint, const QStringList &schemes = QStringList(), const QString &label = QString(), const QString &customError = QString());
+    ValidatorUrl(const QString &field, Constraints constraints = NoConstraint, const QStringList &schemes = QStringList(), const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
     
     /*!
      * \brief Deconstructs the validator.
      */
     ~ValidatorUrl();
     
-    /*!
-     * \brief Performs the validation and returns an empty QString on success, otherwise an error message.
-     */
-    QString validate() const override;
-
-    /*!
-     * \brief Sets optional validation contraints.
-     */
-    void setConstraints(Constraints constraints);
-
-    /*!
-     * \brief Sets an optional list of valid schemes.
-     */
-    void setSchemes(const QStringList &schemes);
-    
 protected:
     /*!
-     * \brief Returns a generic error message.
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value converted into QUrl.
      */
-    QString genericValidationError() const override;
-    
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
     /*!
-     * Constructs a new ValidatorUrl object with the given private class.
+     * \brief Returns a generic error message if validation failed.
      */
-    ValidatorUrl(ValidatorUrlPrivate &dd);
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
     
 private:
     Q_DECLARE_PRIVATE(ValidatorUrl)

--- a/Cutelyst/Plugins/Utils/Validator/validatorurl_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorurl_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,8 @@ namespace Cutelyst {
 class ValidatorUrlPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorUrlPrivate(const QString &f, ValidatorUrl::Constraints c, const QStringList &s, const QString &l, const QString &e) :
-        ValidatorRulePrivate(f, l, e),
+    ValidatorUrlPrivate(const QString &f, ValidatorUrl::Constraints c, const QStringList &s, const Cutelyst::ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
         constraints(c),
         schemes(s)
     {}

--- a/Cutelyst/Plugins/View/Grantlee/csrf.h
+++ b/Cutelyst/Plugins/View/Grantlee/csrf.h
@@ -27,6 +27,8 @@
 
 class CSRFTag : public Grantlee::AbstractNodeFactory
 {
+    Q_OBJECT
+public:
     Grantlee::Node *getNode(const QString &tagContent, Grantlee::Parser *p) const override;
 };
 

--- a/tests/testmemcached.cpp
+++ b/tests/testmemcached.cpp
@@ -19,6 +19,9 @@ using namespace Cutelyst;
 class TestMemcached : public CoverageObject
 {
     Q_OBJECT
+public:
+    explicit TestMemcached(QObject *parent = nullptr) : CoverageObject(parent) {}
+
 private Q_SLOTS:
     void initTestCase();
 
@@ -877,7 +880,7 @@ private:
         return list;
     }
 
-    QHash<QString,QByteArray> getTestHash(const QString &prefix = QLatin1String("val")) {
+    QHash<QString,QByteArray> getTestHash(const QString &prefix = QStringLiteral("val")) {
         QHash<QString,QByteArray> hash;
         hash.insert(prefix + QLatin1Char('1'), QByteArrayLiteral("Lorem ipsum"));
         hash.insert(prefix + QLatin1Char('2'), QByteArrayLiteral("dolor sit amet"));
@@ -888,7 +891,7 @@ private:
         return hash;
     }
 
-    QHash<QString,QVariantList> getTestHashList(const QString &prefix = QLatin1String("val")) {
+    QHash<QString,QVariantList> getTestHashList(const QString &prefix = QStringLiteral("val")) {
         QHash<QString,QVariantList> hash;
         for (int i = 0; i < 6; ++i) {
             hash.insert(prefix + QString::number(i), getTestVariantList2());


### PR DESCRIPTION
The input validator plugin for Cutelyst2 now supports translations for
custom messages as well as for the included generic messages.

Beside translation support, the validator rules were cleaned up and are now
only meant to be used together with a Validator object. Some rules
export their validation logic in a static member function - where i
makes sense.

Validator rules gained more flexibility by being able to get comparison
values from the stash instead using only hard coded values on
construciton.

The returned result will now contain alls extracted and converted input
values.

The email validato has been greatly improved by now parsing email
addresses according to different RFCs and constraints that make it
possible to set a custom threshold about what should be seen as valid.