### PR TITLE
ValidatorPwQuality: improve application of options

### DIFF
--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality.h
@@ -35,6 +35,10 @@ class ValidatorPwQualityPrivate;
  * fails. According to libpwquality a score of 0-30 is of low, a score of 30-60 of medium and a score of 60-100
  * of high quality. Everything below 0 is an error and the password should not be used.
  *
+ * \note The score is strongly related to the \c minlen setting of libpwquality. This setting does not mean, that every
+ * password is invalid, that is shorter than the \c minlen. If you want to require a minimum lengths of your password,
+ * use ValidatorMin.
+ *
  * <h3>Building</h3>
  * As this validator relies on an external library, it will not be included and build by default. Use either
  * <code>-DPLUGIN_VALIDATOR_PWQUALITY:BOOL=ON</code> or <code>-DBUILD_ALL:BOOL=ON</code> when configuring %Cutelyst
@@ -46,7 +50,8 @@ class ValidatorPwQualityPrivate;
  * by libpwquality. For the constructor the options will also be searched in the current \link Context::stash() stash\endlink if
  * it is a QString. The stash value should than be either a QVariantMap or a QString pointing to a configuration file. All values
  * in the QVariantMap used to specify \a options, have to be convertible into QString. The QVariantMap does not have to contain
- * all available option keys, for keys that are not contained, the default values of libpwquality will be used.
+ * all available option keys, for keys that are not contained, the default values of libpwquality will be used. If the \a options
+ * QVariant is not valid, the options from the default libpwquality configuration file will be read.
  *
  * \note Unless \link Validator::validate() validation\endlink is started with \link Validator::NoTrimming NoTrimming\endlink,
  * whitespaces will be removed from the beginning and the end of the input value before validation.

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -613,17 +613,19 @@ public:
     C_ATTR(pwQuality, :Local :AutoArgs)
     void pwQuality(Context *c) {
         static const QVariantMap options({
-                                      {QStringLiteral("difok"), 1},
-                                      {QStringLiteral("minlen"), 8},
-                                      {QStringLiteral("dcredit"), 0},
-                                      {QStringLiteral("ucredit"), 0},
-                                      {QStringLiteral("ocredit"), 0},
-                                      {QStringLiteral("lcredit"), 0},
-                                      {QStringLiteral("minclass"), 0},
-                                      {QStringLiteral("maxrepeat"), 0},
-                                      {QStringLiteral("maxsequence"), 0},
-                                      {QStringLiteral("maxclassrepeat"), 0},
-                                      {QStringLiteral("gecoscheck"), 0}
+                                             {QStringLiteral("difok"), 1},
+                                             {QStringLiteral("minlen"), 10},
+                                             {QStringLiteral("dcredit"), 0},
+                                             {QStringLiteral("ucredit"), 0},
+                                             {QStringLiteral("ocredit"), 0},
+                                             {QStringLiteral("lcredit"), 0},
+                                             {QStringLiteral("minclass"), 0},
+                                             {QStringLiteral("maxrepeat"), 0},
+                                             {QStringLiteral("maxclassrepeat"), 0},
+                                             {QStringLiteral("maxsequence"), 0},
+                                             {QStringLiteral("gecoscheck"), 0},
+                                             {QStringLiteral("dictcheck"), 1},
+                                             {QStringLiteral("usercheck"), 0}
                                   });
         static Validator v({new ValidatorPwQuality(QStringLiteral("field"), 50, options, QString(), QString(), m_validatorMessages)});
         checkResponse(c, v.validate(c));
@@ -2523,10 +2525,11 @@ void TestValidator::testController_data()
     // **** Start testing ValidatorPwQuality
 #ifdef PWQUALITY_ENABLED
     const QList<QString> invalidPws({
-                                        QStringLiteral("schalke04"), // dictionay
                                         QStringLiteral("asdf234a"), // score too low
-                                        QStringLiteral("asdf") // too short
+                                        QStringLiteral("scha"), // too short
+                                        QStringLiteral("password") // dictionary
                                     });
+    count = 0;
     for (const QString &pw : invalidPws) {
         query.clear();
         query.addQueryItem(QStringLiteral("field"), pw);

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -2539,7 +2539,7 @@ void TestValidator::testController_data()
     }
 
     query.clear();
-    query.addQueryItem(QStringLiteral("field"), QStringLiteral("niKeHAm@M0vZ!8sd$uJv?4AYlDaP6"));
+    query.addQueryItem(QStringLiteral("field"), QStringLiteral("niK3sd2eHAm@M0vZ!8sd$uJv?4AYlDaP6"));
     QTest::newRow("pwquality-valid") << QStringLiteral("/pwQuality") << headers << query.toString(QUrl::FullyEncoded).toUtf8() << valid;
 #endif
 

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -2539,7 +2539,7 @@ void TestValidator::testController_data()
     }
 
     query.clear();
-    query.addQueryItem(QStringLiteral("field"), QStringLiteral("niKeHAm@M0vZuJvYlDaP6"));
+    query.addQueryItem(QStringLiteral("field"), QStringLiteral("niKeHAm@M0vZ!8sd$uJv?4AYlDaP6"));
     QTest::newRow("pwquality-valid") << QStringLiteral("/pwQuality") << headers << query.toString(QUrl::FullyEncoded).toUtf8() << valid;
 #endif
 


### PR DESCRIPTION
Do not fail the validation if one or more options are not available in the used version of libpwquality. Instead use the defaults and print a warning to the logging category.