### PR TITLE
Fix FastCGI protocol segfault

### DIFF
--- a/wsgi/protocolfastcgi.cpp
+++ b/wsgi/protocolfastcgi.cpp
@@ -558,9 +558,8 @@ qint64 ProtoRequestFastCGI::doWrite(const char *data, qint64 len)
             fr.version = FCGI_VERSION_1;
             fr.type = FCGI_STDOUT;
 
-            quint8 *sid = reinterpret_cast<quint8 *>(stream_id);
-            fr.req1 = sid[1];
-            fr.req0 = sid[0];
+            fr.req0 = static_cast<quint8>(stream_id & 0xff);
+            fr.req1 = static_cast<quint8>((stream_id >> 8) & 0xff);
 
             quint16 padded_len = FCGI_ALIGN(fcgi_len);
             if (padded_len > fcgi_len) {


### PR DESCRIPTION
At least this fixed the FastCGI issue for me, I am not sure if I
implemented it the correct way as I was not diving deep into FCGI
protocol.

GDB output before this fix:

Thread 2.2 "QThread" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffee1d0700 (LWP 7141)]
CWSGI::ProtoRequestFastCGI::doWrite (this=this@entry=0x7fffe800cd40,
    data=0x7fffe8010538 "Status: 302\r\nContent-Type: text/html; charset=utf-8\r\nServer: cutelyst/2.0.0\r\nX-Robots-Tag: none\r\nReferrer-Policy: no-referrer, strict-origin-when-cross-origin\r\nContent-Security-Policy: default-src 'no"..., len=560) at /usr/src/debug/cutelyst-1.99.60git.1520736217.6be7b34/wsgi/protocolfastcgi.cpp:562
562                 fr.req1 = sid[1];