### PR TITLE
ValidatorEmail: add support for UTF8 local part and IDNs

### DIFF
--- a/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
@@ -755,10 +755,20 @@ bool ValidatorEmailPrivate::checkEmail(const QString &address, ValidatorEmail::O
                 //                       %d127              ;  white space characters
                 const ushort uni = token.unicode();
 
-                if ((uni > 127) || (uni == 0) || (uni == 10)) {
-                    returnStatus.push_back(ValidatorEmail::ErrorExpectingQText); // Fatal error
-                } else if ((uni < 32) || (uni == 127)) {
-                    returnStatus.push_back(ValidatorEmail::DeprecatedQText);
+                if (!allowUtf8Local) {
+                    if ((uni > 127) || (uni == 0) || (uni == 10)) {
+                        returnStatus.push_back(ValidatorEmail::ErrorExpectingQText); // Fatal error
+                    } else if ((uni < 32) || (uni == 127)) {
+                        returnStatus.push_back(ValidatorEmail::DeprecatedQText);
+                    }
+                } else {
+                    if (!token.isLetterOrNumber()) {
+                        if ((uni > 127) || (uni == 0) || (uni == 10)) {
+                            returnStatus.push_back(ValidatorEmail::ErrorExpectingQText); // Fatal error
+                        } else if ((uni < 32) || (uni == 127)) {
+                            returnStatus.push_back(ValidatorEmail::DeprecatedQText);
+                        }
+                    }
                 }
 
                 parseLocalPart += token;

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail.h
@@ -132,9 +132,11 @@ public:
     Q_ENUM(Diagnose)
 
     enum Option : quint8 {
-        NoOption    = 0,    /**< No option enabled, the default. */
-        CheckDNS    = 1,    /**< Enabled a DNS lookup to check if there are MX records for the mail domain. */
-        AllowUTF8   = 2     /**< Allows UTF8 characters in the email address. */
+        NoOption    = 0,                    /**< No option enabled, the default. */
+        CheckDNS    = 1,                    /**< Enabled a DNS lookup to check if there are MX records for the mail domain. */
+        UTF8Local   = 2,                    /**< Allows UTF8 characters in the email address local part. */
+        AllowIDN    = 4,                    /**< Allows internationalized domain names (IDN). */
+        AllowUTF8   = UTF8Local|AllowIDN    /**< Allows UTF8 characters in the email local part and internationalized domain names (IDN). */
     };
     Q_DECLARE_FLAGS(Options, Option)
 

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail.h
@@ -22,7 +22,7 @@
 #include "validatorrule.h"
 
 namespace Cutelyst {
-    
+
 class ValidatorEmailPrivate;
 
 /*!
@@ -131,15 +131,22 @@ public:
     };
     Q_ENUM(Diagnose)
 
+    enum Option : quint8 {
+        NoOption    = 0,    /**< No option enabled, the default. */
+        CheckDNS    = 1,    /**< Enabled a DNS lookup to check if there are MX records for the mail domain. */
+        AllowUTF8   = 2     /**< Allows UTF8 characters in the email address. */
+    };
+    Q_DECLARE_FLAGS(Options, Option)
+
     /*!
      * \brief Constructs a new email validator.
      * \param field         Name of the input field to validate.
-     * \param checkDns      If \c true, a DNS lookup will be performed to check if there are MX records for the email domain.
+     * \param options       Options for the validation process.
      * \param messages      Custom error messages if validation fails.
      * \param defValKey     \link Context::stash() Stash \endlink key containing a default value if input field is empty. This value will \b NOT be validated.
      */
-    ValidatorEmail(const QString &field, Category threshold = RFC5321, bool checkDns = false, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
-    
+    ValidatorEmail(const QString &field, Category threshold = RFC5321, Options options = NoOption, const ValidatorMessages &messages = ValidatorMessages(), const QString &defValKey = QString());
+
     /*!
      * \brief Deconstructs the email validator.
      */
@@ -184,12 +191,12 @@ public:
      * \brief Returns \c true if \a email is a valid address according to the Category given in the \a threshold.
      * \param[in] email         The address to validate.
      * \param[in] threshold     The threshold category that limits the diagnose that is accepted as valid.
-     * \param[in] checkDns      If \c true, a check for valid MX and A records of the address's domain will be performed.
+     * \param[in] options       Options for the validation process.
      * \param[out] diagnoses    If not a \c nullptr, this will contain a list of all issues found by the check, ordered from the highest to the lowest.
      * \return \c true if \a email is a valid address according to the Category given in the \a threshold.
      */
-    static bool validate(const QString &email, Category threshold = RFC5321, bool checkDns = false, QList<Diagnose> *diagnoses = nullptr);
-    
+    static bool validate(const QString &email, Category threshold = RFC5321, Options options = NoOption, QList<Diagnose> *diagnoses = nullptr);
+
 protected:
     /*!
      * \brief Performs the validation and returns the result.
@@ -204,13 +211,15 @@ protected:
      * \brief Returns a generic error if validation failed.
      */
     QString genericValidationError(Context *c, const QVariant &errorData = QVariant()) const override;
-    
+
 private:
     Q_DECLARE_PRIVATE(ValidatorEmail)
     Q_DISABLE_COPY(ValidatorEmail)
 };
-    
+
 }
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(Cutelyst::ValidatorEmail::Options)
 
 #endif //CUTELYSTVALIDATOREMAIL_H
 

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail_p.h
@@ -30,14 +30,14 @@ struct ValidatorEmailDiagnoseStruct {
     QString domain;
     QString literal;
 };
-    
+
 class ValidatorEmailPrivate : public ValidatorRulePrivate
 {
 public:
-    ValidatorEmailPrivate(const QString &f, ValidatorEmail::Category thresh, bool dns, const ValidatorMessages &m, const QString &dvk) :
+    ValidatorEmailPrivate(const QString &f, ValidatorEmail::Category thresh, ValidatorEmail::Options opts, const ValidatorMessages &m, const QString &dvk) :
         ValidatorRulePrivate(f, m, dvk),
         threshold(thresh),
-        checkDns(dns)
+        options(opts)
     {}
 
     enum EmailPart {
@@ -50,12 +50,12 @@ public:
         ContextQuotedPair   = 6
     };
 
-    static bool checkEmail(const QString &email, bool checkDNS = false, ValidatorEmail::Category threshold = ValidatorEmail::RFC5321, ValidatorEmailDiagnoseStruct *diagnoseStruct = nullptr);
+    static bool checkEmail(const QString &email, ValidatorEmail::Options options = ValidatorEmail::NoOption, ValidatorEmail::Category threshold = ValidatorEmail::RFC5321, ValidatorEmailDiagnoseStruct *diagnoseStruct = nullptr);
 
     ValidatorEmail::Category threshold = ValidatorEmail::RFC5321;
-    bool checkDns = false;
+    ValidatorEmail::Options options = ValidatorEmail::NoOption;
 };
-    
+
 }
 
 #endif //CUTELYSTVALIDATOREMAIL_P_H

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail_p.h
@@ -50,7 +50,7 @@ public:
         ContextQuotedPair   = 6
     };
 
-    static bool checkEmail(const QString &email, ValidatorEmail::Options options = ValidatorEmail::NoOption, ValidatorEmail::Category threshold = ValidatorEmail::RFC5321, ValidatorEmailDiagnoseStruct *diagnoseStruct = nullptr);
+    static bool checkEmail(const QString &address, ValidatorEmail::Options options = ValidatorEmail::NoOption, ValidatorEmail::Category threshold = ValidatorEmail::RFC5321, ValidatorEmailDiagnoseStruct *diagnoseStruct = nullptr);
 
     ValidatorEmail::Category threshold = ValidatorEmail::RFC5321;
     ValidatorEmail::Options options = ValidatorEmail::NoOption;

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -365,77 +365,77 @@ public:
     // ***** Endpoint for ValidatorEmail valid ****
     C_ATTR(emailValid, :Local :AutoArgs)
     void emailValid(Context *c) {
-        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::Valid, false, m_validatorMessages)});
+        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::Valid, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming|Validator::BodyParamsOnly));
     }
 
     // ***** Endpoint for ValidatorEmail valid emails completely valid *****
     C_ATTR(emailDnsWarnValid, :Local :AutoArgs)
     void emailDnsWarnValid(Context *c) {
-        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::Valid, true, m_validatorMessages)});
+        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::Valid, ValidatorEmail::CheckDNS, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming|Validator::BodyParamsOnly));
     }
 
     // ***** Endpoint for ValidatorEmail RFC5321 conformant emails valid *****
     C_ATTR(emailRfc5321Valid, :Local :AutoArgs)
     void emailRfc5321Valid(Context *c) {
-        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::RFC5321, false, m_validatorMessages)});
+        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::RFC5321, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming|Validator::BodyParamsOnly));
     }
 
     // ***** Endpoint for ValidatorEmail RFC5321 conformant emails invalid *****
     C_ATTR(emailRfc5321Invalid, :Local :AutoArgs)
     void emailRfc5321Invalid(Context *c) {
-        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::DNSWarn, false, m_validatorMessages)});
+        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::DNSWarn, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming|Validator::BodyParamsOnly));
     }
 
     // ***** Endpoint for ValidatorEmail CFWS conformant emails valid *****
     C_ATTR(emailCfwsValid, :Local :AutoArgs)
     void emailCfwsValid(Context *c) {
-        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::CFWS, false, m_validatorMessages)});
+        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::CFWS, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming|Validator::BodyParamsOnly));
     }
 
     // ***** Endpoint for ValidatorEmail CFWS conformant emails invalid *****
     C_ATTR(emailCfwsInvalid, :Local :AutoArgs)
     void emailCfwsInvalid(Context *c) {
-        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::RFC5321, false, m_validatorMessages)});
+        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::RFC5321, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming|Validator::BodyParamsOnly));
     }
 
     // ***** Endpoint for ValidatorEmail Deprecated emails valid *****
     C_ATTR(emailDeprecatedValid, :Local :AutoArgs)
     void emailDeprecatedValid(Context *c) {
-        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::Deprecated, false, m_validatorMessages)});
+        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::Deprecated, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming|Validator::BodyParamsOnly));
     }
 
     // ***** Endpoint for ValidatorEmail CFWS conformant emails invalid *****
     C_ATTR(emailDeprecatedInvalid, :Local :AutoArgs)
     void emailDeprecatedInvalid(Context *c) {
-        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::CFWS, false, m_validatorMessages)});
+        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::CFWS, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming|Validator::BodyParamsOnly));
     }
 
     // ***** Endpoint for ValidatorEmail RFC5322 emails valid *****
     C_ATTR(emailRfc5322Valid, :Local :AutoArgs)
     void emailRfc5322Valid(Context *c) {
-        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::RFC5322, false, m_validatorMessages)});
+        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::RFC5322, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming|Validator::BodyParamsOnly));
     }
 
     // ***** Endpoint for ValidatorEmail RFC5322 conformant emails invalid *****
     C_ATTR(emailRfc5322Invalid, :Local :AutoArgs)
     void emailRfc5322Invalid(Context *c) {
-        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::Deprecated, false, m_validatorMessages)});
+        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::Deprecated, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming|Validator::BodyParamsOnly));
     }
 
     // ***** Endpoint for ValidatorEmail with errors *****
     C_ATTR(emailErrors, :Local :AutoArgs)
     void emailErrors(Context *c) {
-        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::RFC5322, false, m_validatorMessages)});
+        Validator v({new ValidatorEmail(QStringLiteral("field"), ValidatorEmail::RFC5322, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming|Validator::BodyParamsOnly));
     }
 


### PR DESCRIPTION
Adds support for Email Address Internationalization (EAI) as defined in RFC 6531 (SMTPUTF8 extension).