### PR TITLE
Translation extraction and loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set (CUTELYST_PLUGINS_DIR "${CMAKE_INSTALL_PREFIX}/lib/cutelyst2-plugins" CACHE 
 set (DOXYGEN_TIMESTAMP "YES" CACHE STRING "Enables or disables the footer timestamp in API documentation. Allowed values: YES or NO")
 set (QHG_LOCATION "qhelpgenerator" CACHE FILEPATH "Path to the qhelpgenerator executable")
 set (MANDIR "${DATADIR}/man" CACHE PATH "Directory to install man pages")
+set (I18NDIR "${DATADIR}/cutelyst${PROJECT_VERSION_MAJOR}/translations" CACHE PATH "Directory to install translations")
 
 add_definitions("-DLOCALSTATEDIR=\"${LOCALSTATEDIR}\"")
 
@@ -181,6 +182,8 @@ if (PLUGIN_UWSGI)
 endif ()
 
 add_subdirectory(cmd)
+
+add_subdirectory(i18n)
 
 add_subdirectory(dox)
 

--- a/Cutelyst/Plugins/CSRFProtection/csrfprotection.cpp
+++ b/Cutelyst/Plugins/CSRFProtection/csrfprotection.cpp
@@ -77,6 +77,8 @@ bool CSRFProtection::setup(Application *app)
 {
     Q_D(CSRFProtection);
 
+    app->loadTranslations(QStringLiteral("plugin_csrfprotection"));
+
     const QVariantMap config = app->engine()->config(QStringLiteral("Cutelyst_CSRFProtection_Plugin"));
 
     d->cookieAge = config.value(QStringLiteral("cookie_age"), DEFAULT_COOKIE_AGE).value<qint64>();

--- a/Cutelyst/Plugins/Memcached/memcached.cpp
+++ b/Cutelyst/Plugins/Memcached/memcached.cpp
@@ -233,6 +233,7 @@ bool Memcached::setup(Application *app)
 
     if (ok) {
         connect(app, &Application::postForked, this, &MemcachedPrivate::_q_postFork);
+        app->loadTranslations(QStringLiteral("plugin_memcached"));
     } else {
         qCCritical(C_MEMCACHED) << "Failed to configure the connection to the memcached server(s)";
     }

--- a/Cutelyst/Plugins/Utils/Validator/validator.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validator.cpp
@@ -19,6 +19,7 @@
 #include "validator_p.h"
 #include <Cutelyst/context.h>
 #include <Cutelyst/request.h>
+#include <Cutelyst/application.h>
 #include <QLoggingCategory>
 
 using namespace Cutelyst;
@@ -135,4 +136,9 @@ void Validator::addValidator(ValidatorRule *v)
     Q_D(Validator);
     v->setTranslationContext(d->translationContext);
     d->validators.push_back(v);
+}
+
+void Validator::loadTranslations(Application *app)
+{
+    app->loadTranslations(QStringLiteral("plugin_utils_validator"));
 }

--- a/Cutelyst/Plugins/Utils/Validator/validator.h
+++ b/Cutelyst/Plugins/Utils/Validator/validator.h
@@ -54,6 +54,7 @@ namespace Cutelyst {
 
 class ValidatorPrivate;
 class Context;
+class Application;
 class ValidatorRule;
 
 /*!
@@ -229,6 +230,11 @@ class ValidatorRule;
 
    </form>
  * \endcode
+ *
+ * <h3>Translations</h3>
+ *
+ * Use Validator::loadTranslations(this) in your reimplementation of Application::init() if you are using the %Validator
+ * plugin and want to use translated generic messages.
  */
 class CUTELYST_PLUGIN_UTILS_VALIDATOR_EXPORT Validator
 {
@@ -307,6 +313,11 @@ public:
      * all added rules will get destroyed, too.
      */
     void addValidator(ValidatorRule *v);
+
+    /*!
+     * \brief Loads the translations for the plugin.
+     */
+    static void loadTranslations(Application *app);
 
 protected:
     const QScopedPointer<ValidatorPrivate> d_ptr;

--- a/Cutelyst/Plugins/View/Grantlee/grantleeview.cpp
+++ b/Cutelyst/Plugins/View/Grantlee/grantleeview.cpp
@@ -53,6 +53,8 @@ GrantleeView::GrantleeView(QObject *parent, const QString &name) : View(parent, 
         // If CUTELYST_VAR is set the template might have become
         // {{ Cutelyst.req.base }} instead of {{ c.req.base }}
         d->cutelystVar = app->config(QStringLiteral("CUTELYST_VAR"), QStringLiteral("c")).toString();
+
+        app->loadTranslations(QStringLiteral("plugin_view_grantlee"));
     } else {
         // make sure templates can be found on the current directory
         setIncludePaths({ QDir::currentPath() });

--- a/Cutelyst/application.h
+++ b/Cutelyst/application.h
@@ -184,6 +184,8 @@ public:
      * }
      * @endcode
      *
+     * @sa loadTranslations()
+     *
      * @since Cutelyst 1.5.0
      */
     void addTranslator(const QLocale &locale, QTranslator *translator);
@@ -220,6 +222,33 @@ public:
      * @since Cutelyst 1.5.0
      */
     QString translate(const QLocale &locale, const char *context, const char *sourceText, const char *disambiguation = nullptr, int n = -1) const;
+
+    /**
+     * Loads translations for a specific @a filename.
+     *
+     * This can be used to load translations for a specific component if the translation file names follow a common schema.
+     * Let us assume you organised your translation files as follows:
+     * @li @c /usr/share/myapp/translations/myapp_de.qm
+     * @li @c /usr/share/myapp/translations/myapp_pt_BR.qm
+     * @li @c ...
+     *
+     * You can then use loadTranslations() in your reimplementation of Application::init() as follows:
+     * @code{.cpp}
+     * bool MyApp::init()
+     * {
+     *      loadTranslations(QStringLiteral("myapp"), QStringLiteral("/usr/share/myapp/translations"), QStringLiteral("_"));
+     * }
+     * @endcode
+     *
+     * If @a directory is empty, the default directory, set by <code>-DI18NDIR</code>, will be used. @a prefix is the part between
+     * the file name and the locale part. In the example above it is @c "_", if it is not set the default @c "." will be used. The
+     * @a suffix is the file name suffix that defaults to <code>".qm"</code>.
+     *
+     * @sa addTranslator()
+     *
+     * @since Cuteylst 2.0.0
+     */
+    void loadTranslations(const QString &filename, const QString &directory = QString(), const QString &prefix = QString(), const QString &suffix = QString());
 
 protected:
     /**

--- a/Messages.sh
+++ b/Messages.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+if [ ! -d i18n ]; then
+    mkdir i18n
+fi
+
+if [ ! $QT5LUPDATE ]; then
+    QT5LUPDATE=/usr/bin/lupdate; fi
+
+if [ ! -x "$QT5LUPDATE" ]; then
+    echo "${QT5LUPDATE} can not be found or is not executable."; echo "Use export QT5LUPDATE=/path/to/lupdate"; exit 1; fi
+
+
+$QT5LUPDATE -no-obsolete -locations none -source-language en -target-language en cmd -ts i18n/cutelystcmd.ts
+
+$QT5LUPDATE -no-obsolete -locations none -source-language en -target-language en wsgi -ts i18n/cutelystwsgi.ts
+
+$QT5LUPDATE -no-obsolete -locations none -source-language en -target-language en -no-recursive Cutelyst -ts i18n/cutelystcore.ts
+
+$QT5LUPDATE -no-obsolete -locations none -source-language en -target-language en Cutelyst/Plugins/Memcached -ts i18n/plugin_memcached.ts
+
+$QT5LUPDATE -no-obsolete -locations none -source-language en -target-language en Cutelyst/Plugins/CSRFProtection -ts i18n/plugin_csrfprotection.ts
+
+$QT5LUPDATE -no-obsolete -locations none -source-language en -target-language en Cutelyst/Plugins/View/Grantlee -ts i18n/plugin_view_grantlee.ts
+
+$QT5LUPDATE -no-obsolete -locations none -source-language en -target-language en Cutelyst/Plugins/Utils/Validator -ts i18n/plugin_utils_validator.ts

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -31,13 +31,13 @@ bool buildControllerImplementation(const QString &filename, const QString &contr
 bool createController(const QString &controllerName)
 {
     if (controllerName.contains(QRegularExpression(QStringLiteral("\\W"))) || controllerName.contains(QRegularExpression(QStringLiteral("^\\d")))) {
-        std::cerr << "Error: Invalid Controller name." << std::endl;
+        std::cerr << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Error: Invalid Controller name.")) << std::endl;
         return false;
     }
 
     QDir projectDir;
     if (!Helper::findProjectDir(QDir::current(), &projectDir)) {
-        std::cerr << "Error: failed to find project" << std::endl;
+        std::cerr << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Error: failed to find project")) << std::endl;
         return false;
     }
 
@@ -58,7 +58,7 @@ bool createController(const QString &controllerName)
     utime(projectDir.absoluteFilePath(QStringLiteral("CMakeLists.txt")).toLatin1().data(), NULL);
 #endif
 
-    std::cout << "Now, on your application class include and instantiate the controller." << std::endl;
+    std::cout << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Now, on your application class include and instantiate the controller.")) << std::endl;
 
     return true;
 }
@@ -104,7 +104,7 @@ bool buildApplicationImplementation(const QString &filename, const QString &appN
 
         return true;
     }
-    std::cerr << "Error: failed to create file" << qPrintable(filename) << std::endl;
+    std::cerr << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Error: failed to create file")) << qPrintable(filename) << std::endl;
 
     return false;
 }
@@ -144,7 +144,7 @@ bool buildApplicationHeader(const QString &filename, const QString &appName)
 
         return true;
     }
-    std::cerr << "Error: failed to create file" << qPrintable(filename) << std::endl;
+    std::cerr << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Error: failed to create file")) << qPrintable(filename) << std::endl;
 
     return false;
 }
@@ -194,7 +194,7 @@ bool buildControllerImplementation(const QString &filename, const QString &contr
 
         return true;
     }
-    std::cerr << "Error: failed to create file" << qPrintable(filename) << std::endl;
+    std::cerr << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Error: failed to create file")) << qPrintable(filename) << std::endl;
 
     return false;
 }
@@ -246,7 +246,7 @@ bool buildControllerHeader(const QString &filename, const QString &controllerNam
 
         return true;
     }
-    std::cerr << "Error: failed to create file" << qPrintable(filename) << std::endl;
+    std::cerr << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Error: failed to create file")) << qPrintable(filename) << std::endl;
 
     return false;
 }
@@ -284,7 +284,7 @@ bool buildSrcCMakeLists(const QString &name, const QString &appName)
 
         return true;
     }
-    std::cerr << "Error: failed to create file" << qPrintable(name) << std::endl;
+    std::cerr << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Error: failed to create file")) << qPrintable(name) << std::endl;
 
     return false;
 }
@@ -339,7 +339,7 @@ bool buildProjectCMakeLists(const QString &name, const QString &appName)
 
         return true;
     }
-    std::cerr << "Error: failed to create file" << qPrintable(name) << std::endl;
+    std::cerr << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Error: failed to create file")) << qPrintable(name) << std::endl;
 
     return false;
 }
@@ -355,7 +355,7 @@ bool createDir(const QDir &parentDir, const QString &name)
         return true;
     }
 
-    std::cerr << "Error: failed to create directory:" << qPrintable(newDir) << std::endl;
+    std::cerr << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Error: failed to create directory:")) << qPrintable(newDir) << std::endl;
     return false;
 }
 
@@ -364,7 +364,7 @@ bool createApplication(const QString &name)
     QString nameWithUnderscore = name;
     nameWithUnderscore.replace(QLatin1Char('-'), QLatin1Char('_'));
     if (nameWithUnderscore.contains(QRegularExpression(QStringLiteral("\\W"))) || nameWithUnderscore.contains(QRegularExpression(QStringLiteral("^\\d")))) {
-        std::cerr << "Error: Invalid Application name." << std::endl;
+        std::cerr << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Error: Invalid Application name.")) << std::endl;
         return false;
     }
 
@@ -416,7 +416,7 @@ bool createApplication(const QString &name)
         return false;
     }
 
-    std::cout << "Change to application directory, then build directory and Run \"cmake ..\" to make sure your install is complete" << std::endl;
+    std::cout << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Change to application directory, then build directory and Run \"cmake ..\" to make sure your install is complete")) << std::endl;
 
     return true;
 }
@@ -441,39 +441,43 @@ int main(int argc, char *argv[])
                       QLibraryInfo::location(QLibraryInfo::TranslationsPath));
     QCoreApplication::installTranslator(&qtTranslator);
 
+    QTranslator appTranslator;
+    if (appTranslator.load(QLocale(), QStringLiteral("cutelystcmd"), QStringLiteral("."), QStringLiteral(I18NDIR))) {
+        QCoreApplication::installTranslator(&appTranslator);
+    }
 
     QCommandLineParser parser;
-    parser.setApplicationDescription(QStringLiteral("Cutelyst DEVELOPER helper, it can create a skeleton for a new application, controllers and start your application"));
+    parser.setApplicationDescription(QCoreApplication::translate("cutelystcmd", "Cutelyst DEVELOPER helper, it can create a skeleton for a new application, controllers and start your application"));
     parser.addHelpOption();
     parser.addVersionOption();
 
     QCommandLineOption appName(QStringLiteral("create-app"),
-                               QStringLiteral("Creates a new Cutelyst application"),
+                               QCoreApplication::translate("cutelystcmd", "Creates a new Cutelyst application"),
                                QStringLiteral("app_name"));
     parser.addOption(appName);
 
     QCommandLineOption controller(QStringLiteral("controller"),
-                                  QStringLiteral("Name of the Controller application to create"),
+                                  QCoreApplication::translate("cutelystcmd", "Name of the Controller application to create"),
                                   QStringLiteral("controller_name"));
 
     parser.addOption(controller);
 
     QCommandLineOption server(QStringLiteral("server"),
-                              QStringLiteral("Starts a HTTP server"));
+                              QCoreApplication::translate("cutelystcmd", "Starts a HTTP server"));
     parser.addOption(server);
 
     QCommandLineOption appFile(QStringLiteral("app-file"),
-                               QStringLiteral("Application file of to use with the server (usually in build/src/lib*.so), if not set it will try to auto-detect"),
+                               QCoreApplication::translate("cutelystcmd", "Application file of to use with the server (usually in build/src/lib*.so), if not set it will try to auto-detect"),
                                QStringLiteral("file_name"));
     parser.addOption(appFile);
 
     QCommandLineOption serverPort({ QStringLiteral("server-port"), QStringLiteral("p") },
-                                  QStringLiteral("Development server port"),
+                                  QCoreApplication::translate("cutelystcmd", "Development server port"),
                                   QStringLiteral("port"));
     parser.addOption(serverPort);
 
     QCommandLineOption restartOpt({ QStringLiteral("restart"), QStringLiteral("r") },
-                                  QStringLiteral("Restarts the development server when the application file changes"));
+                                  QCoreApplication::translate("cutelystcmd", "Restarts the development server when the application file changes"));
     parser.addOption(restartOpt);
 
     const QStringList arguments = app.arguments();
@@ -520,7 +524,7 @@ int main(int argc, char *argv[])
 
         QDir projectDir;
         if (!Helper::findProjectDir(QDir::current(), &projectDir)) {
-            std::cerr << "Error: failed to find project" << std::endl;
+            std::cerr << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Error: failed to find project")) << std::endl;
             return 1;
         }
         wsgi.setChdir2(projectDir.absolutePath());
@@ -529,7 +533,7 @@ int main(int argc, char *argv[])
         if (localFilename.isEmpty()) {
             localFilename = Helper::findApplication(projectDir);
             if (!QFile::exists(localFilename)) {
-                std::cerr << "Error: Application file not found" << std::endl;
+                std::cerr << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Error: Application file not found")) << std::endl;
                 return 1;
             }
         }

--- a/config.h.in
+++ b/config.h.in
@@ -15,6 +15,7 @@
 #define DATADIR "@DATADIR@"
 #define LIBDIR "@LIBDIR@"
 #define BUILDDIR "@BUILDDIR@"
+#define I18NDIR "@I18NDIR@"
 
 /* Name of package */
 #define PACKAGE_NAME "cutelyst"

--- a/i18n/CMakeLists.txt
+++ b/i18n/CMakeLists.txt
@@ -1,0 +1,49 @@
+find_program(LRELEASE_CMD_PATH NAMES lrelease-qt5 lrelease)
+set(LRELEASE_CMD ${LRELEASE_CMD_PATH})
+if (LRELEASE_CMD)
+    message(STATUS "Found lrelease at ${LRELEASE_CMD}")
+    message(STATUS "Translations are enabled")
+
+    set (LCPREFIX ".")
+    set (PATHSEP "/")
+
+    set (PARTS
+        cutelystcmd
+        cutelystwsgi
+        cutelystcore
+        plugin_memcached
+        plugin_csrfprotection
+        plugin_view_grantlee
+        plugin_utils_validator)
+
+    foreach(PART ${PARTS})
+        string(CONCAT GLOBEXPRESSION ${PART} ${LCPREFIX} "*.ts")
+        file(GLOB TRANSLATIONS ${CMAKE_CURRENT_SOURCE_DIR} ${GLOBEXPRESSION})
+        foreach(TRANS ${TRANSLATIONS})
+            string(COMPARE NOTEQUAL ${TRANS} ${CMAKE_CURRENT_SOURCE_DIR} NOTTHEDIR)
+            string(CONCAT SOURCE_FILE ${CMAKE_CURRENT_SOURCE_DIR} ${PATHSEP} ${PART} ".ts")
+            string(COMPARE NOTEQUAL ${TRANS} ${SOURCE_FILE} NOTTHESOURCE)
+            if (NOTTHEDIR AND NOTTHESOURCE)
+                string(LENGTH ${CMAKE_CURRENT_SOURCE_DIR} CURRENT_SOURCE_DIR_LENGTH)
+                string(LENGTH ${PART} PART_LENGTH)
+                string(LENGTH ${TRANS} TRANS_LENGTH)
+                string(LENGTH ${LCPREFIX} LCPREFIX_LENGTH)
+                math(EXPR SUBSTART ${CURRENT_SOURCE_DIR_LENGTH}+${PART_LENGTH}+${LCPREFIX_LENGTH}+1)
+                math(EXPR SUBLENGTH ${TRANS_LENGTH}-${CURRENT_SOURCE_DIR_LENGTH}-${PART_LENGTH}-${LCPREFIX_LENGTH}-4)
+                string(SUBSTRING ${TRANS} ${SUBSTART} ${SUBLENGTH} LC)
+                execute_process(COMMAND ${LRELEASE_CMD} -silent ${TRANS} -qm ${CMAKE_CURRENT_BINARY_DIR}${PATHSEP}${PART}${LCPREFIX}${LC}.qm RESULT_VARIABLE LRELEASE_RESULT ERROR_VARIABLE LRELEASE_ERROR)
+                if (${LRELEASE_RESULT} EQUAL 0)
+                    list(APPEND QM_FILES ${CMAKE_CURRENT_BINARY_DIR}${PATHSEP}${PART}${LCPREFIX}${LC}.qm)
+                else (${LRELEASE_RESULT} EQUAL 0)
+                    message(WARNING ${LRELEASE_ERROR})
+                endif (${LRELEASE_RESULT} EQUAL 0)
+            endif (NOTTHEDIR AND NOTTHESOURCE)
+        endforeach(TRANS)
+    endforeach(PART)
+
+    install (FILES ${QM_FILES} DESTINATION ${I18NDIR})
+
+else (LRELEASE_CMD)
+    message(WARNING "lrelease executable cannot be found")
+    message(WARNING "Translations are disabled")
+endif (LRELEASE_CMD)

--- a/i18n/cutelystcmd.ts
+++ b/i18n/cutelystcmd.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en" sourcelanguage="en">
+<context>
+    <name>cutelystcmd</name>
+    <message>
+        <source>Error: Invalid Controller name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error: failed to find project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Now, on your application class include and instantiate the controller.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error: failed to create file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error: failed to create directory:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error: Invalid Application name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change to application directory, then build directory and Run &quot;cmake ..&quot; to make sure your install is complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutelyst DEVELOPER helper, it can create a skeleton for a new application, controllers and start your application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creates a new Cutelyst application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name of the Controller application to create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts a HTTP server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application file of to use with the server (usually in build/src/lib*.so), if not set it will try to auto-detect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Development server port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restarts the development server when the application file changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error: Application file not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/i18n/cutelystcore.ts
+++ b/i18n/cutelystcore.ts
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en" sourcelanguage="en">
+<context>
+    <name>Cutelyst::Dispatcher</name>
+    <message>
+        <source>No default action defined</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown resource &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/i18n/cutelystwsgi.ts
+++ b/i18n/cutelystwsgi.ts
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en" sourcelanguage="en">
+<context>
+    <name>main</name>
+    <message>
+        <source>Fast, developer-friendly WSGI server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>load config from ini file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>load config from JSON file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>chdir to specified directory before apps loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>chdir to specified directory afterapps loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>set lazy mode (load app in workers instead of master)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application to load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of thread to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>spawn the specified number of processes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>processes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable master process</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>set internal buffer size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bytes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>set size after which will buffer to disk instead of memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>set buffer size for read() in post buffering mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bind to the specified TCP socket using HTTP protocol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bind to the specified TCP socket using HTTPS protocol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bind to the specified UNIX/TCP socket using FastCGI protocol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>set the LOCAL socket access, such as &apos;ugo&apos; standing for User, Group, Other access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>set internal sockets timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>map mountpoint to static directory (or file)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mountpoint=path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>like static-map but completely appending the requested resource to the docroot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>auto restarts when the application file changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>reload application if the specified file is modified/touched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>enable TCP NODELAY on each request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>enable TCP KEEPALIVEs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>set SO_SNDBUF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>set SO_RCVBUF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>sets the socket receive buffer size in bytes at the OS level. This maps to the SO_RCVBUF socket option</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kbytes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>create pidfile (before privileges drop)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>create pidfile (after privileges drop)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>stop an instance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pidfile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>setuid to the specified user/uid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>user/uid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>setgid to the specified group/gid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>group/gid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disable additional groups set via initgroups()</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>chown unix sockets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>uid:gid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>set file mode creation mask</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>set CPU affinity with the number of CPUs available for each worker core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>core count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>enable SO_REUSEPORT flag on socket (Linux 3.9+)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>balances new connections to threads using round-robin</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/i18n/plugin_csrfprotection.ts
+++ b/i18n/plugin_csrfprotection.ts
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en" sourcelanguage="en">
+<context>
+    <name>Cutelyst::CSRFProtection</name>
+    <message>
+        <source>403 Forbidden - CSRF protection check failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The CSRF protection plugin has not been registered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Referer checking failed - no Referer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Referer checking failed - Referer is malformed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Referer checking failed - Referer is insecure while host is secure.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Referer checking failed - %1 does not match any trusted origins.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSRF cookie not set.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSRF token missing or incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/i18n/plugin_memcached.ts
+++ b/i18n/plugin_memcached.ts
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en" sourcelanguage="en">
+<context>
+    <name>Cutelyst::Memcached</name>
+    <message>
+        <source>The request was successfully executed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An unknown failure has occurred in the server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A DNS failure has occurred.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An unknown error has occured while trying to connect to a server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error has occured while trying to write to a server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error has occured while trying to read from a server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An unknown error has occured while trying to read from a server. This only occures when either there is a bug in the server, or in rare cases where an ethernet NIC is reporting dubious information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An unknown error has occured in the protocol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An unknown client error has occured internally.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An unknown error has occured in the server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A general error occured.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The data for the given key alrey exists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The data requested with the key given was not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The request to store an object failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The requested object has been successfully stored on the server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The object requested was not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error has occurred while trying to allocate memory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The read operation was only partcially successful.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A multi request has been made, and some underterminate number of errors have occurred.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No servers have been added to the Memcached plugin.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The server has completed returning all of the objects requested.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The object requested by the key has been deleted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A &quot;stat&quot; command has been returned in the protocol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error has occurred in the driver which has set errno.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The given method is not supported in the server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A request has been made, but the server has not finished the fetch of the last request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The operation has timed out.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The request has been buffered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The key provided is not a valid key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The server you are connecting to has an invalid protocol. Most likely you are connecting to an older server that does not speak the binary protocol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The requested server has been marked dead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The server you are communicating with has a stat key which has not be defined in the protocol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item is too large for the server to store.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The arguments supplied to the given function were not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The key that has been provided is too large for the given server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An unknown issue has occured during SASL authentication.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The credentials provided are not valid for this server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authentication has been paused.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error has occurred while trying to parse the configuration string.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An error has occurred in parsing the configuration string.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The method that was requested has been deprecated.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Cutelyst Memcached plugin has not been registered to the application.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An unknown error has occured.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/i18n/plugin_utils_validator.ts
+++ b/i18n/plugin_utils_validator.ts
@@ -1,0 +1,1615 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en" sourcelanguage="en">
+<context>
+    <name>Cutelyst::Validator</name>
+    <message>
+        <source>“%1” has to be accepted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorAccepted</name>
+    <message>
+        <source>Has to be accepted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorAfter</name>
+    <message>
+        <source>The date in the “%1” field must be after %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The date and time in the “%1” field must be after %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The time in the “%1” field must be after %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The comparison value is not a valid date and/or time, or cannot be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not be parsed according to the follwing date and/or time format: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value of the “%1” field could not be parsed according to the follwing date and/or time format: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not be parsed as date and time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not be parsed as time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not be parsed as date.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value of the “%1” field could not be parsed as date and time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value of the “%1” field could not be parsed as time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value of the “%1” field could not be parsed as date.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorAlhpa</name>
+    <message>
+        <source>Must be entirely alphabetic characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The text in the “%1” field must be entirely alphabetic characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorAlphaDash</name>
+    <message>
+        <source>Can only contain alpha-numeric characters, dashes and underscores.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The “%1” field can only contain alpha-numeric characters, as well as dashes and underscores, but nothing else.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorBefore</name>
+    <message>
+        <source>The date in the “%1” field must be before %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The date and time in the “%1” field must be before %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The time in the “%1” field must be before %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The comparison value is not a valid date and/or time, or cannot be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not be parsed according to the follwing date and/or time format: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value of the “%1” field could not be parsed according to the follwing date and/or time format: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not be parsed as date and time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not be parsed as time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not be parsed as date.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value of the “%1” field could not be parsed as date and time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value of the “%1” field could not be parsed as time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value of the “%1” field could not be parsed as date.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorBetween</name>
+    <message>
+        <source>The text must be between %1 and %2 characters long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value must be between %1 and %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The text in the “%1“ field must be between %2 and %3 characters long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field must be between %2 and %3.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum comparison value is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum comparison value for the “%1” field is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The comparison type with ID %1 is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The comparison type with ID %1 for the “%2” field is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The maximum comparison value is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The maximum comparison value for the “%1” field is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value into a floating point number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value for the “%1” field into a floating point number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value into an integer number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value for the “%1” field into an integer number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorBoolean</name>
+    <message>
+        <source>Can not be interpreted as boolean value.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field can not be interpreted as a boolean value.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorConfirmed</name>
+    <message>
+        <source>Confirmation failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1“ field has not been confirmed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorDate</name>
+    <message>
+        <source>Not a valid date according to the following date format: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not a valid date.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field can not be parsed as date according to the following scheme: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field can not be parsed as date.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorDateTime</name>
+    <message>
+        <source>Not a valid date and time according to the following date format: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not a valid date and time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field can not be parsed as date and time according to the following date and time format: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field can not be prased as date and time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorDifferent</name>
+    <message>
+        <source>Has to be different from the value in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the field “%1” has to be different from the value in the field “%2“.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorDigits</name>
+    <message numerus="yes">
+        <source>Must contain exactly %n digit(s).</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Must only contain digits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>The “%1” field must contain exactly %n digit(s).</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>The “%1” field must only contain digits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorDigitsBetween</name>
+    <message>
+        <source>Must contain between %1 and %2 digits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The “%1” field must contain between %2 and %3 digits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorDomain</name>
+    <message>
+        <source>The domain name seems to be valid but could not be found in the domain name system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain name contains characters that are not allowed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At least one of the sections separated by dots exceeds the maximum allowed length of 63 characters. Note that internationalized domain names may be internally longer than they are displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The full name of the domain must not be longer than 253 characters. Note that internationalized domain names may be internally longer than they are displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This is not a valid domain name because it has either no parts (is empty) or only has a top level domain.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At least one of the sections separated by dots is empty. Check whether you have entered two dots consecutively.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The top level domain (last part) contains characters that are not allowed, like digits and or dashes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Domain name sections are not allowed to start with a dash.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Domain name sections are not allowed to end with a dash.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Domain name sections are not allowed to start with a digit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain name is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The DNS lookup was aborted because it took too long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain name in the “%1“ field seems to be valid but could not be found in the domain name system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain name in the “%1“ field contains characters that are not allowed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain name in the “%1“ field is not valid because at least one of the sections separated by dots exceeds the maximum allowed length of 63 characters. Note that internationalized domain names may be internally longer than they are displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The full name of the domain in the “%1” field must not be longer than 253 characters. Note that internationalized domain names may be internally longer than they are displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The “%1” field does not contain a valid domain name because it has either no parts (is empty) or only has a top level domain.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain name in the “%1“ field is not valid because at least on of the sections separated by dots is empty. Check whether you have entered two dots consecutively.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The top level domain (last part) of the domain name in the “%1” field contains characters that are not allowed, like digits and or dashes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain name in the “%1“ field is not valid because domain name sections are not allowed to start with a dash.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain name in the “%1“ field is not valid because domain name sections are not allowed to end with a dash.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain name in the “%1“ field is not valid because domain name sections are not allowed to start with a digit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain name in the “%1” field is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The DNS lookup for the name in the “%1” field was aborted because it took too long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorEmail</name>
+    <message>
+        <source>Address is valid. Please note that this does not mean the address actually exists, nor even that the domain actually exists. This address could be issued by the domain owner without breaking the rules of any RFCs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find an MX record for this address’ domain but an A record does exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could neither find an MX record nor an A record for this address’ domain.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address is valid but at a Top Level Domain.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address is valid but the Top Level Domain begins with a number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address is valid but contains a quoted string.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address is valid but uses an IP address instead of a domain name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address is valid but uses an IP address that contains a :: only eliding one zero group. All implementations must accept and be able to handle any legitimate RFC 4291 format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address contains comments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address contains folding white spaces like line breaks.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The local part is in a deprecated form.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address contains an obsolete form of folding white spaces.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A quoted string contains a deprecated character.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A quoted pair contains a deprecate character.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address contains a comment in a position that is deprecated.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A comment contains a deprecated character.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address contains a comment or folding white space around the @ sign.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address is RFC 5322 compliant but contains domain charachters that are not allowed by DNS.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address is too long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The local part of the address is too long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain part is too long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain part contains an element that is too long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain literal is not a valid RFC 5321 address literal.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain literal is not a valid RFC 5321 domain literal and it contains obsolete characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The IPv6 literal address contains the wrong number of groups.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The IPv6 literal address contains too many :: sequences.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The IPv6 address contains an illegal group of characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The IPv6 address has too many groups.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The IPv6 address starts with a single colon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The IPv6 address ends with a single colon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A domain literal contains a character that is not allowed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address has no local part.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address has no domain part.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address may not contain consecutive dots.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address contains text after a comment or folding white space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address contains text after a quoted string.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extra characters were found after the end of the domain literal.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Address contains a character that is not allowed in a quoted pair.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address contains a character that is not allowed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A quoted string contains a character that is not allowed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A comment contains a character that is not allowed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address can&apos;t end with a backslash.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Neither part of the address may begin with a dot.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Neither part of the address may end with a dot.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A domain or subdomain can not begin with a hyphen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A domain or subdomain can not end with a hyphen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unclosed quoted string. (Missing double quotation mark)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unclosed comment. (Missing closing parantheses)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Domain literal is missing its closing bracket.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folding white space contains consecutive line break sequences (CRLF).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folding white space ends with a line break sequence (CRLF).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address contains a carriage return (CR) that is not followed by a line feed (LF).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A fatal error occured while parsing the address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field is valid. Please note that this does not mean the address actually exists, nor even that the domain actually exists. This address could be issued by the domain owner without breaking the rules of any RFCs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not find an MX record for the address’ domain in the “%1” field but an A record does exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could neither find an MX record nor an A record for address’ domain in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field is valid but at a Top Level Domain.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field is valid but the Top Level Domain begins with a number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” is valid but contains a quoted string.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field is valid but uses an IP address instead of a domain name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field is valid but uses an IP address that contains a :: only eliding one zero group. All implementations must accept and be able to handle any legitimate RFC 4291 format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field contains comments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field contains folding white spaces like line breaks.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The local part of the address in the “%1” field is in a deprecated form.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field contains an obsolete form of folding white spaces.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A quoted string in the address in the “%1” field contains a deprecated character.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A quoted pair in the address in the “%1” field contains a deprecate character.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field contains a comment in a position that is deprecated.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A comment in the address in the “%1” field contains a deprecated character.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field contains a comment or folding white space around the @ sign.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field is RFC 5322 compliant but contains domain charachters that are not allowed by DNS.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field is too long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The local part of the address in the “%1” field is too long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain part of the address in the “%1” field is too long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain part of the address in the “%1” field contains an element that is too long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain literal of the address in the “%1” field is not a valid RFC 5321 address literal.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The domain literal of the address in the “%1” field is not a valid RFC 5321 domain literal and it contains obsolete characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The IPv6 literal of the address in the “%1” field contains the wrong number of groups.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The IPv6 literal of the address in the “%1” field contains too many :: sequences.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The IPv6 address of the email address in the “%1” field contains an illegal group of characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The IPv6 address of the email address in the “%1” field has too many groups.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The IPv6 address of the email address in the “%1” field starts with a single colon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The IPv6 address of the email address in the “%1” field ends with a single colon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A domain literal of the address in the “%1” field contains a character that is not allowed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field has no local part.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field has no domain part.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field may not contain consecutive dots.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field contains text after a comment or folding white space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field contains text after a quoted string.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extra characters were found after the end of the domain literal of the address in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field contains a character that is not allowed in a quoted pair.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field contains a character that is not allowed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A quoted string in the address in the “%1” field contains a character that is not allowed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A comment in the address in the “%1” field contains a character that is not allowed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field can&apos;t end with a backslash.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Neither part of the address in the “%1” field may begin with a dot.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Neither part of the address in the “%1” field may end with a dot.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A domain or subdomain of the address in the “%1” field can not begin with a hyphen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A domain or subdomain of the address in the “%1” field can not end with a hyphen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unclosed quoted string in the address in the “%1” field. (Missing double quotation mark)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unclosed comment in the address in the “%1” field. (Missing closing parantheses)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Domain literal of the address in the “%1” field is missing its closing bracket.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folding white space in the address in the “%1” field contains consecutive line break sequences (CRLF).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folding white space in the address in the “%1” field ends with a line break sequence (CRLF).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field contains a carriage return (CR) that is not followed by a line feed (LF).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A fatal error occured while parsing the address in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address is valid but a dns check was not successful.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address is valid for SMTP but has unusual elements.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address is valid within the message but can not be used unmodified for the envelope.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address contains deprecated elements but my still be valid in restricted contexts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address is only valid according to the broad definition of RFC 5322. It is otherwise invalid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address is invalid for any purpose.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field is valid but a dns check was not successful.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field is valid for SMTP but has unusual elements.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field is valid within the message but can not be used unmodified for the envelope.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field contains deprecated elements but my still be valid in restricted contexts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field is only valid according to the broad definition of RFC 5322. It is otherwise invalid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The address in the “%1” field is invalid for any purpose.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorFileSize</name>
+    <message>
+        <source>Invalid file size or file size not within the allowed limits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field is either not a valid file size or not within the allowed limits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid file size.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The “%1” field does not contain a valid file size.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum file size comparison value is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum file size comparison value for the “%1” field is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The maximum file size comparison value is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The maximum file size comparison value for the “%1” field is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorFilled</name>
+    <message>
+        <source>Must be filled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You must fill in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorIn</name>
+    <message>
+        <source>Has to be one of the following: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field has to be one of the following: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The list of comparison values is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The list of comparison values for the “%1” field is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorIp</name>
+    <message>
+        <source>IP address is invalid or not acceptable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The IP address in the “%1” field is invalid or not acceptable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorJson</name>
+    <message>
+        <source>Invalid JSON data: %1</source>
+        <extracomment>%1 will contain the json error</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid JSON data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The data entered in the “%1” field is not valid JSON: %2</source>
+        <extracomment>%1 will contain the field label, %2 will contain the json error</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The data entered in the “%1” field is not valid JSON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorMax</name>
+    <message>
+        <source>The text must be shorter than %1 characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value must be lower than %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The text in the “%1“ field must be shorter than %2 characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field must be lower than %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The comparison type with ID %1 is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The comparison type with ID %1 for the “%2” field is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The maximum comparison value is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The maximum comparison value for the “%1” field is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value into a floating point number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value for the “%1” field into a floating point number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value into an integer number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value for the “%1” field into an integer number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorMin</name>
+    <message>
+        <source>The text must be longer than %1 characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value must be greater than %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The text in the “%1“ field must be longer than %2 characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field must be greater than %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum comparison value is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum comparison value for the “%1” field is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The comparison type with ID %1 is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The comparison type with ID %1 for the “%2” field is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value into a floating point number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value for the “%1” field into a floating point number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value into an integer number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value for the “%1” field into an integer number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorNotIn</name>
+    <message>
+        <source>Value is not allowed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field is not allowed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The list of comparison values is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The list of comparison values for the “%1” field is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorNumeric</name>
+    <message>
+        <source>Must be numeric, like 1, -2.5 or 3.454e3.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have to enter a numeric value into the “%1” field, like 1, -2.5 or 3.454e3</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorPresent</name>
+    <message>
+        <source>Has to be present in input data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The “%1” field was not found in the input data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorPwQuality</name>
+    <message>
+        <source>Password quality check failed because of a memory allocation error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password is the same as the old one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password is a palindrome.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password differs with case changes only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password is too similar to the old one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password contains the user name in some form.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password contains words from the real name of the user in some form.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password contains forbidden words in some form.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password contains too few digits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password contains too few uppercase letters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password contains too few lowercase letters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password contains less than %ld non-alphanumeric characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password is too short.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password is just rotated old one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password does not contain enough character classes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password contains too many same characters consecutively.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password contains too many characters of the same class consecutively.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password contains too long of a monotonic character sequence.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No password supplied.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check failed because we cannot obtain random numbers from the RNG device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password fails the dictionary check.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check failed because of an unknown setting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check failed because of a bad integer value in the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check failed because of a settings entry is not of integer type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check failed because of a settings entry is not of string type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check failed because opening the configuration file failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check failed because the configuration file is malformed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check failed because of a fatal failure.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check failed because of an unknown error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password quality score of %1 is below the threshold of %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check for the “%1“ field failed because of a memory allocation error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field is the same as the old one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field is a palindrome.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field differs with case changes only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field is too similar to the old one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field contains the user name in some form.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field contains words from the real name of the user in some form.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field contains forbidden words in some form.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field contains too few digits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field contains too few uppercase letters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field contains too few lowercase letters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field contains less than %ld non-alphanumeric characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field is too short.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field is just rotated old one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field does not contain enough character classes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field contains too many same characters consecutively.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field contains too many characters of the same class consecutively.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field contains too long of a monotonic character sequence.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No password supplied in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check for the “%1“ field failed because we cannot obtain random numbers from the RNG device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password in the “%1” field fails the dictionary check.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check for the “%1“ field failed because of an unknown setting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check for the “%1“ field failed because of a bad integer value in the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check for the “%1“ field failed because of a settings entry is not of integer type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check for the “%1“ field failed because of a settings entry is not of string type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check for the “%1“ field failed because opening the configuration file failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check for the “%1“ field failed because the configuration file is malformed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check for the “%1“ field failed because of a fatal failure.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password quality check for the “%1” field failed because of an unknown error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The quality score of %1 for the password in the “%2” field is below the threshold of %3.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorRegularExpression</name>
+    <message>
+        <source>Does not match the desired format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The “%1” field does not match the desired format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorRequired</name>
+    <message>
+        <source>This is required.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The “%1” field is required.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorRequiredIf</name>
+    <message>
+        <source>This is required.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You must fill in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorRequiredIfStash</name>
+    <message>
+        <source>This is required.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You must fill in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorRequiredUnless</name>
+    <message>
+        <source>This is required.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You must fill in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorRequiredUnlessStash</name>
+    <message>
+        <source>This is required.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You must fill in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorRequiredWith</name>
+    <message>
+        <source>This is required.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You must fill in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorRequiredWithAll</name>
+    <message>
+        <source>This is required.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You must fill in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorRequiredWithout</name>
+    <message>
+        <source>This is required.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You must fill in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorRequiredWithoutAll</name>
+    <message>
+        <source>This is required.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You must fill in the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorRule</name>
+    <message>
+        <source>The input data in the “%1” field is not acceptable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The input data is not acceptable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The input data in the “%1“ field could not be parsed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The input data could not be parsed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Missing or invalid validation data for the “%1” field.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Missing or invalid validation data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorSize</name>
+    <message>
+        <source>The text must be exactly %1 characters long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value must be %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The text in the “%1“ field must be exactly %2 characters long.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field must be %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The comparison type with ID %1 is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The comparison type with ID %1 for the “%2” field is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The comparison value is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The comparison value for the “%1” field is not valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value into a floating point number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value for the “%1” field into a floating point number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value into an integer number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to parse the input value for the “%1” field into an integer number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorTime</name>
+    <message>
+        <source>Not a valid time according to the following date format: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not a valid time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field can not be parsed as time according to the following scheme: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field can not be parse as time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Cutelyst::ValidatorUrl</name>
+    <message>
+        <source>Not a valid URL.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1” field is not a valid URL.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ValidatorAlphaNum</name>
+    <message>
+        <source>Must be entierly alpha-numeric characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The text in the “%1” field must be entirely alpha-numeric characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ValidatorInteger</name>
+    <message>
+        <source>Not a valid integer value between %1 and %2.</source>
+        <extracomment>%1 is the minimum numerical limit for the selected type, %2 is the maximum numeric limit</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The value in the “%1“ field is not a valid integer between %2 and %3.</source>
+        <extracomment>%2 is the minimum numerical limit for the selected type, %3 is the maximum numeric limit</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/i18n/plugin_view_grantlee.ts
+++ b/i18n/plugin_view_grantlee.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en" sourcelanguage="en">
+<context>
+    <name>Cutelyst::GrantleeView</name>
+    <message>
+        <source>Internal server error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/wsgi/main.cpp
+++ b/wsgi/main.cpp
@@ -35,6 +35,11 @@ int main(int argc, char *argv[])
 
     QCoreApplication app(argc, argv);
 
+    QTranslator appTranslator;
+    if (appTranslator.load(QLocale(), QStringLiteral("cutelystwsgi"), QStringLiteral("."), QStringLiteral(I18NDIR))) {
+        QCoreApplication::installTranslator(&appTranslator);
+    }
+
     wsgi.parseCommandLine(app.arguments());
 
 //    QTranslator qtTranslator;


### PR DESCRIPTION
This changes will add support for translation extraction and translation loading.

Extraction is done in a shell script (Messages.sh) that will extract translations from different parts into different translation source files in the i18n directory. My current proposal for the parts:
* i18n/cutelystcmd.ts contains all translations from the cmd subdirectory
* i18n/cutelystwsgi.ts contains all translation from the wsgi subdirectory
* i18n/cutelystcore.ts contains all translations from the Cutelyst directory **withouth** the content from the subdirectories
* i18n/plugin_memcached.ts contains all translations from the Cutelyst/Plugins/Memcached subdirectory
* i18n/plugin_csrfprotection.ts contains all translations from the Cutelyst/Plugins/CSRFProtection subdirectory
* i18n/plugin_view_grantlee.ts contains all translations from the Cutelyst/Plugins/View/Grantlee subdirectory
* i18n/plugin_utils_validator.ts contains all translations from the Cutelyst/Plugins/Utils/Validator subdirectory

Not sure if that fits into your naming conventions or preferences. :)

The CMakeLists.txt in the i18n directory contains the logic to compile the language source files (*.ts) into .qm files and installs them into the I18NDIR (variable added to main CMakeLists.txt). Translation compilation is enabled if the lrelease command can be found. The I18NDIR variable has also been added to config.h.in to make the loading from the installed location possible.

To make the loading of the translations easier I added the loadTranslations() method to the Application class. This will be used to load internal application but can also be used by applications to load their translations (at least for the _core_, not for templates). Application::loadTranslations() will load all available translations found for the specified filename/component.

I used this in the constructor of Application to load the core translations and in the setup methods of the plugins. For the Validator plugin I added the static method because it will not be instantiated in the Application::init() method.

I did not add _real_ translations yes as Transifex for example will create the ts files on its own for every language. So not sure, what service you want to use. :)

For the translation files and the sources I decided to use the following format: `{componentname}{prefix}{langcode}.ts`. These will be compiled into `{componentname}{prefix}{langcode}.qm`. So, for exmaple the core translation files will be `cutelystcore.pt_BR.ts` and will be compiled into `cutelystcore.pt_BR.ts`. For sure we could change the prefix to an underscore, so we would have `cutelystcore_pt_BR.ts' etc. I chose the dot as prefix because it seems to be the default on QTranslator.