### PR TITLE
Validator plugin: new ValidatorPwQuality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
       clearsilver-dev
       libmemcached-dev
       libjemalloc-dev
+      libpwquality-dev
       qt${QT_VERSION_MM}base qt${QT_VERSION_MM}tools
       && export CMAKE_PREFIX_PATH=/opt/qt${QT_VERSION_MM};
     fi
@@ -50,6 +51,7 @@ before_script:
        -DPLUGIN_MEMCACHED=off
        -DPLUGIN_MEMCACHEDSESSIONSTORE=off
        -DPLUGIN_UWSGI=off
+       -DPLUGIN_VALIDATOR_PWQUALITY=off
        -DUSE_JEMALLOC=off
      ;fi
    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ option(PLUGIN_VIEW_EMAIL "Enables View::Email plugin" ${BUILD_ALL})
 option(PLUGIN_VIEW_GRANTLEE "Enables View::Grantlee plugin" ${BUILD_ALL})
 option(PLUGIN_VIEW_CLEARSILVER "Enables View::ClearSilver plugin" ${BUILD_ALL})
 option(PLUGIN_UWSGI "Enables uWSGI plugin" ${BUILD_ALL})
-option(PLUGIN_VALIDATOR_PWQUALITY "Enables ValidatorPwQuality that required libpwquality" ${BUILD_ALL})
+option(PLUGIN_VALIDATOR_PWQUALITY "Enables ValidatorPwQuality that requires libpwquality 1.2.2 or newer" ${BUILD_ALL})
 
 # NONE
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ option(PLUGIN_VIEW_EMAIL "Enables View::Email plugin" ${BUILD_ALL})
 option(PLUGIN_VIEW_GRANTLEE "Enables View::Grantlee plugin" ${BUILD_ALL})
 option(PLUGIN_VIEW_CLEARSILVER "Enables View::ClearSilver plugin" ${BUILD_ALL})
 option(PLUGIN_UWSGI "Enables uWSGI plugin" ${BUILD_ALL})
+option(PLUGIN_VALIDATOR_PWQUALITY "Enables ValidatorPwQuality that required libpwquality" ${BUILD_ALL})
 
 # NONE
 

--- a/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
+++ b/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (PLUGIN_VALIDATOR_PWQUALITY)
     find_package(PkgConfig REQUIRED)
-    pkg_search_module(PWQUALITY REQUIRED pwquality)
+    pkg_search_module(PWQUALITY REQUIRED pwquality>=1.2.2)
     message(STATUS "PLUGIN: Validator, enable PwQuality")
     add_definitions(-DPWQUALITY_ENABLED)
     set(plugin_validator_pwquality_SRC

--- a/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
+++ b/Cutelyst/Plugins/Utils/Validator/CMakeLists.txt
@@ -1,3 +1,17 @@
+if (PLUGIN_VALIDATOR_PWQUALITY)
+    find_package(PkgConfig REQUIRED)
+    pkg_search_module(PWQUALITY REQUIRED pwquality)
+    message(STATUS "PLUGIN: Validator, enable PwQuality")
+    add_definitions(-DPWQUALITY_ENABLED)
+    set(plugin_validator_pwquality_SRC
+        validatorpwquality.cpp
+        validatorpwquality_p.h
+    )
+    set(plugin_validator_pwquality_HEADERS
+        validatorpwquality.h
+    )
+endif (PLUGIN_VALIDATOR_PWQUALITY)
+
 set(plugin_validator_SRC
     validator.cpp
     validator_p.h
@@ -87,7 +101,8 @@ set(plugin_validator_SRC
     validatorurl_p.h
     validatorresult.cpp
     validatorresult_p.h
-) 
+    ${plugin_validator_pwquality_SRC}
+)
 
 
 set(plugin_validator_HEADERS
@@ -139,6 +154,7 @@ set(plugin_validator_HEADERS
     Validators
     validatorresult.h
     ValidatorResult
+    ${plugin_validator_pwquality_HEADERS}
 )
 
 add_library(Cutelyst2Qt5UtilsValidator SHARED
@@ -156,6 +172,7 @@ set_target_properties(Cutelyst2Qt5UtilsValidator PROPERTIES
 target_link_libraries(Cutelyst2Qt5UtilsValidator
     PRIVATE Cutelyst2Qt5::Core
     Qt5::Network
+    ${PWQUALITY_LIBRARIES}
 )
 
 set_property(TARGET Cutelyst2Qt5UtilsValidator PROPERTY PUBLIC_HEADER ${plugin_validator_HEADERS})

--- a/Cutelyst/Plugins/Utils/Validator/validator.h
+++ b/Cutelyst/Plugins/Utils/Validator/validator.h
@@ -45,6 +45,11 @@ namespace Cutelyst {
  * <h3>Building and using</h3>
  * The plugin is linked to %Cutelyst Core API and the QtNetwork module. To use it in your application, link your
  * application to \a Cutelyst::Utils::Validator.
+ *
+ * <h4>Optional validators</h4>
+ * ValidatorPwQuality relies on <a href="https://github.com/libpwquality/libpwquality">libpwquality</a> and will not
+ * be included and build by default. Use either <code>-DPLUGIN_VALIDATOR_PWQUALITY:BOOL=ON</code> or
+ * <code>-DBUILD_ALL:BOOL=ON</code> when configuring %Cutelyst for build with cmake.
  */
 
 class ValidatorPrivate;

--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality.cpp
@@ -25,7 +25,11 @@ using namespace Cutelyst;
 ValidatorPwQuality::ValidatorPwQuality(const QString &field, int threshold, const QVariant &options, const QString &userName, const QString &oldPassword, const ValidatorMessages &messages) :
     ValidatorRule(*new ValidatorPwQualityPrivate(field, threshold, options, userName, oldPassword, messages))
 {
-
+    // this is kind of a dirty hack for older versions of libpwquality
+    // version 1.2.2 of libpwquality on Ubuntu Trusty for example will
+    // return a score of 0 for the first time of use, not sure why
+    // libpwquality 1.4.0 on openSUSE does not have this problem
+    ValidatorPwQuality::validate(QStringLiteral("asdf234a"));
 }
 
 ValidatorPwQuality::~ValidatorPwQuality()

--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality.cpp
@@ -1,0 +1,300 @@
+﻿/*
+ * Copyright (C) 2018 Matthias Fehring <kontakt@buschmann23.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "validatorpwquality_p.h"
+#include <pwquality.h>
+
+using namespace Cutelyst;
+
+ValidatorPwQuality::ValidatorPwQuality(const QString &field, int threshold, const ValidatorMessages &messages) :
+    ValidatorRule(*new ValidatorPwQualityPrivate(field, threshold, messages))
+{
+
+}
+
+ValidatorPwQuality::~ValidatorPwQuality()
+{
+
+}
+
+int ValidatorPwQuality::validate(const QString &value, const QString &oldPassword, const QString &user)
+{
+    int rv = 0;
+
+    if (!value.isEmpty()) {
+
+        pwquality_settings_t *pwq = pwquality_default_settings();
+        if (pwq) {
+
+            rv = pwquality_read_config(pwq, nullptr, nullptr);
+
+            if (rv == 0) {
+                const char *pw = value.toUtf8().constData();
+                const char *opw = oldPassword.isEmpty() ? nullptr : oldPassword.toUtf8().constData();
+                const char *u = user.isEmpty() ? nullptr : user.toUtf8().constData();
+
+                rv = pwquality_check(pwq, pw, opw, u, nullptr);
+            }
+
+            pwquality_free_settings(pwq);
+
+        } else {
+            rv = PWQ_ERROR_MEM_ALLOC;
+        }
+    } else {
+        rv = PWQ_ERROR_EMPTY_PASSWORD;
+    }
+
+    return rv;
+}
+
+QString ValidatorPwQuality::errorString(Context *c, int returnValue, const QString &label, int threshold)
+{
+    QString error;
+
+    if (label.isEmpty()) {
+        switch (returnValue) {
+        case PWQ_ERROR_MEM_ALLOC:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check failed because of a memory allocation error.");
+            break;
+        case PWQ_ERROR_SAME_PASSWORD:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password is the same as the old one.");
+            break;
+        case PWQ_ERROR_PALINDROME:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password is a palindrome.");
+            break;
+        case PWQ_ERROR_CASE_CHANGES_ONLY:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password differs with case changes only.");
+            break;
+        case PWQ_ERROR_TOO_SIMILAR:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password is too similar to the old one.");
+            break;
+        case PWQ_ERROR_USER_CHECK:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password contains the user name in some form.");
+            break;
+        case PWQ_ERROR_GECOS_CHECK:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password contains words from the real name of the user in some form.");
+            break;
+        case PWQ_ERROR_BAD_WORDS:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password contains forbidden words in some form.");
+            break;
+        case PWQ_ERROR_MIN_DIGITS:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password contains too few digits.");
+            break;
+        case PWQ_ERROR_MIN_UPPERS:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password contains too few uppercase letters.");
+            break;
+        case PWQ_ERROR_MIN_LOWERS:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password contains too few lowercase letters.");
+            break;
+        case PWQ_ERROR_MIN_OTHERS:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password contains less than %ld non-alphanumeric characters.");
+            break;
+        case PWQ_ERROR_MIN_LENGTH:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password is too short.");
+            break;
+        case PWQ_ERROR_ROTATED:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password is just rotated old one.");
+            break;
+        case PWQ_ERROR_MIN_CLASSES:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password does not contain enough character classes.");
+            break;
+        case PWQ_ERROR_MAX_CONSECUTIVE:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password contains too many same characters consecutively.");
+            break;
+        case PWQ_ERROR_MAX_CLASS_REPEAT:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password contains too many characters of the same class consecutively.");
+            break;
+        case PWQ_ERROR_MAX_SEQUENCE:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password contains too long of a monotonic character sequence.");
+            break;
+        case PWQ_ERROR_EMPTY_PASSWORD:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "No password supplied.");
+            break;
+        case PWQ_ERROR_RNG:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check failed because we cannot obtain random numbers from the RNG device");
+            break;
+        case PWQ_ERROR_CRACKLIB_CHECK:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password fails the dictionary check.");
+            break;
+        case PWQ_ERROR_UNKNOWN_SETTING:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check failed because of an unknown setting.");
+            break;
+        case PWQ_ERROR_INTEGER:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check failed because of a bad integer value in the settings.");
+            break;
+        case PWQ_ERROR_NON_INT_SETTING:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check failed because of a settings entry is not of integer type.");
+            break;
+        case PWQ_ERROR_NON_STR_SETTING:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check failed because of a settings entry is not of string type.");
+            break;
+        case PWQ_ERROR_CFGFILE_OPEN:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check failed because opening the configuration file failed.");
+            break;
+        case PWQ_ERROR_CFGFILE_MALFORMED:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check failed because the configuration file is malformed.");
+            break;
+        case PWQ_ERROR_FATAL_FAILURE:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check failed because of a fatal failure.");
+            break;
+        default:
+        {
+            if (returnValue < 0) {
+                error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check failed because of an unknown error.");
+            } else {
+                if (returnValue < threshold) {
+                    error = c->translate("Cutelyst::ValidatorPwQuality", "The password quality score of %1 is below the threshold of %2.").arg(QString::number(returnValue), QString::number(threshold));
+                }
+            }
+        }
+            break;
+        }
+    } else {
+        switch (returnValue) {
+        case PWQ_ERROR_MEM_ALLOC:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check for the “%1“ field failed because of a memory allocation error.").arg(label);
+            break;
+        case PWQ_ERROR_SAME_PASSWORD:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field is the same as the old one.").arg(label);
+            break;
+        case PWQ_ERROR_PALINDROME:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field is a palindrome.").arg(label);
+            break;
+        case PWQ_ERROR_CASE_CHANGES_ONLY:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field differs with case changes only.").arg(label);
+            break;
+        case PWQ_ERROR_TOO_SIMILAR:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field is too similar to the old one.").arg(label);
+            break;
+        case PWQ_ERROR_USER_CHECK:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field contains the user name in some form.").arg(label);
+            break;
+        case PWQ_ERROR_GECOS_CHECK:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field contains words from the real name of the user in some form.").arg(label);
+            break;
+        case PWQ_ERROR_BAD_WORDS:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field contains forbidden words in some form.").arg(label);
+            break;
+        case PWQ_ERROR_MIN_DIGITS:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field contains too few digits.").arg(label);
+            break;
+        case PWQ_ERROR_MIN_UPPERS:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field contains too few uppercase letters.").arg(label);
+            break;
+        case PWQ_ERROR_MIN_LOWERS:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field contains too few lowercase letters.").arg(label);
+            break;
+        case PWQ_ERROR_MIN_OTHERS:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field contains less than %ld non-alphanumeric characters.").arg(label);
+            break;
+        case PWQ_ERROR_MIN_LENGTH:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field is too short.").arg(label);
+            break;
+        case PWQ_ERROR_ROTATED:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field is just rotated old one.").arg(label);
+            break;
+        case PWQ_ERROR_MIN_CLASSES:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field does not contain enough character classes.").arg(label);
+            break;
+        case PWQ_ERROR_MAX_CONSECUTIVE:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field contains too many same characters consecutively.").arg(label);
+            break;
+        case PWQ_ERROR_MAX_CLASS_REPEAT:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field contains too many characters of the same class consecutively.").arg(label);
+            break;
+        case PWQ_ERROR_MAX_SEQUENCE:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field contains too long of a monotonic character sequence.").arg(label);
+            break;
+        case PWQ_ERROR_EMPTY_PASSWORD:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "No password supplied in the “%1” field.").arg(label);
+            break;
+        case PWQ_ERROR_RNG:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check for the “%1“ field failed because we cannot obtain random numbers from the RNG device").arg(label);
+            break;
+        case PWQ_ERROR_CRACKLIB_CHECK:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "The password in the “%1” field fails the dictionary check.").arg(label);
+            break;
+        case PWQ_ERROR_UNKNOWN_SETTING:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check for the “%1“ field failed because of an unknown setting.").arg(label);
+            break;
+        case PWQ_ERROR_INTEGER:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check for the “%1“ field failed because of a bad integer value in the settings.").arg(label);
+            break;
+        case PWQ_ERROR_NON_INT_SETTING:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check for the “%1“ field failed because of a settings entry is not of integer type.").arg(label);
+            break;
+        case PWQ_ERROR_NON_STR_SETTING:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check for the “%1“ field failed because of a settings entry is not of string type.").arg(label);
+            break;
+        case PWQ_ERROR_CFGFILE_OPEN:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check for the “%1“ field failed because opening the configuration file failed.").arg(label);
+            break;
+        case PWQ_ERROR_CFGFILE_MALFORMED:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check for the “%1“ field failed because the configuration file is malformed.").arg(label);
+            break;
+        case PWQ_ERROR_FATAL_FAILURE:
+            error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check for the “%1“ field failed because of a fatal failure.").arg(label);
+            break;
+        default:
+        {
+            if (returnValue < 0) {
+                error = c->translate("Cutelyst::ValidatorPwQuality", "Password quality check for the “%1” field failed because of an unknown error.").arg(label);
+            } else {
+                if (returnValue < threshold) {
+                    error = c->translate("Cutelyst::ValidatorPwQuality", "The quality score of %1 for the password in the “%2” field is below the threshold of %3.").arg(QString::number(returnValue), label, QString::number(threshold));
+                }
+            }
+        }
+            break;
+        }
+    }
+
+    return error;
+}
+
+ValidatorReturnType ValidatorPwQuality::validate(Context *c, const ParamsMultiMap &params) const
+{
+    ValidatorReturnType result;
+
+    const QString v = value(params);
+
+    if (!v.isEmpty()) {
+        Q_D(const ValidatorPwQuality);
+        int rv = validate(v);
+        if (rv < d->threshold) {
+            result.errorMessage = validationError(c, rv);
+        } else {
+            result.value.setValue<QString>(v);
+        }
+    }
+
+    return result;
+}
+
+QString ValidatorPwQuality::genericValidationError(Context *c, const QVariant &errorData) const
+{
+    QString error;
+
+    Q_D(const ValidatorPwQuality);
+    const int returnValue = errorData.toInt();
+    const QString _label = label(c);
+    error = ValidatorPwQuality::errorString(c, returnValue, _label, d->threshold);
+
+    return error;
+}

--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality.cpp
@@ -21,8 +21,8 @@
 
 using namespace Cutelyst;
 
-ValidatorPwQuality::ValidatorPwQuality(const QString &field, int threshold, const QVariant &options, const ValidatorMessages &messages) :
-    ValidatorRule(*new ValidatorPwQualityPrivate(field, threshold, options, messages))
+ValidatorPwQuality::ValidatorPwQuality(const QString &field, int threshold, const QVariant &options, const QString &userName, const QString &oldPassword, const ValidatorMessages &messages) :
+    ValidatorRule(*new ValidatorPwQualityPrivate(field, threshold, options, userName, oldPassword, messages))
 {
 
 }
@@ -312,7 +312,21 @@ ValidatorReturnType ValidatorPwQuality::validate(Context *c, const ParamsMultiMa
                 }
             }
         }
-        int rv = validate(v, opts);
+        QString un;
+        if (!d->userName.isEmpty()) {
+            un = params.value(d->userName);
+            if (un.isEmpty()) {
+                un = c->stash(d->userName).toString();
+            }
+        }
+        QString opw;
+        if (!d->oldPassword.isEmpty()) {
+            opw = params.value(d->oldPassword);
+            if (opw.isEmpty()) {
+                opw = c->stash(d->oldPassword).toString();
+            }
+        }
+        int rv = validate(v, opts, opw, un);
         if (rv < d->threshold) {
             result.errorMessage = validationError(c, rv);
         } else {

--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality.cpp
@@ -18,6 +18,7 @@
 
 #include "validatorpwquality_p.h"
 #include <pwquality.h>
+#include <QLoggingCategory>
 
 using namespace Cutelyst;
 
@@ -329,6 +330,14 @@ ValidatorReturnType ValidatorPwQuality::validate(Context *c, const ParamsMultiMa
         int rv = validate(v, opts, opw, un);
         if (rv < d->threshold) {
             result.errorMessage = validationError(c, rv);
+            if (C_VALIDATOR().isDebugEnabled()) {
+                if (rv < 0) {
+                    char buf[1024];
+                    qCDebug(C_VALIDATOR, "ValidatorPwQuality: Validation failed for field %s at %s::%s: %s", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), pwquality_strerror(buf, sizeof(buf), rv, nullptr));
+                } else {
+                    qCDebug(C_VALIDATOR, "ValidatorPwQuality: Validation failed for field %s at %s::%s because the quality score %i is below the threshold of %i.", qPrintable(field()), qPrintable(c->controllerName()), qPrintable(c->actionName()), rv, d->threshold);
+                }
+            }
         } else {
             result.value.setValue<QString>(v);
         }

--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2018 Matthias Fehring <kontakt@buschmann23.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef CUTELYSTVALIDATORPWQUALITY_H
+#define CUTELYSTVALIDATORPWQUALITY_H
+
+#include <Cutelyst/cutelyst_global.h>
+#include "validatorrule.h"
+
+namespace Cutelyst {
+
+class ValidatorPwQualityPrivate;
+
+/*!
+ * \ingroup plugins-utils-validator-rules
+ * \class ValidatorPwQuality validatorpwquality.h <Cutelyst/Plugins/Utils/validatorpwquality.h>
+ * \brief Validates an input field with libpwquality to check password quality.
+ *
+ * This validator uses <a href="https://github.com/libpwquality/libpwquality">libpwquality</a> to generate a
+ * password quality score that is compared against a \a threshold. If it is below the \a threshold, the validation
+ * fails. According to libpwquality a score of 0-30 is of low, a score of 30-60 of medium and a score of 60-100
+ * of high quality. Everything below 0 is an error and the password should not be used.
+ *
+ * As this validator relies on an external library, it will not be included and build by default. Use either
+ * <code>-DPLUGIN_VALIDATOR_PWQUALITY:BOOL=ON</code> or <code>-DBUILD_ALL:BOOL=ON</code> when configuring %Cutelyst
+ * for build with cmake.
+ *
+ * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
+ * whitespaces will be removed from the beginning and the end of the input value before validation.
+ * If the \a field's value is empty or if the \a field is missing in the input data, the validation will succeed without
+ * performing the validation itself. Use one of the \link ValidatorRequired required validators \endlink to require the
+ * field to be present and not empty.
+ *
+ * \sa Validator for general usage of validators.
+ *
+ * \since Cutelyst 2.0.0
+ */
+class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT ValidatorPwQuality : public ValidatorRule
+{
+public:
+    /*!
+     * \brief Constructs a new %ValidatorPwQuality with the given parameters.
+     * \param field     Name of the input field to validate.
+     * \param threshold The quality score threshold below the validation fails.
+     * \param messages  Custom error messages if validation fails.
+     */
+    explicit ValidatorPwQuality(const QString &field, int threshold = 30, const ValidatorMessages &messages = ValidatorMessages());
+
+    /*!
+     * \brief Deconstructs the %ValidatorPwQuality.
+     */
+    ~ValidatorPwQuality();
+
+    /*!
+     * \ingroup plugins-utils-validator-rules
+     * \brief Returns the password quality score for \a value.
+     * \param value         The value to validate.
+     * \param oldPassword   Optional old password used for some checks.
+     * \param user          Optional user name used for some checks.
+     * \return the password quality score, everything below \c 0 is an error, everything >= 0 is a quality score where
+     * 0-30 is low, 30-60 medium and 60-100 high quality. You can use ValidatorPwQuality::errorString() to get a human
+     * readable string explaining the return value.
+     */
+    static int validate(const QString &value, const QString &oldPassword = QString(), const QString &user = QString());
+
+    /*!
+     * \brief Returns a human readable string for the return value of ValidatorPwQuality::validate()
+     * \param c             Current context, used for translations.
+     * \param returnValue   The return value of ValidatorPwQuality::validate()
+     * \param label         Optional label used in the returned string.
+     * \param threshold     The threshold below that a password is invalid.
+     * \return Human readable error string. If \a returnValue is >= 0 but below \a threshold, a string explaining the
+     * threshold will be returned. If \a returnValue is >= \a threshold, an empty string will be returned.
+     */
+    static QString errorString(Context *c, int returnValue, const QString &label = QString(), int threshold = 0);
+
+protected:
+    /*!
+     * \brief Performs the validation and returns the result.
+     *
+     * If validation succeeded, ValidatorReturnType::value will contain the input paramter
+     * value as QString.
+     */
+    ValidatorReturnType validate(Context *c, const ParamsMultiMap &params) const override;
+
+    /*!
+     * \brief Returns a generic error message if validation failed.
+     *
+     * The \a errorData will contain the score returned by ValidatorPqQuality::validate()
+     */
+    QString genericValidationError(Context *c, const QVariant &errorData) const override;
+
+private:
+    Q_DECLARE_PRIVATE(ValidatorPwQuality)
+    Q_DISABLE_COPY(ValidatorPwQuality)
+};
+
+}
+
+#endif // CUTELYSTVALIDATORPWQUALITY_H

--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality.h
@@ -65,10 +65,19 @@ public:
      * \brief Constructs a new %ValidatorPwQuality with the given parameters.
      * \param field     Name of the input field to validate.
      * \param threshold The quality score threshold below the validation fails.
-     * \param options   Options for libpwquality.
+     * \param options   Options for libpwquality. Use invalid QVariant to omit.
+     * \param userName  Input params key or stash key containing the user name, used for quality checks.
+     * Will first try params, than stash. Leave empty to omit.
+     * \param oldPassword   Input params key or stash key containing the old password, used for quality checks.
+     * Will first try params, than stash. Leave empty to omit.
      * \param messages  Custom error messages if validation fails.
      */
-    explicit ValidatorPwQuality(const QString &field, int threshold = 30, const QVariant &options = QVariant(), const ValidatorMessages &messages = ValidatorMessages());
+    explicit ValidatorPwQuality(const QString &field,
+                                int threshold = 30,
+                                const QVariant &options = QVariant(),
+                                const QString &userName = QString(),
+                                const QString &oldPassword = QString(),
+                                const ValidatorMessages &messages = ValidatorMessages());
 
     /*!
      * \brief Deconstructs the %ValidatorPwQuality.

--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality.h
@@ -35,9 +35,18 @@ class ValidatorPwQualityPrivate;
  * fails. According to libpwquality a score of 0-30 is of low, a score of 30-60 of medium and a score of 60-100
  * of high quality. Everything below 0 is an error and the password should not be used.
  *
+ * <h3>Building</h3>
  * As this validator relies on an external library, it will not be included and build by default. Use either
  * <code>-DPLUGIN_VALIDATOR_PWQUALITY:BOOL=ON</code> or <code>-DBUILD_ALL:BOOL=ON</code> when configuring %Cutelyst
  * for build with cmake.
+ *
+ * <h3>Options</h3>
+ * %ValidatorPwQuality can take additional \a options. To learn more about the available options see <code>man 5 pwquality.conf</code>.
+ * The options value can be either a QVariantMap containing the options or a QString specifying a file name that will be read
+ * by libpwquality. For the constructor the options will also be searched in the current \link Context::stash() stash\endlink if
+ * it is a QString. The stash value should than be either a QVariantMap or a QString pointing to a configuration file. All values
+ * in the QVariantMap used to specify \a options, have to be convertible into QString. The QVariantMap does not have to contain
+ * all available option keys, for keys that are not contained, the default values of libpwquality will be used.
  *
  * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
  * whitespaces will be removed from the beginning and the end of the input value before validation.
@@ -56,9 +65,10 @@ public:
      * \brief Constructs a new %ValidatorPwQuality with the given parameters.
      * \param field     Name of the input field to validate.
      * \param threshold The quality score threshold below the validation fails.
+     * \param options   Options for libpwquality.
      * \param messages  Custom error messages if validation fails.
      */
-    explicit ValidatorPwQuality(const QString &field, int threshold = 30, const ValidatorMessages &messages = ValidatorMessages());
+    explicit ValidatorPwQuality(const QString &field, int threshold = 30, const QVariant &options = QVariant(), const ValidatorMessages &messages = ValidatorMessages());
 
     /*!
      * \brief Deconstructs the %ValidatorPwQuality.
@@ -69,13 +79,14 @@ public:
      * \ingroup plugins-utils-validator-rules
      * \brief Returns the password quality score for \a value.
      * \param value         The value to validate.
+     * \param options       Options for libpwquality.
      * \param oldPassword   Optional old password used for some checks.
      * \param user          Optional user name used for some checks.
      * \return the password quality score, everything below \c 0 is an error, everything >= 0 is a quality score where
      * 0-30 is low, 30-60 medium and 60-100 high quality. You can use ValidatorPwQuality::errorString() to get a human
      * readable string explaining the return value.
      */
-    static int validate(const QString &value, const QString &oldPassword = QString(), const QString &user = QString());
+    static int validate(const QString &value, const QVariant &options = QVariant(), const QString &oldPassword = QString(), const QString &user = QString());
 
     /*!
      * \brief Returns a human readable string for the return value of ValidatorPwQuality::validate()

--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality_p.h
@@ -26,15 +26,19 @@ namespace Cutelyst {
 class ValidatorPwQualityPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorPwQualityPrivate(const QString &f, int t, const QVariant &opts, const ValidatorMessages &m) :
+    ValidatorPwQualityPrivate(const QString &f, int t, const QVariant &opts, const QString &un, const QString &opw, const ValidatorMessages &m) :
         ValidatorRulePrivate(f, m, QString()),
         options(opts),
+        userName(un),
+        oldPassword(opw),
         threshold(t)
     {
 
     }
 
     QVariant options;
+    QString userName;
+    QString oldPassword;
     int threshold = 30;
 };
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality_p.h
@@ -26,12 +26,15 @@ namespace Cutelyst {
 class ValidatorPwQualityPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorPwQualityPrivate(const QString &f, int t, const ValidatorMessages &m) :
-        ValidatorRulePrivate(f, m, QString())
+    ValidatorPwQualityPrivate(const QString &f, int t, const QVariant &opts, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString()),
+        options(opts),
+        threshold(t)
     {
 
     }
 
+    QVariant options;
     int threshold = 30;
 };
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality_p.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018 Matthias Fehring <kontakt@buschmann23.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef CUTELYSTVALIDATORPWQUALITY_P_H
+#define CUTELYSTVALIDATORPWQUALITY_P_H
+
+#include "validatorpwquality.h"
+#include "validatorrule_p.h"
+
+namespace Cutelyst {
+
+class ValidatorPwQualityPrivate : public ValidatorRulePrivate
+{
+public:
+    ValidatorPwQualityPrivate(const QString &f, int t, const ValidatorMessages &m) :
+        ValidatorRulePrivate(f, m, QString())
+    {
+
+    }
+
+    int threshold = 30;
+};
+
+}
+
+#endif // CUTELYSTVALIDATORPWQUALITY_P_H

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -162,6 +162,7 @@ build_script:
     -DPLUGIN_MEMCACHED=off
     -DPLUGIN_MEMCACHEDSESSIONSTORE=off
     -DPLUGIN_UWSGI=off
+    -DPLUGIN_VALIDATOR_PWQUALITY=off
     -DUSE_JEMALLOC=off
   - cmake --build . --config Debug
   - cmake --build . --config Release

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,9 @@ cutelyst_templates_unit_tests(
     testactionrenderview
 )
 
+if(PLUGIN_VALIDATOR_PWQUALITY)
+    add_definitions(-DPWQUALITY_ENABLED)
+endif(PLUGIN_VALIDATOR_PWQUALITY)
 cute_test(testvalidator Cutelyst2Qt5::Utils::Validator "" "")
 
 if (NOT CMAKE_GENERATOR MATCHES "Visual Studio" AND NOT CMAKE_GENERATOR MATCHES "Ninja")

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -623,9 +623,7 @@ public:
                                       {QStringLiteral("maxrepeat"), 0},
                                       {QStringLiteral("maxsequence"), 0},
                                       {QStringLiteral("maxclassrepeat"), 0},
-                                      {QStringLiteral("gecoscheck"), 0},
-                                      {QStringLiteral("dictcheck"), 1},
-                                      {QStringLiteral("usercheck"), 1}
+                                      {QStringLiteral("gecoscheck"), 0}
                                   });
         Validator v({new ValidatorPwQuality(QStringLiteral("field"), 50, options, QString(), QString(), m_validatorMessages)});
         checkResponse(c, v.validate(c));

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -2522,10 +2522,6 @@ void TestValidator::testController_data()
 
     // **** Start testing ValidatorPwQuality
 #ifdef PWQUALITY_ENABLED
-    query.clear();
-    query.addQueryItem(QStringLiteral("field"), QStringLiteral("niKeHAm@M0vZuJvYlDaP6"));
-    QTest::newRow("pwquality-valid") << QStringLiteral("/pwQuality") << headers << query.toString(QUrl::FullyEncoded).toUtf8() << valid;
-
     const QList<QString> invalidPws({
                                         QStringLiteral("schalke04"), // dictionay
                                         QStringLiteral("asdf234a"), // score too low
@@ -2538,6 +2534,10 @@ void TestValidator::testController_data()
                 << QStringLiteral("/pwQuality") << headers << query.toString(QUrl::FullyEncoded).toUtf8() << invalid;
         count++;
     }
+
+    query.clear();
+    query.addQueryItem(QStringLiteral("field"), QStringLiteral("niKeHAm@M0vZuJvYlDaP6"));
+    QTest::newRow("pwquality-valid") << QStringLiteral("/pwQuality") << headers << query.toString(QUrl::FullyEncoded).toUtf8() << valid;
 #endif
 
 

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -612,7 +612,22 @@ public:
 #ifdef PWQUALITY_ENABLED
     C_ATTR(pwQuality, :Local :AutoArgs)
     void pwQuality(Context *c) {
-        Validator v({new ValidatorPwQuality(QStringLiteral("field"), 50, QVariant(), m_validatorMessages)});
+        const QVariantMap options({
+                                      {QStringLiteral("difok"), 1},
+                                      {QStringLiteral("minlen"), 8},
+                                      {QStringLiteral("dcredit"), 0},
+                                      {QStringLiteral("ucredit"), 0},
+                                      {QStringLiteral("ocredit"), 0},
+                                      {QStringLiteral("lcredit"), 0},
+                                      {QStringLiteral("minclass"), 0},
+                                      {QStringLiteral("maxrepeat"), 0},
+                                      {QStringLiteral("maxsequence"), 0},
+                                      {QStringLiteral("maxclassrepeat"), 0},
+                                      {QStringLiteral("gecoscheck"), 0},
+                                      {QStringLiteral("dictcheck"), 1},
+                                      {QStringLiteral("usercheck"), 1}
+                                  });
+        Validator v({new ValidatorPwQuality(QStringLiteral("field"), 50, options, QString(), QString(), m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 #endif

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -2523,7 +2523,7 @@ void TestValidator::testController_data()
     // **** Start testing ValidatorPwQuality
 #ifdef PWQUALITY_ENABLED
     const QList<QString> validPws({
-                                      QStringLiteral("diN3nah(afx0dAw"),
+                                      QStringLiteral("niKeHAm@M0vZuJvYlDaP6"),
                                       QStringLiteral("q@zSAJH@rizA"),
                                       QStringLiteral("UrykiRYxRaH9")
                                   });

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -612,7 +612,7 @@ public:
 #ifdef PWQUALITY_ENABLED
     C_ATTR(pwQuality, :Local :AutoArgs)
     void pwQuality(Context *c) {
-        const QVariantMap options({
+        static const QVariantMap options({
                                       {QStringLiteral("difok"), 1},
                                       {QStringLiteral("minlen"), 8},
                                       {QStringLiteral("dcredit"), 0},
@@ -625,7 +625,7 @@ public:
                                       {QStringLiteral("maxclassrepeat"), 0},
                                       {QStringLiteral("gecoscheck"), 0}
                                   });
-        Validator v({new ValidatorPwQuality(QStringLiteral("field"), 50, options, QString(), QString(), m_validatorMessages)});
+        static Validator v({new ValidatorPwQuality(QStringLiteral("field"), 50, options, QString(), QString(), m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 #endif

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -2525,7 +2525,7 @@ void TestValidator::testController_data()
     const QList<QString> validPws({
                                       QStringLiteral("niKeHAm@M0vZuJvYlDaP6"),
                                       QStringLiteral("q@zSAJH@rizA"),
-                                      QStringLiteral("UrykiRYxRaH9")
+                                      QStringLiteral("UrykiR9YxRaH!b")
                                   });
 
     count = 0;

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -2522,20 +2522,9 @@ void TestValidator::testController_data()
 
     // **** Start testing ValidatorPwQuality
 #ifdef PWQUALITY_ENABLED
-    const QList<QString> validPws({
-                                      QStringLiteral("niKeHAm@M0vZuJvYlDaP6"),
-                                      QStringLiteral("q@zSAJH@rizA"),
-                                      QStringLiteral("UrykiR9YxRaH!b")
-                                  });
-
-    count = 0;
-    for (const QString &pw : validPws) {
-        query.clear();
-        query.addQueryItem(QStringLiteral("field"), pw);
-        QTest::newRow(qUtf8Printable(QStringLiteral("pwquality-valid0%1").arg(count)))
-                << QStringLiteral("/pwQuality") << headers << query.toString(QUrl::FullyEncoded).toUtf8() << valid;
-        count++;
-    }
+    query.clear();
+    query.addQueryItem(QStringLiteral("field"), QStringLiteral("niKeHAm@M0vZuJvYlDaP6"));
+    QTest::newRow("pwquality-valid") << QStringLiteral("/pwQuality") << headers << query.toString(QUrl::FullyEncoded).toUtf8() << valid;
 
     const QList<QString> invalidPws({
                                         QStringLiteral("schalke04"), // dictionay

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -612,7 +612,7 @@ public:
 #ifdef PWQUALITY_ENABLED
     C_ATTR(pwQuality, :Local :AutoArgs)
     void pwQuality(Context *c) {
-        Validator v({new ValidatorPwQuality(QStringLiteral("field"), 50, m_validatorMessages)});
+        Validator v({new ValidatorPwQuality(QStringLiteral("field"), 50, QVariant(), m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 #endif


### PR DESCRIPTION
This new validator uses libpwquality to generate a password quality
score that will be compared against a threshold. If the score is below
the threshold, the validation fails. As this relies on an external
library it is not build by default. Use -DPLUGIN_VALIDATOR_PWQUALITY:BOOL=ON
or -DBUILD_ALL:BOOL=ON to enable its build.