### PR TITLE
ValidatorPwQuality: I fooled myself...

### DIFF
--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality.cpp
@@ -25,11 +25,7 @@ using namespace Cutelyst;
 ValidatorPwQuality::ValidatorPwQuality(const QString &field, int threshold, const QVariant &options, const QString &userName, const QString &oldPassword, const ValidatorMessages &messages) :
     ValidatorRule(*new ValidatorPwQualityPrivate(field, threshold, options, userName, oldPassword, messages))
 {
-    // this is kind of a dirty hack for older versions of libpwquality
-    // version 1.2.2 of libpwquality on Ubuntu Trusty for example will
-    // return a score of 0 for the first time of use, not sure why
-    // libpwquality 1.4.0 on openSUSE does not have this problem
-    ValidatorPwQuality::validate(QStringLiteral("asdf234a"));
+
 }
 
 ValidatorPwQuality::~ValidatorPwQuality()
@@ -85,9 +81,12 @@ int ValidatorPwQuality::validate(const QString &value, const QVariant &options, 
                 }
             }
 
-            const char *pw = value.toUtf8().constData();
-            const char *opw = oldPassword.isEmpty() ? nullptr : oldPassword.toUtf8().constData();
-            const char *u = user.isEmpty() ? nullptr : user.toUtf8().constData();
+            const QByteArray pwba = value.toUtf8();
+            const char *pw = pwba.constData();
+            const QByteArray opwba = oldPassword.toUtf8();
+            const char *opw = opwba.isEmpty() ? nullptr : opwba.constData();
+            const QByteArray uba = user.toUtf8();
+            const char *u = uba.isEmpty() ? nullptr : uba.constData();
 
             rv = pwquality_check(pwq, pw, opw, u, nullptr);
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality.cpp
@@ -55,27 +55,33 @@ int ValidatorPwQuality::validate(const QString &value, const QVariant &options, 
                         const int orv = pwquality_set_option(pwq, opt.toUtf8().constData());
                         if (orv != 0) {
                             char buf[1024];
-                            const char *strError = pwquality_strerror(buf, sizeof(buf), orv, nullptr);
-                            qCWarning(C_VALIDATOR, "ValidatorPwQuality: Failed to set pwquality option %s: %s", qUtf8Printable(opt), strError);
+                            qCWarning(C_VALIDATOR, "ValidatorPwQuality: Failed to set pwquality option %s: %s", qUtf8Printable(opt), pwquality_strerror(buf, sizeof(buf), orv, nullptr));
                         }
                         ++i;
                     }
                 } else if (options.type() == QVariant::String) {
                     const QString configFile = options.toString();
-                    void *auxerror;
-                    const int rcrv = pwquality_read_config(pwq, configFile.toUtf8().constData(), &auxerror);
-                    if (rcrv != 0) {
-                        char buf[1024];
-                        const char *strError = pwquality_strerror(buf, sizeof(buf), rcrv, auxerror);
-                        qCWarning(C_VALIDATOR, "ValidatorPwQuality: Failed to read configuration file %s: %s", qUtf8Printable(configFile), strError);
+                    if (C_VALIDATOR().isWarningEnabled()) {
+                        void *auxerror;
+                        const int rcrv = pwquality_read_config(pwq, configFile.toUtf8().constData(), &auxerror);
+                        if (rcrv != 0) {
+                            char buf[1024];
+                            qCWarning(C_VALIDATOR, "ValidatorPwQuality: Failed to read configuration file %s: %s", qUtf8Printable(configFile), pwquality_strerror(buf, sizeof(buf), rcrv, auxerror));
+                        }
+                    } else {
+                        pwquality_read_config(pwq, configFile.toUtf8().constData(), nullptr);
                     }
                 }
             } else {
-                void *auxerror;
-                const int rcrv = pwquality_read_config(pwq, nullptr, &auxerror);
-                if (rcrv != 0) {
-                    char buf[1024];
-                    qCWarning(C_VALIDATOR, "ValidatorPwQuality: Failed to read default configuration file: %s", pwquality_strerror(buf, sizeof(buf), rcrv, auxerror));
+                if (C_VALIDATOR().isWarningEnabled()) {
+                    void *auxerror;
+                    const int rcrv = pwquality_read_config(pwq, nullptr, &auxerror);
+                    if (rcrv != 0) {
+                        char buf[1024];
+                        qCWarning(C_VALIDATOR, "ValidatorPwQuality: Failed to read default configuration file: %s", pwquality_strerror(buf, sizeof(buf), rcrv, auxerror));
+                    }
+                } else {
+                    pwquality_read_config(pwq, nullptr, nullptr);
                 }
             }
 

--- a/Cutelyst/Plugins/Utils/Validator/validatorpwquality.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorpwquality.h
@@ -35,10 +35,6 @@ class ValidatorPwQualityPrivate;
  * fails. According to libpwquality a score of 0-30 is of low, a score of 30-60 of medium and a score of 60-100
  * of high quality. Everything below 0 is an error and the password should not be used.
  *
- * \note The score is strongly related to the \c minlen setting of libpwquality. This setting does not mean, that every
- * password is invalid, that is shorter than the \c minlen. If you want to require a minimum lengths of your password,
- * use ValidatorMin.
- *
  * <h3>Building</h3>
  * As this validator relies on an external library, it will not be included and build by default. Use either
  * <code>-DPLUGIN_VALIDATOR_PWQUALITY:BOOL=ON</code> or <code>-DBUILD_ALL:BOOL=ON</code> when configuring %Cutelyst

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -614,7 +614,7 @@ public:
     void pwQuality(Context *c) {
         static const QVariantMap options({
                                              {QStringLiteral("difok"), 1},
-                                             {QStringLiteral("minlen"), 10},
+                                             {QStringLiteral("minlen"), 8},
                                              {QStringLiteral("dcredit"), 0},
                                              {QStringLiteral("ucredit"), 0},
                                              {QStringLiteral("ocredit"), 0},
@@ -2523,24 +2523,25 @@ void TestValidator::testController_data()
 
 
     // **** Start testing ValidatorPwQuality
-//#ifdef PWQUALITY_ENABLED
-//    const QList<QString> invalidPws({
-//                                        QStringLiteral("1234"),
-//                                        QStringLiteral("scha"),
-//                                    });
-//    count = 0;
-//    for (const QString &pw : invalidPws) {
-//        query.clear();
-//        query.addQueryItem(QStringLiteral("field"), pw);
-//        QTest::newRow(qUtf8Printable(QStringLiteral("pwquality-invalid0%1").arg(count)))
-//                << QStringLiteral("/pwQuality") << headers << query.toString(QUrl::FullyEncoded).toUtf8() << invalid;
-//        count++;
-//    }
+#ifdef PWQUALITY_ENABLED
+    const QList<QString> invalidPws({
+                                        QStringLiteral("ovkaCPa"), // too short, lower than 8
+                                        QStringLiteral("password"), // dictionary
+                                        QStringLiteral("aceg1234") // score too low
+                                    });
+    count = 0;
+    for (const QString &pw : invalidPws) {
+        query.clear();
+        query.addQueryItem(QStringLiteral("field"), pw);
+        QTest::newRow(qUtf8Printable(QStringLiteral("pwquality-invalid0%1").arg(count)))
+                << QStringLiteral("/pwQuality") << headers << query.toString(QUrl::FullyEncoded).toUtf8() << invalid;
+        count++;
+    }
 
-//    query.clear();
-//    query.addQueryItem(QStringLiteral("field"), QStringLiteral("niK3sd2eHAm@M0vZ!8sd$uJv?4AYlDaP6"));
-//    QTest::newRow("pwquality-valid") << QStringLiteral("/pwQuality") << headers << query.toString(QUrl::FullyEncoded).toUtf8() << valid;
-//#endif
+    query.clear();
+    query.addQueryItem(QStringLiteral("field"), QStringLiteral("niK3sd2eHAm@M0vZ!8sd$uJv?4AYlDaP6"));
+    QTest::newRow("pwquality-valid") << QStringLiteral("/pwQuality") << headers << query.toString(QUrl::FullyEncoded).toUtf8() << valid;
+#endif
 
 
     // **** Start testing ValidatorRegex *****


### PR DESCRIPTION
One should consider the lifetime of return values. I missed the fact, that the QByteArray ran out of scope when used its constData() function directly after returning it with QString::toUtf8(). So the const char*
pointed to some arbitrary data what let me think, pwquality diced the score. And in fact it diced it, because I diced the input data.