### PR TITLE
Fix wrong install location for Grantlee view headers

### DIFF
--- a/Cutelyst/Plugins/Utils/Validator/validator.h
+++ b/Cutelyst/Plugins/Utils/Validator/validator.h
@@ -44,7 +44,7 @@ namespace Cutelyst {
  *
  * <h3>Building and using</h3>
  * The plugin is linked to %Cutelyst Core API and the QtNetwork module. To use it in your application, link your
- * application to \a Cutelyst2Qt5::Utils::Validator.
+ * application to \a Cutelyst::Utils::Validator.
  */
 
 class ValidatorPrivate;

--- a/Cutelyst/Plugins/View/Grantlee/CMakeLists.txt
+++ b/Cutelyst/Plugins/View/Grantlee/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(Cutelyst2Qt5ViewGrantlee
 set_property(TARGET Cutelyst2Qt5ViewGrantlee PROPERTY PUBLIC_HEADER ${plugin_view_grantlee_HEADERS})
 install(TARGETS Cutelyst2Qt5ViewGrantlee
     EXPORT CutelystTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    PUBLIC_HEADER DESTINATION include/cutelyst2-qt5/Cutelyst/Plugins/View/JSON
+    PUBLIC_HEADER DESTINATION include/cutelyst2-qt5/Cutelyst/Plugins/View/Grantlee
 )
 
 # urifor and csrf_token


### PR DESCRIPTION
Public headers for the Grantlee view plugin were installed into the JSON view headers directory. Also fixing wrong component name in validator plugin documentation.