### PR TITLE
Haiku doesn't have sys/epoll.h so disable EventLoopEPoll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ install(EXPORT CutelystTargets
 
 add_subdirectory(Cutelyst)
 
-if(UNIX AND NOT APPLE)
+if(UNIX AND NOT (APPLE OR HAIKU))
     set(LINUX TRUE)
 endif()
 


### PR DESCRIPTION
Other than this it seems Cutelyst runs okay on Haiku.

https://www.haiku-os.org/

I've tested only a hello world example:

https://ibb.co/S64YCX4

Can't find a way to disable IPv6 so I found the appropriate address from here:

https://stackoverflow.com/a/46711717