### PR TITLE
ValidatorPwQuality unit tests: use less invalid password tests

### DIFF
--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -2525,9 +2525,8 @@ void TestValidator::testController_data()
     // **** Start testing ValidatorPwQuality
 #ifdef PWQUALITY_ENABLED
     const QList<QString> invalidPws({
-                                        QStringLiteral("asdf234a"), // score too low
-                                        QStringLiteral("scha"), // too short
-                                        QStringLiteral("password") // dictionary
+                                        QStringLiteral("asdf1234"),
+                                        QStringLiteral("scha"),
                                     });
     count = 0;
     for (const QString &pw : invalidPws) {


### PR DESCRIPTION
As every password to test makes it harder to predict the outcome when
compared with different versions of libpwquality, there will be now only
one real test vor invalidity.