### PR TITLE
add refresh() for Authentication

### DIFF
--- a/Cutelyst/Plugins/Authentication/authentication.h
+++ b/Cutelyst/Plugins/Authentication/authentication.h
@@ -120,6 +120,12 @@ public:
      */
     static void logout(Context *c);
 
+    /**
+     * Refreshs the current user. Reloads the user from store.
+     * Use this, if you modified the user object in the store.
+     */
+    static bool refresh(Context *c);
+
 protected:
     virtual bool setup(Application *app) override;
 


### PR DESCRIPTION
Reloads the current user from authentication store to refresh all attributes.

Problem:
If I change the representation of the user in the database, the AuthenticationUser object in the application is not updated, because it is stored in the session. I did not found a way to force a reload, hence my implementation of refresh().

Workarounds:
I did not found a reliable way to reload the user from the store, because reload relies on findUser() which does not support a unique id, but only a ParamsMultiMap, whose interpretation is up to the specific implementation.