### PR TITLE
Fix StoreHtpasswd::addUser if file doesn't exist

### DIFF
--- a/Cutelyst/Plugins/Authentication/htpasswd.cpp
+++ b/Cutelyst/Plugins/Authentication/htpasswd.cpp
@@ -63,7 +63,7 @@ void StoreHtpasswd::addUser(const ParamsMultiMap &user)
     }
 
     if (!wrote) {
-        QByteArray line = username.toLatin1() + ':' + user.value(QStringLiteral("password")).toLatin1() + '\n';
+        QByteArray line = username.toLatin1() + ':' + user.value(QStringLiteral("password")).toLatin1().replace(':', ',') + '\n';
         tmp.write(line);
     }
 


### PR DESCRIPTION
Previously colons were not replaced.