### PR TITLE
Validator plugin: add new ValidatorDomain to check domain names

### DIFF
--- a/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
+++ b/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
@@ -31,6 +31,8 @@ set(plugin_validator_SRC
     validatordigits_p.h
     validatordigitsbetween.cpp
     validatordigitsbetween_p.h
+    validatordomain.cpp
+    validatordomain_p.h
     validatoremail.cpp
     validatoremail_p.h
     validatorfilesize.cpp
@@ -107,6 +109,7 @@ set(plugin_validator_HEADERS
     validatordifferent.h
     validatordigits.h
     validatordigitsbetween.h
+    validatordomain.h
     validatoremail.h
     validatorfilesize.h
     validatorfilled.h

--- a/Cutelyst/Plugins/Utils/Validator/Validators
+++ b/Cutelyst/Plugins/Utils/Validator/Validators
@@ -12,6 +12,7 @@
 #include "validatordifferent.h"
 #include "validatordigits.h"
 #include "validatordigitsbetween.h"
+#include "validatordomain.h"
 #include "validatoremail.h"
 #include "validatorfilesize.h"
 #include "validatorfilled.h"

--- a/Cutelyst/Plugins/Utils/Validator/validatordomain.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatordomain.cpp
@@ -1,0 +1,306 @@
+/*
+ * Copyright (C) 2018 Matthias Fehring <kontakt@buschmann23.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "validatordomain_p.h"
+#include <QUrl>
+#include <QStringList>
+#include <QHostInfo>
+
+using namespace Cutelyst;
+
+ValidatorDomain::ValidatorDomain(const QString &field, bool checkDNS, const ValidatorMessages &messages, const QString &defValKey) :
+    ValidatorRule(* new ValidatorDomainPrivate(field, checkDNS, messages, defValKey))
+{
+}
+
+ValidatorDomain::~ValidatorDomain()
+{
+}
+
+bool ValidatorDomain::validate(const QString &value, bool checkDNS, Cutelyst::ValidatorDomain::Diagnose *diagnose, QString *extractedValue)
+{
+    bool valid = true;
+
+    Diagnose diag = Valid;
+
+    QString _v = value;
+    bool hasRootDot = false;
+    if (_v.endsWith(QLatin1Char('.'))) {
+        hasRootDot = true;
+        _v.chop(1);
+    }
+
+    // convert to lower case puny code
+    const QString v = QString::fromLatin1(QUrl::toAce(_v)).toLower();
+
+    // split up the utf8 string into parts to get the non puny code TLD
+    const QStringList nonAceParts = _v.split(QLatin1Char('.'));
+    if (!nonAceParts.empty()) {
+        const QString tld = nonAceParts.last();
+        if (!tld.isEmpty()) {
+            // there are no TLDs with digits inside, but IDN TLDs can
+            // have digits in their puny code representation, so we have
+            // to check at first if the IDN TLD contains digits beforce
+            // converting all to ACE puny code
+            for (const QChar &ch : tld) {
+                const ushort &uc = ch.unicode();
+                if (((uc > 47) && (uc < 58)) || (uc == 45)) {
+                    diag = InvalidTLD;
+                    valid = false;
+                    break;
+                }
+            }
+
+            if (valid) {
+                if (!v.isEmpty()) {
+                    // maximum length of the name in the DNS is 253 without the last dot
+                    if (v.length() < 254) {
+                        const QStringList parts = v.split(QLatin1Char('.'), QString::KeepEmptyParts);
+                        // there has to be more than only the TLD
+                        if (parts.size() > 1) {
+                            // the TLD can not have only 1 char
+                            if (parts.last().length() > 1) {
+                                for (int i = 0; i < parts.size(); ++i) {
+                                    if (valid) {
+                                        const QString part = parts.at(i);
+                                        if (!part.isEmpty()) {
+                                            // labels/parts can have a maximum length of 63 chars
+                                            if (part.length() < 64) {
+                                                bool isTld = (i == (parts.size() -1));
+                                                bool isPunyCode = part.startsWith(QLatin1String("xn--"));
+                                                for (int j = 0; j < part.size(); ++j) {
+                                                    const ushort &uc = part.at(j).unicode();
+                                                    const bool isDigit = ((uc > 47) && (uc < 58));
+                                                    const bool isDash = (uc == 45);
+                                                    // no part/label can start with a digit or a dash
+                                                    if ((j == 0) && (isDash || isDigit)) {
+                                                        valid = false;
+                                                        diag = isDash ? DashStart : DigitStart;
+                                                        break;
+                                                    }
+                                                    // no part/label can end with a dash
+                                                    if ((j == (part.size() - 1)) && isDash) {
+                                                        valid = false;
+                                                        diag = DashEnd;
+                                                        break;
+                                                    }
+                                                    const bool isChar = ((uc > 96) && (uc < 123));
+                                                    if (!isTld) {
+                                                        // if it is not the tld, it can have a-z 0-9 and -
+                                                        if (!(isDigit || isDash || isChar)) {
+                                                            valid = false;
+                                                            diag = InvalidChars;
+                                                            break;
+                                                        }
+                                                    } else {
+                                                        if (isPunyCode) {
+                                                            if (!(isDigit || isDash || isChar)) {
+                                                                valid = false;
+                                                                diag = InvalidTLD;
+                                                                break;
+                                                            }
+                                                        } else {
+                                                            if (!isChar) {
+                                                                valid = false;
+                                                                diag = InvalidTLD;
+                                                                break;
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            } else {
+                                                valid = false;
+                                                diag = LabelTooLong;
+                                                break;
+                                            }
+                                        } else {
+                                            valid = false;
+                                            diag = EmptyLabel;
+                                            break;
+                                        }
+                                    } else {
+                                        break;
+                                    }
+                                }
+                            } else {
+                                valid = false;
+                                diag = InvalidTLD;
+                            }
+                        } else {
+                            valid = false;
+                            diag = InvalidLabelCount;
+                        }
+                    } else {
+                        valid = false;
+                        diag = TooLong;
+                    }
+                } else {
+                    valid = false;
+                    diag = EmptyLabel;
+                }
+            }
+        } else {
+            valid = false;
+            diag = EmptyLabel;
+        }
+    } else {
+        valid = false;
+        diag = EmptyLabel;
+    }
+
+
+    if (valid && checkDNS) {
+        const QHostInfo hi = QHostInfo::fromName(v);
+        if ((hi.error() != QHostInfo::NoError) || hi.addresses().empty()) {
+            diag = MissingDNS;
+            valid = false;
+        }
+    }
+
+    if (diagnose) {
+        *diagnose = diag;
+    }
+
+    if (valid && extractedValue) {
+        if (hasRootDot) {
+            *extractedValue = v + QLatin1Char('.');
+        } else {
+            *extractedValue = v;
+        }
+    }
+
+    return valid;
+}
+
+QString ValidatorDomain::diagnoseString(Context *c, Diagnose diagnose, const QString &label)
+{
+    QString error;
+
+    if (label.isEmpty()) {
+        switch (diagnose) {
+        case MissingDNS:
+            error = c->translate("Cutelyst::ValidatorDomain", "The domain name seems to be valid but could not be found in the domain name system.");
+            break;
+        case InvalidChars:
+            error = c->translate("Cutelyst::ValidatorDomain", "The domain name contains characters that are not allowed.");
+            break;
+        case LabelTooLong:
+            error = c->translate("Cutelyst::ValidatorDomain", "At least one of the sections separated by dots exceeds the maximum allowed length of 63 characters. Note that internationalized domain names may be internally longer than they are displayed.");
+            break;
+        case TooLong:
+            error = c->translate("Cutelyst::ValidatorDomain", "The full name of the domain must not be longer than 253 characters. Note that internationalized domain names may be internally longer than they are displayed.");
+            break;
+        case InvalidLabelCount:
+            error = c->translate("Cutelyst::ValidatorDomain", "This is not a valid domain name because it has either no parts (is empty) or only has a top level domain.");
+            break;
+        case EmptyLabel:
+            error = c->translate("Cutelyst::ValidatorDomain", "At least one of the sections separated by dots is empty. Check whether you have entered two dots consecutively.");
+            break;
+        case InvalidTLD:
+            error = c->translate("Cutelyst::ValidatorDomain", "The top level domain (last part) contains characters that are not allowed, like digits and or dashes.");
+            break;
+        case DashStart:
+            error = c->translate("Cutelyst::ValidatorDomain", "Domain name sections are not allowed to start with a dash.");
+            break;
+        case DashEnd:
+            error = c->translate("Cutelyst::ValidatorDomain", "Domain name sections are not allowed to end with a dash.");
+            break;
+        case DigitStart:
+            error = c->translate("Cutelyst::ValidatorDomain", "Domain name sections are not allowed to start with a digit.");
+            break;
+        case Valid:
+            error = c->translate("Cutelyst::ValidatorDomain", "The domain name is valid.");
+            break;
+        default:
+            Q_ASSERT_X(false, "domain validation diagnose", "invalid diagnose");
+            break;
+        }
+    } else {
+        switch (diagnose) {
+        case MissingDNS:
+            error = c->translate("Cutelyst::ValidatorDomain", "The domain name in the “%1“ field seems to be valid but could not be found in the domain name system.").arg(label);
+            break;
+        case InvalidChars:
+            error = c->translate("Cutelyst::ValidatorDomain", "The domain name in the “%1“ field contains characters that are not allowed.").arg(label);
+            break;
+        case LabelTooLong:
+            error = c->translate("Cutelyst::ValidatorDomain", "The domain name in the “%1“ field is not valid because at least one of the sections separated by dots exceeds the maximum allowed length of 63 characters. Note that internationalized domain names may be internally longer than they are displayed.").arg(label);
+            break;
+        case TooLong:
+            error = c->translate("Cutelyst::ValidatorDomain", "The full name of the domain in the “%1” field must not be longer than 253 characters. Note that internationalized domain names may be internally longer than they are displayed.").arg(label);
+            break;
+        case InvalidLabelCount:
+            error = c->translate("Cutelyst::ValidatorDomain", "The “%1” field does not contain a valid domain name because it has either no parts (is empty) or only has a top level domain.").arg(label);
+            break;
+        case EmptyLabel:
+            error = c->translate("Cutelyst::ValidatorDomain", "The domain name in the “%1“ field is not valid because at least on of the sections separated by dots is empty. Check whether you have entered two dots consecutively.").arg(label);
+            break;
+        case InvalidTLD:
+            error = c->translate("Cutelyst::ValidatorDomain", "The top level domain (last part) of the domain name in the “%1” field contains characters that are not allowed, like digits and or dashes.").arg(label);
+            break;
+        case DashStart:
+            error = c->translate("Cutelyst::ValidatorDomain", "The domain name in the “%1“ field is not valid because domain name sections are not allowed to start with a dash.").arg(label);
+            break;
+        case DashEnd:
+            error = c->translate("Cutelyst::ValidatorDomain", "The domain name in the “%1“ field is not valid because domain name sections are not allowed to end with a dash.").arg(label);
+            break;
+        case DigitStart:
+            error = c->translate("Cutelyst::ValidatorDomain", "The domain name in the “%1“ field is not valid because domain name sections are not allowed to start with a digit.").arg(label);
+            break;
+        case Valid:
+            error = c->translate("Cutelyst::ValidatorDomain", "The domain name in the “%1” field is valid.").arg(label);
+            break;
+        default:
+            Q_ASSERT_X(false, "domain validation diagnose", "invalid diagnose");
+            break;
+        }
+    }
+
+    return error;
+}
+
+ValidatorReturnType ValidatorDomain::validate(Context *c, const ParamsMultiMap &params) const
+{
+    ValidatorReturnType result;
+
+    const QString &v = value(params);
+
+    if (!v.isEmpty()) {
+        Q_D(const ValidatorDomain);
+        QString exVal;
+        Diagnose diag;
+        if (ValidatorDomain::validate(v, d->checkDNS, &diag, &exVal)) {
+            result.value.setValue<QString>(exVal);
+        } else {
+            result.errorMessage = validationError(c, diag);
+        }
+    } else {
+        defaultValue(c, &result, "ValidatorDomain");
+    }
+
+    return result;
+}
+
+QString ValidatorDomain::genericValidationError(Context *c, const QVariant &errorData) const
+{
+    QString error;
+    const QString _label = label(c);
+    const Diagnose diag = errorData.value<Diagnose>();
+    error = ValidatorDomain::diagnoseString(c, diag, _label);
+    return error;
+}

--- a/Cutelyst/Plugins/Utils/Validator/validatordomain.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordomain.h
@@ -61,7 +61,8 @@ public:
         InvalidTLD          = 7,    /**< The TLD label contains characters that are not allowed. */
         DashStart           = 8,    /**< At least one label starts with a dash. */
         DashEnd             = 9,    /**< At least one label ends with a dash. */
-        DigitStart          = 10    /**< At least one label starts with a digit. */
+        DigitStart          = 10,   /**< At least one label starts with a digit. */
+        DNSTimeout          = 11    /**< The DNS lookup took too long. */
     };
     Q_ENUM(Diagnose)
 

--- a/Cutelyst/Plugins/Utils/Validator/validatordomain.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordomain.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2018 Matthias Fehring <kontakt@buschmann23.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef CUTELYSTVALIDATORDOMAIN_H
+#define CUTELYSTVALIDATORDOMAIN_H
+
+#include <Cutelyst/cutelyst_global.h>
+#include "validatorrule.h"
+
+namespace Cutelyst {
+
+class ValidatorDomainPrivate;
+
+/*!
+ * \ingroup plugins-utils-validator-rules
+ * \class ValidatorDomain validatordomain.h <Cutelyst/Plugins/Utils/validatordomain.h>
+ * \brief Checks if the value of the input \a field contains FQDN according to RFC 1035.
+ *
+ * The \a field under validation must contain a fully qualified domain name according to <a href="https://tools.ietf.org/html/rfc1035">RFC 1035</a>.
+ * If \a checkDNS is set to \c false, there will be no check if the domain is known to the domain name system, the validator will
+ * only check conformance to RFC 1035. Internationalized domain names will first be converted into puny code according to IDNA.
+ *
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
+ *
+ * \sa Validator for general usage of validators.
+ */
+class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorDomain : public ValidatorRule
+{
+    Q_GADGET
+public:
+    /*!
+     * \brief Possible diagnose information for the checked domain.
+     */
+    enum Diagnose : quint8 {
+        Valid               = 0,    /**< The domain name is valid. If \a checkDNS has been set to \c false, this says nothing about the existence of the domain in the DNS. */
+        MissingDNS          = 1,    /**< The domain name is valid according to RFC 1035, but there could be no DNS entry found for it. */
+        InvalidChars        = 2,    /**< The domain name contains chars that are not allowed. */
+        LabelTooLong        = 3,    /**< At least one of the domain name labels exceeds the maximum size of 63 chars. */
+        TooLong             = 4,    /**< The whole domain name exceeds the maximum size of 253 chars. */
+        InvalidLabelCount   = 5,    /**< Not a valid domain name because it has either no labels or only the TLD. */
+        EmptyLabel          = 6,    /**< At least one of the domain name labels is empty. */
+        InvalidTLD          = 7,    /**< The TLD label contains characters that are not allowed. */
+        DashStart           = 8,    /**< At least one label starts with a dash. */
+        DashEnd             = 9,    /**< At least one label ends with a dash. */
+        DigitStart          = 10    /**< At least one label starts with a digit. */
+    };
+    Q_ENUM(Diagnose)
+
+    /*!
+     * \brief Constructs a new %ValidatorDomain with the given parameters.
+     * \param field     Name of the input field to validate.
+     * \param checkDNS  If \c true, a DNS lookup will be performed to check if the domain name exists in the domain name system.
+     * \param messages  Custom error messages if validation fails.
+     * \param defValKey \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
+     */
+    ValidatorDomain(const QString &field, bool checkDNS = false, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
+
+    /*!
+     * Deconstructs %ValidatorDomain
+     */
+    ~ValidatorDomain();
+
+    /*!
+     * \ingroup plugins-utils-validator-rules
+     * \brief Returns \c true if \a value is a valid domain name.
+     * \param value             The value to validate.
+     * \param checkDNS          If \c true, a DNS lookup will be performed to check if the domain name exists in the domain name system.
+     * \param diagnose          Optional pointer to a variable that will be filled with the Diagnose that describes the error if validation fails.
+     * \param extractedValue    Optional pointer to a variable that will contain the validated domain converted into ACE puny code.
+     * \return \c true if the \a value is a valid domain name.
+     */
+    static bool validate(const QString &value, bool checkDNS, Diagnose *diagnose = nullptr, QString *extractedValue = nullptr);
+
+    /*!
+     * \brief Returns a human readable description of a Diagnose.
+     * \param c         Current Context, used for translations.
+     * \param diagnose  The Diagnose to get the description for.
+     * \param label     Optinonal label that will be part of the diagnose string if not empty.
+     * \return a human readable diagnose description.
+     */
+    static QString diagnoseString(Context *c, Diagnose diagnose, const QString &label = QString());
+
+protected:
+    /*!
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as ACE version of the domain in a QString.
+     */
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
+    /*!
+     * \brief Returns a generic error message if validation failed.
+     *
+     * \a errorData will contain the Diagnose returned by ValidatorDomain::validate().
+     */
+    QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
+
+private:
+    Q_DECLARE_PRIVATE(ValidatorDomain)
+    Q_DISABLE_COPY(ValidatorDomain)
+};
+
+}
+
+#endif // CUTELYSTVALIDATORDOMAIN_H

--- a/Cutelyst/Plugins/Utils/Validator/validatordomain_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatordomain_p.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2018 Matthias Fehring <kontakt@buschmann23.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef CUTELYSTVALIDATORDOMAIN_P_H
+#define CUTELYSTVALIDATORDOMAIN_P_H
+
+#include "validatordomain.h"
+#include "validatorurl_p.h"
+
+namespace Cutelyst {
+
+class ValidatorDomainPrivate : public ValidatorRulePrivate
+{
+public:
+    ValidatorDomainPrivate(const QString &f, bool cd, const ValidatorMessages &m, const QString &dvk) :
+        ValidatorRulePrivate(f, m, dvk),
+        checkDNS(cd)
+    {}
+
+    bool checkDNS = false;
+};
+
+}
+
+#endif // CUTELYSTVALIDATORDOMAIN_P_H


### PR DESCRIPTION
This validator will check if an input field contains a domain name that
is valid according to RFC 1035 and can optionally also check it's
existence in the domain name system through a host name lookup.