### PR TITLE
Frontend proxy

### DIFF
--- a/wsgi/protocol.h
+++ b/wsgi/protocol.h
@@ -70,6 +70,9 @@ public:
     HeaderConnection headerConnection = HeaderConnectionNotSet;
     char *buffer;
     bool headerHost = false;
+    bool X_Forwarded_For = false;
+    bool X_Forwarded_Host = false;
+    bool X_Forwarded_Proto = false;
 };
 
 class Protocol

--- a/wsgi/protocol.h
+++ b/wsgi/protocol.h
@@ -56,6 +56,9 @@ public:
         buf_size = 0;
         headerConnection = HeaderConnectionNotSet;
         headerHost = false;
+        X_Forwarded_For = false;
+        X_Forwarded_Host = false;
+        X_Forwarded_Proto = false;
     }
 
     virtual void socketDisconnected() {}

--- a/wsgi/protocolhttp.cpp
+++ b/wsgi/protocolhttp.cpp
@@ -335,10 +335,7 @@ void ProtocolHttp::parseHeader(const char *ptr, const char *end, Socket *sock) c
         protoRequest->X_Forwarded_Host = true;
         protoRequest->headerHost = true; // ignore a following Host: header (if any)
     } else if (usingFrontendProxy && !protoRequest->X_Forwarded_Proto && key == QLatin1String("X_FORWARDED_PROTO")) {
-        if (value == QLatin1String("http"))
-            protoRequest->isSecure = false;
-        else if (value == QLatin1String("https"))
-            protoRequest->isSecure = true;
+        protoRequest->isSecure = (value == QLatin1String("https"));
         protoRequest->X_Forwarded_Proto = true;
     }
     protoRequest->headers.pushRawHeader(key, value);

--- a/wsgi/protocolhttp.h
+++ b/wsgi/protocolhttp.h
@@ -150,6 +150,7 @@ protected:
 
     ProtocolWebSocket *m_websocketProto;
     ProtocolHttp2 *m_upgradeH2c;
+    bool usingFrontendProxy;
 };
 
 }

--- a/wsgi/protocolhttp.h
+++ b/wsgi/protocolhttp.h
@@ -105,6 +105,7 @@ public:
         serverAddress = sock->serverAddress;
         remoteAddress = sock->remoteAddress;
         remotePort = sock->remotePort;
+        isSecure = sock->isSecure;
     }
 
     virtual void socketDisconnected() override final;

--- a/wsgi/wsgi.cpp
+++ b/wsgi/wsgi.cpp
@@ -293,6 +293,11 @@ void WSGI::parseCommandLine(const QStringList &arguments)
                                          QCoreApplication::translate("main", "balances new connections to threads using round-robin"));
     parser.addOption(threadBalancerOpt);
 
+    QCommandLineOption frontendProxy(QStringLiteral("using-frontend-proxy"),
+                                     QCoreApplication::translate("main", "Enable frontend (reverse-)proxy support"));
+    parser.addOption(frontendProxy);
+
+
     // Process the actual command line arguments given by the user
     parser.process(arguments);
 
@@ -481,6 +486,10 @@ void WSGI::parseCommandLine(const QStringList &arguments)
         if (!ok || size < 1) {
             parser.showHelp(1);
         }
+    }
+
+    if (parser.isSet(frontendProxy)) {
+        setUsingFrontendProxy(true);
     }
 
     setHttpSocket(httpSocket() + parser.values(httpSocketOpt));

--- a/wsgi/wsgi.cpp
+++ b/wsgi/wsgi.cpp
@@ -1339,6 +1339,19 @@ bool WSGI::lazy() const
     return d->lazy;
 }
 
+void WSGI::setUsingFrontendProxy(bool enable)
+{
+    Q_D(WSGI);
+    d->usingFrontendProxy = enable;
+    Q_EMIT changed();
+}
+
+bool WSGI::usingFrontendProxy() const
+{
+    Q_D(const WSGI);
+    return d->usingFrontendProxy;
+}
+
 void WSGIPrivate::setupApplication()
 {
     Cutelyst::Application *localApp = app;

--- a/wsgi/wsgi.h
+++ b/wsgi/wsgi.h
@@ -408,6 +408,16 @@ public:
     void setLazy(bool enable);
     bool lazy() const;
 
+    /**
+     * Defines if a reverse proxy operates in front of this application server.
+     * If enabled, parses the http headers X-Forwarded-For, X-Forwarded-Host and X-Forwarded-Proto
+     * and uses this info to update Cutelyst::EngineRequest
+     * @accessors usingFrontendProxy(), setUsingFrontendProxy()
+     */
+    Q_PROPERTY(bool using_frontend_proxy READ usingFrontendProxy WRITE setUsingFrontendProxy NOTIFY changed)
+    void setUsingFrontendProxy(bool enable);
+    bool usingFrontendProxy() const;
+
 Q_SIGNALS:
     /**
      * It is emitted once the server is ready.

--- a/wsgi/wsgi_p.h
+++ b/wsgi/wsgi_p.h
@@ -113,6 +113,7 @@ public:
     bool userEventLoop = false;
     bool upgradeH2c = false;
     bool httpsH2 = false;
+    bool usingFrontendProxy = false;
 
 Q_SIGNALS:
     void postForked(int workerId);


### PR DESCRIPTION
see #170 

This patch implements parsing of three http headers: X-Forwarded-For, X-Forwarded-Host and X-Forwarded-Proto, but only if the property using_frontend_proxy is set (via ini-file or command line).

This supports the use case: reverse proxy (nginx) with SSL termination --> cutelyst http app server