### PR TITLE
Validator plugin: add two required validators that use the stash

### DIFF
--- a/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
+++ b/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
@@ -65,6 +65,8 @@ set(plugin_validator_SRC
     validatorrequiredifstash_p.h
     validatorrequiredunless.cpp
     validatorrequiredunless_p.h
+    validatorrequiredunlessstash.cpp
+    validatorrequiredunlessstash_p.h
     validatorrequiredwith.cpp
     validatorrequiredwith_p.h
     validatorrequiredwithall.cpp
@@ -122,6 +124,7 @@ set(plugin_validator_HEADERS
     validatorrequiredif.h
     validatorrequiredifstash.h
     validatorrequiredunless.h
+    validatorrequiredunlessstash.h
     validatorrequiredwith.h
     validatorrequiredwithall.h
     validatorrequiredwithout.h

--- a/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
+++ b/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
@@ -61,6 +61,8 @@ set(plugin_validator_SRC
     validatorrequired_p.h
     validatorrequiredif.cpp
     validatorrequiredif_p.h
+    validatorrequiredifstash.cpp
+    validatorrequiredifstash_p.h
     validatorrequiredunless.cpp
     validatorrequiredunless_p.h
     validatorrequiredwith.cpp
@@ -118,6 +120,7 @@ set(plugin_validator_HEADERS
     validatorregularexpression.h
     validatorrequired.h
     validatorrequiredif.h
+    validatorrequiredifstash.h
     validatorrequiredunless.h
     validatorrequiredwith.h
     validatorrequiredwithall.h

--- a/Cutelyst/Plugins/Utils/Validator/Validators
+++ b/Cutelyst/Plugins/Utils/Validator/Validators
@@ -29,6 +29,7 @@
 #include "validatorrequiredif.h"
 #include "validatorrequiredifstash.h"
 #include "validatorrequiredunless.h"
+#include "validatorrequiredunlessstash.h"
 #include "validatorrequiredwith.h"
 #include "validatorrequiredwithall.h"
 #include "validatorrequiredwithout.h"

--- a/Cutelyst/Plugins/Utils/Validator/Validators
+++ b/Cutelyst/Plugins/Utils/Validator/Validators
@@ -27,6 +27,7 @@
 #include "validatorregularexpression.h"
 #include "validatorrequired.h"
 #include "validatorrequiredif.h"
+#include "validatorrequiredifstash.h"
 #include "validatorrequiredunless.h"
 #include "validatorrequiredwith.h"
 #include "validatorrequiredwithall.h"

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredifstash.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredifstash.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018 Matthias Fehring <kontakt@buschmann23.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "validatorrequiredifstash_p.h"
+
+using namespace Cutelyst;
+
+ValidatorRequiredIfStash::ValidatorRequiredIfStash(const QString &field, const QString &stashKey, const QVariantList &stashValues, const ValidatorMessages &messages) :
+    ValidatorRule(* new ValidatorRequiredIfStashPrivate(field, stashKey, stashValues, messages))
+{
+}
+
+ValidatorRequiredIfStash::~ValidatorRequiredIfStash()
+{
+}
+
+ValidatorReturnType ValidatorRequiredIfStash::validate(Context *c, const ParamsMultiMap &params) const
+{
+    ValidatorReturnType result;
+
+    Q_D(const ValidatorRequiredIfStash);
+
+    if (d->stashKey.isEmpty() || d->stashValues.empty()) {
+        result.errorMessage = validationDataError(c);
+        qCWarning(C_VALIDATOR, "ValidatorRequiredIfStash: invalid validation data for field %s at %s::%s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+    } else {
+        const QString v = value(params);
+        const QVariant sv = c->stash(d->stashKey);
+        if (d->stashValues.contains(sv)) {
+            if (v.isEmpty()) {
+                result.errorMessage = validationError(c);
+                qCDebug(C_VALIDATOR, "ValidatorRequiredIfStash: Validation failed for field %s at %s::%s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+            } else {
+                result.value.setValue<QString>(v);
+            }
+        } else {
+            if (!v.isEmpty()) {
+                result.value.setValue<QString>(v);
+            }
+        }
+    }
+
+    return result;
+}
+
+QString ValidatorRequiredIfStash::genericValidationError(Context *c, const QVariant &errorData) const
+{
+    QString error;
+    Q_UNUSED(errorData);
+    const QString _label = label(c);
+    if (_label.isEmpty()) {
+        error = c->translate("Cutelyst::ValidatorRequiredIfStash", "This is required.");
+    } else {
+        error = c->translate("Cutelyst::ValidatorRequiredIfStash", "You must fill in the “%1” field.").arg(_label);
+    }
+    return error;
+}

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredifstash.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredifstash.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2018 Matthias Fehring <kontakt@buschmann23.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef CUTELYSTVALIDATORREQUIREDIFSTASH_H
+#define CUTELYSTVALIDATORREQUIREDIFSTASH_H
+
+#include "validatorrule.h"
+#include <Cutelyst/cutelyst_global.h>
+
+namespace Cutelyst {
+
+class ValidatorRequiredIfStashPrivate;
+
+/*!
+ * \ingroup plugins-utils-validator-rules
+ * \class ValidatorRequiredIfStash validatorrequiredifstash.h <Cutelyst/Plugins/Utils/validatorrequiredifstash.h>
+ * \brief The field under validation must be present and not empty if the content of a stash key is equal to one from a list.
+ *
+ * If the value of the \link Context::stash() stash\endlink key is equal to one of the values defined in the \a stashValues list,
+ * the input \a field under validation must be present and not empty. This validator is the opposite of ValidatorRequiredUnlessStash
+ * and it is similar to ValidatorRequiredIf.
+ *
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation. So, fields that only contain
+ * whitespaces will be treated as empty.
+ *
+ * \sa Validator for general usage of validators.
+ *
+ * \sa ValidatorRequired, ValidatorRequiredIf, ValidatorRequiredUnless, ValidatorRequiredWith, ValidatorRequiredWithAll, ValidatorRequiredWithout,
+ * ValidatorRequiredWithoutAll, ValidatorRequiredUnlessStash
+ */
+class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorRequiredIfStash : public ValidatorRule
+{
+public:
+    /*!
+     * \brief Constructs a new required if stash validator.
+     * \param field         Name of the input field to validate.
+     * \param stashKey      Name of the stash key to compare against.
+     * \param stashValues   Values in the \a stashKey from which one must match the content of the stash key to require the \a field.
+     * \param messages      Custom error messages if validation fails.
+     */
+    ValidatorRequiredIfStash(const QString &field, const QString &stashKey, const QVariantList &stashValues, const ValidatorMessages &messages = ValidatorMessages());
+
+    /*!
+     * \brief Deconstructs the required if validator.
+     */
+    ~ValidatorRequiredIfStash();
+
+protected:
+    /*!
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
+     */
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
+    /*!
+     * \brief Returns a generic error message if validation failed.
+     */
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
+
+private:
+    Q_DECLARE_PRIVATE(ValidatorRequiredIfStash)
+    Q_DISABLE_COPY(ValidatorRequiredIfStash)
+};
+
+}
+
+#endif // CUTELYSTVALIDATORREQUIREDIFSTASH_H

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredifstash_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredifstash_p.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Matthias Fehring <kontakt@buschmann23.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef CUTELYSTVALIDATORREQUIREDIFSTASH_P_H
+#define CUTELYSTVALIDATORREQUIREDIFSTASH_P_H
+
+#include "validatorrequiredifstash.h"
+#include "validatorrule_p.h"
+
+namespace Cutelyst {
+
+class ValidatorRequiredIfStashPrivate : public ValidatorRulePrivate
+{
+public:
+    ValidatorRequiredIfStashPrivate(const QString &f, const QString &sk, const QVariantList &sv, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString()),
+        stashKey(sk),
+        stashValues(sv)
+    {}
+
+    QString stashKey;
+    QVariantList stashValues;
+};
+
+}
+
+#endif // CUTELYSTVALIDATORREQUIREDIFSTASH_P_H

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredunlessstash.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredunlessstash.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018 Matthias Fehring <kontakt@buschmann23.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "validatorrequiredunlessstash_p.h"
+
+using namespace Cutelyst;
+
+ValidatorRequiredUnlessStash::ValidatorRequiredUnlessStash(const QString &field, const QString &stashKey, const QVariantList &stashValues, const ValidatorMessages &messages) :
+    ValidatorRule(* new ValidatorRequiredUnlessStashPrivate(field, stashKey, stashValues, messages))
+{
+}
+
+ValidatorRequiredUnlessStash::~ValidatorRequiredUnlessStash()
+{
+}
+
+ValidatorReturnType ValidatorRequiredUnlessStash::validate(Context *c, const ParamsMultiMap &params) const
+{
+    ValidatorReturnType result;
+
+    Q_D(const ValidatorRequiredUnlessStash);
+
+    if (d->stashKey.isEmpty() || d->stashValues.empty()) {
+        result.errorMessage = validationDataError(c);
+        qCWarning(C_VALIDATOR, "ValidatorRequiredUnlessStash: invalid validation data for field %s at %s::%s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()));
+    } else {
+        const QString v = value(params);
+        const QVariant sv = c->stash(d->stashKey);
+        if (!d->stashValues.contains(sv)) {
+            if (!v.isEmpty()) {
+                result.value.setValue<QString>(v);
+            } else {
+                result.errorMessage = validationError(c);
+            }
+        } else {
+            if (!v.isEmpty()) {
+                result.value.setValue<QString>(v);
+            }
+        }
+    }
+
+    return result;
+}
+
+QString ValidatorRequiredUnlessStash::genericValidationError(Context *c, const QVariant &errorData) const
+{
+    QString error;
+    Q_UNUSED(errorData)
+    const QString _label = label(c);
+    if (_label.isEmpty()) {
+        error = c->translate("Cutelyst::ValidatorRequiredUnlessStash", "This is required.");
+    } else {
+        error = c->translate("Cutelyst::ValidatorRequiredUnlessStash", "You must fill in the “%1” field.").arg(_label);
+    }
+    return error;
+}

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredunlessstash.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredunlessstash.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2018 Matthias Fehring <kontakt@buschmann23.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef CUTELYSTVALIDATORREQUIREDUNLESSSTASH_H
+#define CUTELYSTVALIDATORREQUIREDUNLESSSTASH_H
+
+#include "validatorrule.h"
+#include <Cutelyst/cutelyst_global.h>
+
+namespace Cutelyst {
+
+class ValidatorRequiredUnlessStashPrivate;
+
+/*!
+ * \ingroup plugins-utils-validator-rules
+ * \class ValidatorRequiredUnlessStash validatorrequiredunlessstash.h <Cutelyst/Plugins/Utils/validatorrequiredunlessstash.h>
+ * \brief The \a field under validation must be present and not emptly unless the content of a stash key is equal to a value in a list.
+ *
+ * If the \link Context::stash() stash\endlink content identified by \a stashKey does \b not contain \b any of the values specified in the
+ * \a stashValues list, the \a field under validation must be present and not empty. This validator ist the opposite of ValidatorRequiredIfStash
+ * and is similar to ValidatorRequiredUnless.
+ *
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation. So, fields that only contain
+ * whitespaces will be treated as empty.
+ *
+ * \sa Validator for general usage of validators.
+ *
+ * \sa ValidatorRequired, ValidatorRequiredIf, ValidatorRequiredUnless, ValidatorRequiredWith, ValidatorRequiredWithAll, ValidatorRequiredWithout,
+ * ValidatorRequiredWithoutAll, ValidatorRequiredIfStash
+ */
+class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorRequiredUnlessStash : public ValidatorRule
+{
+public:
+    /*!
+     * \brief Constructs a new required unless stash validator.
+     * \param field         Name of the input field to validate.
+     * \param stashKey      Name of the stash key to compare against.
+     * \param stashValues   Values in the \a stashKey from which no one must match the content of the stash key to require the \a field.
+     * \param messages      Custom error messages if validation fails.
+     */
+    ValidatorRequiredUnlessStash(const QString &field, const QString &stashKey, const QVariantList &stashValues, const ValidatorMessages &messages = ValidatorMessages());
+
+    /*!
+     * \brief Deconstructs the required unless stash validator.
+     */
+    ~ValidatorRequiredUnlessStash();
+
+protected:
+    /*!
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
+     */
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
+    /*!
+     * \brief Returns a generic error message if validation failed.
+     */
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
+
+private:
+    Q_DECLARE_PRIVATE(ValidatorRequiredUnlessStash)
+    Q_DISABLE_COPY(ValidatorRequiredUnlessStash)
+};
+
+}
+
+#endif // CUTELYSTVALIDATORREQUIREDUNLESSSTASH_H

--- a/Cutelyst/Plugins/Utils/Validator/validatorrequiredunlessstash_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrequiredunlessstash_p.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 Matthias Fehring <kontakt@buschmann23.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef CUTELYSTVALIDATORREQUIREDUNLESSSTASH_P_H
+#define CUTELYSTVALIDATORREQUIREDUNLESSSTASH_P_H
+
+#include "validatorrequiredunlessstash.h"
+#include "validatorrule_p.h"
+
+namespace Cutelyst {
+
+class ValidatorRequiredUnlessStashPrivate : public ValidatorRulePrivate
+{
+public:
+    ValidatorRequiredUnlessStashPrivate(const QString &f, const QString &sk, const QVariantList &sv, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString()),
+        stashKey(sk),
+        stashValues(sv)
+    {}
+
+    QString stashKey;
+    QVariantList stashValues;
+};
+
+}
+
+#endif // CUTELYSTVALIDATORREQUIREDUNLESSSTASH_P_H

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -613,6 +613,22 @@ public:
         checkResponse(c, v.validate(c));
     }
 
+    // ***** Endpoint for ValidatorRequiredIfStash with stash match *****
+    C_ATTR(requiredIfStashMatch, :Local :AutoArgs)
+    void requiredIfStashMatch(Context *c) {
+        c->setStash(QStringLiteral("stashkey"), QStringLiteral("eins"));
+        Validator v({new ValidatorRequiredIfStash(QStringLiteral("field"), QStringLiteral("stashkey"), QVariantList({QStringLiteral("eins"), QStringLiteral("zwei")}), m_validatorMessages)});
+        checkResponse(c, v.validate(c));
+    }
+
+    // ***** Endpoint for ValidatorRequiredIfStash with stash not match *****
+    C_ATTR(requiredIfStashNotMatch, :Local :AutoArgs)
+    void requiredIfStashNotMatch(Context *c) {
+        c->setStash(QStringLiteral("stashkey"), QStringLiteral("drei"));
+        Validator v({new ValidatorRequiredIfStash(QStringLiteral("field"), QStringLiteral("stashkey"), QVariantList({QStringLiteral("eins"), QStringLiteral("zwei")}), m_validatorMessages)});
+        checkResponse(c, v.validate(c));
+    }
+
     // ***** Endpoint for ValidatorRequiredUnless ******
     C_ATTR(requiredUnless, :Local :AutoArgs)
     void requiredUnless(Context *c) {
@@ -2439,6 +2455,24 @@ void TestValidator::testController_data()
     QTest::newRow("requiredif-invalid01") << QStringLiteral("/requiredIf") << headers << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
 
+
+    // **** Start testing ValidatorRequiredIfStash with matching stash key *****
+
+    query.clear();
+    query.addQueryItem(QStringLiteral("field"), QStringLiteral("adsf"));
+    QTest::newRow("requiredifstash-valid01") << QStringLiteral("/requiredIfStashMatch") << headers << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+
+    query.clear();
+    query.addQueryItem(QStringLiteral("field"), QStringLiteral("adsf"));
+    QTest::newRow("requiredifstash-valid02") << QStringLiteral("/requiredIfStashNotMatch") << headers << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+
+    query.clear();
+    query.addQueryItem(QStringLiteral("field2"), QStringLiteral("adsf"));
+    QTest::newRow("requiredifstash-invalid03") << QStringLiteral("/requiredIfStashNotMatch") << headers << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+
+    query.clear();
+    query.addQueryItem(QStringLiteral("field2"), QStringLiteral("adsf"));
+    QTest::newRow("requiredifstash-invalid") << QStringLiteral("/requiredIfStashMatch") << headers << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     // **** Start testing ValidatorRequiredUnless *****
 

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -636,6 +636,22 @@ public:
         checkResponse(c, v.validate(c));
     }
 
+    // ***** Endpoint for ValidatorRequiredUnlessStash with stash match *****
+    C_ATTR(requiredUnlessStashMatch, :Local :AutoArgs)
+    void requiredUnlessStashMatch(Context *c) {
+        c->setStash(QStringLiteral("stashkey"), QStringLiteral("eins"));
+        Validator v({new ValidatorRequiredUnlessStash(QStringLiteral("field"), QStringLiteral("stashkey"), QVariantList({QStringLiteral("eins"), QStringLiteral("zwei")}), m_validatorMessages)});
+        checkResponse(c, v.validate(c));
+    }
+
+    // ***** Endpoint for ValidatorRequiredUnlessStash with stash not match *****
+    C_ATTR(requiredUnlessStashNotMatch, :Local :AutoArgs)
+    void requiredUnlessStashNotMatch(Context *c) {
+        c->setStash(QStringLiteral("stashkey"), QStringLiteral("drei"));
+        Validator v({new ValidatorRequiredUnlessStash(QStringLiteral("field"), QStringLiteral("stashkey"), QVariantList({QStringLiteral("eins"), QStringLiteral("zwei")}), m_validatorMessages)});
+        checkResponse(c, v.validate(c));
+    }
+
     // ***** Endpoint for ValidatorRequiredWith ******
     C_ATTR(requiredWith, :Local :AutoArgs)
     void requiredWith(Context *c) {
@@ -2456,7 +2472,7 @@ void TestValidator::testController_data()
 
 
 
-    // **** Start testing ValidatorRequiredIfStash with matching stash key *****
+    // **** Start testing ValidatorRequiredIfStash *****
 
     query.clear();
     query.addQueryItem(QStringLiteral("field"), QStringLiteral("adsf"));
@@ -2505,6 +2521,27 @@ void TestValidator::testController_data()
     QTest::newRow("requiredunless-invalid01") << QStringLiteral("/requiredUnless") << headers << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
 
+    // **** Start testing ValidatorRequiredUnlessStash *****
+
+    query.clear();
+    query.addQueryItem(QStringLiteral("field"), QStringLiteral("asdf"));
+    QTest::newRow("requiredunlessstash-valid00") << QStringLiteral("/requiredUnlessStashMatch") << headers << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+
+    query.clear();
+    query.addQueryItem(QStringLiteral("field2"), QStringLiteral("asdf"));
+    QTest::newRow("requiredunlessstash-valid01") << QStringLiteral("/requiredUnlessStashMatch") << headers << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+
+    query.clear();
+    query.addQueryItem(QStringLiteral("field"), QStringLiteral("asdf"));
+    QTest::newRow("requiredunlessstash-valid02") << QStringLiteral("/requiredUnlessStashNotMatch") << headers << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+
+    query.clear();
+    query.addQueryItem(QStringLiteral("field2"), QStringLiteral("asdf"));
+    QTest::newRow("requiredunlessstash-invalid00") << QStringLiteral("/requiredUnlessStashNotMatch") << headers << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+
+    query.clear();
+    query.addQueryItem(QStringLiteral("field2"), QStringLiteral("%20"));
+    QTest::newRow("requiredunlessstash-invalid01") << QStringLiteral("/requiredUnlessStashNotMatch") << headers << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
 
     // **** Start testing ValidatorRequiredWith *****


### PR DESCRIPTION
Till now there were only requirement validators that compared against other input fields. Now I added two that work like the ones that use the input fields but instead using the current stash.