### PR TITLE
Memcached plugin: add function to check libMemcached version

### DIFF
--- a/Cutelyst/Plugins/Memcached/memcached.cpp
+++ b/Cutelyst/Plugins/Memcached/memcached.cpp
@@ -1401,6 +1401,11 @@ QString Memcached::errorString(Context *c, MemcachedReturnType rt)
     }
 }
 
+QVersionNumber Memcached::libMemcachedVersion()
+{
+    return QVersionNumber::fromString(QLatin1String(memcached_lib_version()));
+}
+
 void MemcachedPrivate::_q_postFork(Application *app)
 {
     mcd = app->plugin<Memcached *>();

--- a/Cutelyst/Plugins/Memcached/memcached.h
+++ b/Cutelyst/Plugins/Memcached/memcached.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Matthias Fehring <kontakt@buschmann23.de>
+ * Copyright (C) 2017-2018 Matthias Fehring <kontakt@buschmann23.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -23,6 +23,7 @@
 #include <Cutelyst/plugin.h>
 
 #include <QDataStream>
+#include <QVersionNumber>
 
 namespace Cutelyst {
 
@@ -949,6 +950,11 @@ public:
      * Converts the return type @a rt into human readable error string.
      */
     static QString errorString(Context *c, MemcachedReturnType rt);
+
+    /*!
+     * Returns the version of the currently used libmemcached.
+     */
+    static QVersionNumber libMemcachedVersion();
 
 protected:
     const QScopedPointer<MemcachedPrivate> d_ptr;

--- a/tests/testmemcached.cpp
+++ b/tests/testmemcached.cpp
@@ -30,6 +30,7 @@ private Q_SLOTS:
     void testController() {
         doTest();
     }
+    void testLibMemcachedVersion();
 
     void cleanupTestCase();
 
@@ -1126,6 +1127,13 @@ void TestMemcached::testController_data()
     for (const std::pair<QString,QByteArray> &test : testVect) {
         QTest::newRow(test.first.toLocal8Bit().constData()) << QStringLiteral("/memcached/test/") + test.first << headers << QByteArray() << test.second;
     }
+}
+
+void TestMemcached::testLibMemcachedVersion()
+{
+    const QVersionNumber version = Memcached::libMemcachedVersion();
+    qDebug() << "libMemcached version:" << version.toString();
+    QVERIFY(!version.isNull());
 }
 
 QTEST_MAIN(TestMemcached)


### PR DESCRIPTION
Memcached::libMemcachedVersion() returns the version of the libmemcached
library in use as QVersionNumber.