### PR TITLE
Cppcheck 1

### DIFF
--- a/Cutelyst/Actions/REST/actionrest.cpp
+++ b/Cutelyst/Actions/REST/actionrest.cpp
@@ -59,15 +59,8 @@ using namespace Cutelyst;
  * with the list of implemented request methods. If you do not provide an _HEAD either, we will auto dispatch to the _GET one
  * in case it exists.
  */
-ActionREST::ActionREST(QObject *parent) : Action(parent)
-    , d_ptr(new ActionRESTPrivate)
+ActionREST::ActionREST(QObject *parent) : Action(new ActionRESTPrivate(this), parent)
 {
-    d_ptr->q_ptr = this;
-}
-
-ActionREST::~ActionREST()
-{
-    delete d_ptr;
 }
 
 bool ActionREST::doExecute(Context *c)
@@ -79,6 +72,10 @@ bool ActionREST::doExecute(Context *c)
     }
 
     return d->dispatchRestMethod(c, c->request()->method());
+}
+
+ActionRESTPrivate::ActionRESTPrivate(ActionREST* q) : q_ptr(q)
+{
 }
 
 bool ActionRESTPrivate::dispatchRestMethod(Context *c, const QString &httpMethod) const

--- a/Cutelyst/Actions/REST/actionrest.h
+++ b/Cutelyst/Actions/REST/actionrest.h
@@ -34,11 +34,8 @@ public:
      * Constructs a new ActionREST object with the given parent.
      */
     explicit ActionREST(QObject *parent = nullptr);
-    virtual ~ActionREST() override;
 
 protected:
-    ActionRESTPrivate *d_ptr;
-
     bool doExecute(Context *c) override;
 };
 

--- a/Cutelyst/Actions/REST/actionrest.h
+++ b/Cutelyst/Actions/REST/actionrest.h
@@ -48,7 +48,7 @@ class ActionRESTFactory : public QObject, public ComponentFactory
     Q_PLUGIN_METADATA(IID "org.cutelyst.ComponentFactory" FILE "metadata.json")
     Q_INTERFACES(Cutelyst::ComponentFactory)
 public:
-    Component *createComponent(QObject *parent) { return new ActionREST(parent); }
+    virtual Component *createComponent(QObject *parent) override { return new ActionREST(parent); }
 };
 
 }

--- a/Cutelyst/Actions/REST/actionrest_p.h
+++ b/Cutelyst/Actions/REST/actionrest_p.h
@@ -19,13 +19,15 @@
 #define ACTIONREST_P_H
 
 #include "actionrest.h"
+#include "action_p.h"
 
 namespace Cutelyst {
 
-class ActionRESTPrivate
+class ActionRESTPrivate : ActionPrivate
 {
     Q_DECLARE_PUBLIC(ActionREST)
 public:
+    explicit ActionRESTPrivate(ActionREST* q);
     bool dispatchRestMethod(Context *c, const QString &restMethod) const;
     bool returnOptions(Context *c, const QString &methodName) const;
     bool returnNotImplemented(Context *c, const QString &methodName) const;

--- a/Cutelyst/Actions/RenderView/renderview.cpp
+++ b/Cutelyst/Actions/RenderView/renderview.cpp
@@ -62,15 +62,9 @@ using namespace Cutelyst;
  * ...
  * \endcode
  */
-RenderView::RenderView(QObject *parent) : Action(parent)
-    , d_ptr(new RenderViewPrivate)
+RenderView::RenderView(QObject *parent) : Action(new RenderViewPrivate, parent)
 {
     setObjectName(QString::fromLatin1(metaObject()->className()) + QLatin1String("->execute"));
-}
-
-RenderView::~RenderView()
-{
-    delete d_ptr;
 }
 
 bool RenderView::init(Cutelyst::Application *application, const QVariantHash &args)

--- a/Cutelyst/Actions/RenderView/renderview.h
+++ b/Cutelyst/Actions/RenderView/renderview.h
@@ -34,7 +34,6 @@ public:
      * Constructs a RenderView object with the given \arg parent.
      */
     explicit RenderView(QObject *parent = nullptr);
-    virtual ~RenderView() override;
 
     /**
      * Reimplemented from Plugin::init()
@@ -43,8 +42,6 @@ public:
 
 protected:
     virtual bool doExecute(Cutelyst::Context *c) override;
-
-    RenderViewPrivate *d_ptr;
 };
 
 class RenderViewFactory : public QObject, public ComponentFactory

--- a/Cutelyst/Actions/RenderView/renderview.h
+++ b/Cutelyst/Actions/RenderView/renderview.h
@@ -53,7 +53,7 @@ class RenderViewFactory : public QObject, public ComponentFactory
     Q_PLUGIN_METADATA(IID "org.cutelyst.ComponentFactory" FILE "metadata.json")
     Q_INTERFACES(Cutelyst::ComponentFactory)
 public:
-    Component *createComponent(QObject *parent) { return new RenderView(parent); }
+    virtual Component *createComponent(QObject *parent) override { return new RenderView(parent); }
 };
 
 }

--- a/Cutelyst/Actions/RenderView/renderview_p.h
+++ b/Cutelyst/Actions/RenderView/renderview_p.h
@@ -19,12 +19,13 @@
 #define RENDERVIEW_P_H
 
 #include "renderview.h"
+#include "action_p.h"
 
 #include <Cutelyst/view.h>
 
 namespace Cutelyst {
 
-class RenderViewPrivate
+class RenderViewPrivate : public ActionPrivate
 {
 public:
     View *view;

--- a/Cutelyst/Actions/RoleACL/roleacl.cpp
+++ b/Cutelyst/Actions/RoleACL/roleacl.cpp
@@ -123,14 +123,8 @@ using namespace Cutelyst;
  *
  * Any user with either the 'admin' or 'user' role may execute this action.
  */
-RoleACL::RoleACL(QObject *parent) : Component(parent)
-    , d_ptr(new RoleACLPrivate)
+RoleACL::RoleACL(QObject *parent) : Component(new RoleACLPrivate, parent)
 {
-}
-
-RoleACL::~RoleACL()
-{
-    delete d_ptr;
 }
 
 Component::Modifiers RoleACL::modifiers() const

--- a/Cutelyst/Actions/RoleACL/roleacl.h
+++ b/Cutelyst/Actions/RoleACL/roleacl.h
@@ -37,7 +37,6 @@ public:
      * Constructs a new role ACL object with the given parent.
      */
     explicit RoleACL(QObject *parent = nullptr);
-    virtual ~RoleACL() override;
 
     /**
      * Reimplemented from Component::modifiers().
@@ -64,8 +63,6 @@ protected:
      * Reimplemented from Component::dispatcherReady().
      */
     virtual bool dispatcherReady(const Dispatcher *dispatcher, Controller *controller) override;
-
-    RoleACLPrivate *d_ptr;
 };
 
 class RoleACLFactory : public QObject, public ComponentFactory

--- a/Cutelyst/Actions/RoleACL/roleacl.h
+++ b/Cutelyst/Actions/RoleACL/roleacl.h
@@ -74,7 +74,7 @@ class RoleACLFactory : public QObject, public ComponentFactory
     Q_PLUGIN_METADATA(IID "org.cutelyst.ComponentFactory" FILE "metadata.json")
     Q_INTERFACES(Cutelyst::ComponentFactory)
 public:
-    Component *createComponent(QObject *parent) { return new RoleACL(parent); }
+    virtual Component *createComponent(QObject *parent) override { return new RoleACL(parent); }
 };
 
 

--- a/Cutelyst/Actions/RoleACL/roleacl_p.h
+++ b/Cutelyst/Actions/RoleACL/roleacl_p.h
@@ -19,10 +19,11 @@
 #define ROLEACL_P_H
 
 #include "roleacl.h"
+#include "component_p.h"
 
 namespace Cutelyst {
 
-class RoleACLPrivate
+class RoleACLPrivate : public ComponentPrivate
 {
 public:
     QStringList requiresRole;

--- a/Cutelyst/Plugins/Session/session_p.h
+++ b/Cutelyst/Plugins/Session/session_p.h
@@ -57,14 +57,14 @@ public:
 
     Session *q_ptr;
 
-    qint64 sessionExpires;
-    qint64 expiryThreshold;
+    qint64 sessionExpires = 7200;
+    qint64 expiryThreshold = 0;
     SessionStore *store = nullptr;
     QString sessionName;
     bool cookieHttpOnly = true;
     bool cookieSecure = false;
-    bool verifyAddress;
-    bool verifyUserAgent;
+    bool verifyAddress = false;
+    bool verifyUserAgent = false;
 };
 
 }

--- a/Cutelyst/Plugins/Session/sessionstorefile.cpp
+++ b/Cutelyst/Plugins/Session/sessionstorefile.cpp
@@ -108,7 +108,7 @@ QVariantHash loadSessionData(Context *c, const QString &sid)
     }
 
     // Commit data when Context gets deleted
-    QObject::connect(c->app(), &Application::afterDispatch, c, [=] () {
+    QObject::connect(c->app(), &Application::afterDispatch, c, [c,file] {
         if (!c->stash(SESSION_STORE_FILE_SAVE).toBool()) {
             return;
         }

--- a/Cutelyst/Plugins/Utils/Validator/validatorrule_p.h
+++ b/Cutelyst/Plugins/Utils/Validator/validatorrule_p.h
@@ -202,7 +202,7 @@ public:
         return var;
     }
 
-    QTimeZone extractTimeZone(Context *c, const ParamsMultiMap &params, const QString &field) const
+    static QTimeZone extractTimeZone(Context *c, const ParamsMultiMap &params, const QString &field)
     {
         QTimeZone tz;
 
@@ -225,7 +225,7 @@ public:
         return tz;
     }
 
-    qlonglong extractLongLong(Context *c, const ParamsMultiMap &params, const QVariant &value, bool *ok) const
+    static qlonglong extractLongLong(Context *c, const ParamsMultiMap &params, const QVariant &value, bool *ok)
     {
         qlonglong val = 0;
 
@@ -253,7 +253,7 @@ public:
         return val;
     }
 
-    qulonglong extractULongLong(Context *c, const ParamsMultiMap &params, const QVariant &value, bool *ok) const
+    static qulonglong extractULongLong(Context *c, const ParamsMultiMap &params, const QVariant &value, bool *ok)
     {
         qulonglong val = 0;
 
@@ -281,7 +281,7 @@ public:
         return val;
     }
 
-    double extractDouble(Context *c, const ParamsMultiMap &params, const QVariant &value, bool *ok) const
+    static double extractDouble(Context *c, const ParamsMultiMap &params, const QVariant &value, bool *ok)
     {
         double val = 0.0;
 
@@ -309,7 +309,7 @@ public:
         return val;
     }
 
-    int extractInt(Context *c, const ParamsMultiMap &params, const QVariant &value, bool *ok) const
+    static int extractInt(Context *c, const ParamsMultiMap &params, const QVariant &value, bool *ok)
     {
         int val = 0;
 
@@ -337,7 +337,7 @@ public:
         return val;
     }
 
-    QVariant valueToNumber(Context *c, const QString &value, QMetaType::Type type) const
+    static QVariant valueToNumber(Context *c, const QString &value, QMetaType::Type type)
     {
         QVariant var;
 

--- a/Cutelyst/action.cpp
+++ b/Cutelyst/action.cpp
@@ -22,14 +22,16 @@
 
 using namespace Cutelyst;
 
-Action::Action(QObject *parent) : Component(parent)
-    , d_ptr(new ActionPrivate)
+Action::Action(QObject *parent) : Component(new ActionPrivate, parent)
+{
+}
+
+Action::Action(ActionPrivate *ptr, QObject *parent) : Component(ptr, parent)
 {
 }
 
 Action::~Action()
 {
-    delete d_ptr;
 }
 
 Component::Modifiers Action::modifiers() const

--- a/Cutelyst/action.h
+++ b/Cutelyst/action.h
@@ -130,9 +130,13 @@ public:
     virtual qint8 numberOfCaptures() const;
 
 protected:
-    ActionPrivate *d_ptr;
     friend class Dispatcher;
     friend class ControllerPrivate;
+
+    /*!
+     * A derived class using pimpl should call this constructor, to reduce the number of memory allocations
+     */
+    explicit Action(ActionPrivate *ptr, QObject *parent = nullptr);
 
     /**
      * Execute this action against

--- a/Cutelyst/action_p.h
+++ b/Cutelyst/action_p.h
@@ -19,10 +19,11 @@
 #define CUTELYST_ACTION_P_H
 
 #include "action.h"
+#include "component_p.h"
 
 namespace Cutelyst {
 
-class ActionPrivate
+class ActionPrivate : public ComponentPrivate
 {
 public:
     QString ns;

--- a/Cutelyst/actionchain.cpp
+++ b/Cutelyst/actionchain.cpp
@@ -22,8 +22,7 @@
 
 using namespace Cutelyst;
 
-ActionChain::ActionChain(const ActionList &chain, QObject *parent) : Action(parent)
-  , d_ptr(new ActionChainPrivate)
+ActionChain::ActionChain(const ActionList &chain, QObject *parent) : Action(new ActionChainPrivate, parent)
 {
     Q_D(ActionChain);
     d->chain = chain;
@@ -45,11 +44,6 @@ ActionChain::ActionChain(const ActionList &chain, QObject *parent) : Action(pare
             d->captures += action->numberOfCaptures();
         }
     }
-}
-
-ActionChain::~ActionChain()
-{
-    delete d_ptr;
 }
 
 ActionList ActionChain::chain() const

--- a/Cutelyst/actionchain.h
+++ b/Cutelyst/actionchain.h
@@ -42,7 +42,6 @@ public:
      * Constructs a ActionChain object with the folloing \p chain and the given \p parent.
      */
     explicit ActionChain(const ActionList &chain, QObject *parent = nullptr);
-    virtual ~ActionChain() override;
 
     /**
      * The action chain
@@ -57,8 +56,6 @@ public:
 
 protected:
     virtual bool doExecute(Context *c) override;
-
-    ActionChainPrivate *d_ptr;
 };
 
 }

--- a/Cutelyst/actionchain_p.h
+++ b/Cutelyst/actionchain_p.h
@@ -19,10 +19,11 @@
 #define ACTIONCHAIN_P_H
 
 #include "actionchain.h"
+#include "action_p.h"
 
 namespace Cutelyst {
 
-class ActionChainPrivate
+class ActionChainPrivate : public ActionPrivate
 {
 public:
     ActionList chain;

--- a/Cutelyst/component.cpp
+++ b/Cutelyst/component.cpp
@@ -26,6 +26,11 @@ Component::Component(QObject *parent) : QObject(parent)
 {
 }
 
+Component::Component(ComponentPrivate* d, QObject *parent) : QObject(parent)
+  , d_ptr(d)
+{
+}
+
 Component::~Component()
 {
     delete d_ptr;

--- a/Cutelyst/component.h
+++ b/Cutelyst/component.h
@@ -99,6 +99,11 @@ public:
     bool execute(Context *c);
 
 protected:
+    /*!
+     * A derived class using pimpl should call this constructor, to reduce the number of memory allocations
+     */
+    explicit Component(ComponentPrivate *d, QObject *parent = nullptr);
+
     /**
      * Reimplement this if you want to do processing before doExecute
      */
@@ -135,7 +140,7 @@ protected:
 
 protected:
     friend class Controller;
-    ComponentPrivate *d_ptr;
+    ComponentPrivate *d_ptr; //!< we cannot inherit from QObjectPrivate and therefore need our own d_ptr
 };
 
 }

--- a/Cutelyst/context_p.h
+++ b/Cutelyst/context_p.h
@@ -56,10 +56,10 @@ public:
     Dispatcher *dispatcher;
 
     // Pointer to Engine data
-    EngineRequest *engineRequest;
+    EngineRequest *engineRequest = nullptr;
 
-    Request *request;
-    Response *response;
+    Request *request = nullptr;
+    Response *response = nullptr;
     Action *action = nullptr;
     View *view = nullptr;
     Stats *stats = nullptr;
@@ -74,12 +74,12 @@ class DummyRequest : public QObject, public EngineRequest
 public:
     DummyRequest(QObject *parent) : QObject(parent) {}
 
-    virtual qint64 doWrite(const char *, qint64) { return -1; }
+    virtual qint64 doWrite(const char *, qint64) override { return -1; }
 
     /*!
      * Reimplement this to write the headers back to the client
      */
-    virtual bool writeHeaders(quint16 , const Headers &) { return false; }
+    virtual bool writeHeaders(quint16 , const Headers &) override { return false; }
 };
 
 }

--- a/Cutelyst/controller.cpp
+++ b/Cutelyst/controller.cpp
@@ -279,8 +279,8 @@ void ControllerPrivate::registerActionMethods(const QMetaObject *meta, Controlle
 
             // Build up the list of attributes for the class info
             QByteArray attributeArray;
-            for (int i = meta->classInfoCount() - 1; i >= 0; --i) {
-                QMetaClassInfo classInfo = meta->classInfo(i);
+            for (int i2 = meta->classInfoCount() - 1; i2 >= 0; --i2) {
+                QMetaClassInfo classInfo = meta->classInfo(i2);
                 if (name == classInfo.name()) {
                     attributeArray.append(classInfo.value());
                 }
@@ -432,8 +432,8 @@ QMap<QString, QString> ControllerPrivate::parseAttributes(const QMetaMethod &met
             // If the signature is not QStringList we count them
             if (!(method.parameterCount() == 2 && method.parameterType(1) == QMetaType::QStringList)) {
                 int parameterCount = 0;
-                for (int i = 1; i < method.parameterCount(); ++i) {
-                    int typeId = method.parameterType(i);
+                for (int i2 = 1; i2 < method.parameterCount(); ++i2) {
+                    int typeId = method.parameterType(i2);
                     if (typeId == QMetaType::QString) {
                         ++parameterCount;
                     }

--- a/Cutelyst/controller_p.h
+++ b/Cutelyst/controller_p.h
@@ -46,9 +46,9 @@ public:
     QString pathPrefix;
     ActionList beginAutoList;
     Action *end = nullptr;
-    Application *application;
+    Application *application = nullptr;
     Controller *q_ptr;
-    Dispatcher *dispatcher;
+    Dispatcher *dispatcher = nullptr;
     QMap<QString, Action *> actions;
     ActionList actionList;
     bool parsedActions = false;

--- a/Cutelyst/dispatchtypechained.cpp
+++ b/Cutelyst/dispatchtypechained.cpp
@@ -99,9 +99,9 @@ QByteArray DispatchTypeChained::list() const
         for (Action *p : parents) {
             QString name = QLatin1Char('/') + p->reverse();
 
-            QString extra = DispatchTypeChainedPrivate::listExtraHttpMethods(p);
-            if (!extra.isEmpty()) {
-                name.prepend(extra + QLatin1Char(' '));
+            QString extraHttpMethod = DispatchTypeChainedPrivate::listExtraHttpMethods(p);
+            if (!extraHttpMethod.isEmpty()) {
+                name.prepend(extraHttpMethod + QLatin1Char(' '));
             }
 
             const auto attributes = p->attributes();
@@ -280,8 +280,8 @@ QString DispatchTypeChained::uriForAction(Action *action, const QStringList &cap
     QStringList parts;
     Action *curr = action;
     while (curr) {
-        const QMap<QString, QString> attributes = curr->attributes();
-        if (attributes.contains(QStringLiteral("CaptureArgs"))) {
+        const QMap<QString, QString> curr_attributes = curr->attributes();
+        if (curr_attributes.contains(QStringLiteral("CaptureArgs"))) {
             if (localCaptures.size() < curr->numberOfCaptures()) {
                 // Not enough captures
                 qCWarning(CUTELYST_DISPATCHER_CHAINED) << "uriForAction: not enough captures" << curr->numberOfCaptures() << captures.size();
@@ -292,12 +292,12 @@ QString DispatchTypeChained::uriForAction(Action *action, const QStringList &cap
             localCaptures = localCaptures.mid(0, localCaptures.size() - curr->numberOfCaptures());
         }
 
-        const QString pp = attributes.value(QStringLiteral("PathPart"));
+        const QString pp = curr_attributes.value(QStringLiteral("PathPart"));
         if (!pp.isEmpty()) {
             parts.prepend(pp);
         }
 
-        parent = attributes.value(QStringLiteral("Chained"));
+        parent = curr_attributes.value(QStringLiteral("Chained"));
         curr = d->actions.value(parent);
     }
 

--- a/Cutelyst/enginerequest.h
+++ b/Cutelyst/enginerequest.h
@@ -161,7 +161,7 @@ public:
     Headers headers;
 
     /*! The timestamp of the start of request, TODO remove in Cutelyst 3 */
-    quint64 startOfRequest;
+    quint64 startOfRequest = 0;
 
     /*! Connection status */
     Status status = InitialState;

--- a/Cutelyst/headers.cpp
+++ b/Cutelyst/headers.cpp
@@ -34,9 +34,8 @@ Headers::Headers()
 
 }
 
-Headers::Headers(const Headers &other)
+Headers::Headers(const Headers &other) : m_data(other.m_data)
 {
-    m_data = other.m_data;
 }
 
 QString Headers::contentDisposition() const

--- a/EventLoopEPoll/eventdispatcher_epoll_p.h
+++ b/EventLoopEPoll/eventdispatcher_epoll_p.h
@@ -46,7 +46,7 @@ class EventFdInfo : public EpollAbastractEvent
 public:
     EventFdInfo(int _fd, EventDispatcherEPollPrivate *prv) : EpollAbastractEvent(_fd), epPriv(prv) {}
 
-    virtual void process(quint32 events);
+    virtual void process(quint32 events) override;
 
     EventDispatcherEPollPrivate *epPriv;
 };
@@ -56,12 +56,12 @@ class SocketNotifierInfo : public EpollAbastractEvent
 public:
     SocketNotifierInfo(int _fd) : EpollAbastractEvent(_fd) { }
 
-    virtual void process(quint32 events);
+    virtual void process(quint32 events) override;
 
     QSocketNotifier *r = nullptr;
     QSocketNotifier *w = nullptr;
     QSocketNotifier *x = nullptr;
-    quint32 events;
+    quint32 events = 0;
 };
 
 class ZeroTimer : public EpollAbastractEvent
@@ -69,7 +69,7 @@ class ZeroTimer : public EpollAbastractEvent
 public:
     ZeroTimer(int _timerId, QObject *obj) : object(obj), timerId(_timerId) {}
 
-    virtual void process(quint32 events);
+    virtual void process(quint32 events) override;
 
     QObject *object;
     int timerId;
@@ -82,7 +82,7 @@ public:
     TimerInfo(int fd, int _timerId, int _interval, QObject *obj)
         : EpollAbastractEvent(fd), object(obj), timerId(_timerId), interval(_interval) {}
 
-    virtual void process(quint32 events);
+    virtual void process(quint32 events) override;
 
     QObject *object;
     struct timeval when;

--- a/wsgi/hpack.cpp
+++ b/wsgi/hpack.cpp
@@ -296,7 +296,7 @@ int HPack::decode(unsigned char *it, unsigned char *itEnd, H2Stream *stream)
         if (*it & 0x80){
             it = decodeUInt16(it, itEnd, intValue, INT_MASK(7));
 //            qDebug() << "6.1 Indexed Header Field Representation" << *it << intValue << it;
-            if (!it || intValue <= 0) {
+            if (!it || intValue == 0) {
                 return ErrorCompressionError;
             }
 

--- a/wsgi/localserver.h
+++ b/wsgi/localserver.h
@@ -55,7 +55,7 @@ private:
     void socketNotifierActivated();
 #endif
 
-    QSocketNotifier *m_socketNotifier;
+    QSocketNotifier *m_socketNotifier = nullptr;
     CWsgiEngine *m_engine = nullptr;
     WSGI *m_wsgi;
 

--- a/wsgi/protocol.h
+++ b/wsgi/protocol.h
@@ -64,7 +64,7 @@ public:
     virtual void socketDisconnected() {}
     virtual void setupNewConnection(Socket *sock) = 0;
 
-    qint64 contentLength;
+    qint64 contentLength = 0;
     Socket *sock;//temporary
     QIODevice *io;
     ProtocolData *upgradedFrom = nullptr;

--- a/wsgi/protocolfastcgi.cpp
+++ b/wsgi/protocolfastcgi.cpp
@@ -322,13 +322,12 @@ bool ProtocolFastCGI::writeBody(ProtoRequestFastCGI *request, char *buf, qint64 
 
 qint64 ProtocolFastCGI::readBody(Socket *sock, QIODevice *io, qint64 bytesAvailable) const
 {
-    qint64 len;
     auto request = static_cast<ProtoRequestFastCGI *>(sock->protoData);
     QIODevice *body = request->body;
     int &pad = request->buf_size;
     while (bytesAvailable && request->pktsize + pad) {
         // We need to read and ignore ending PAD data
-        len = io->read(m_postBuffer, qMin(m_postBufferSize, static_cast<qint64>(request->pktsize + pad)));
+        qint64 len = io->read(m_postBuffer, qMin(m_postBufferSize, static_cast<qint64>(request->pktsize + pad)));
         if (len == -1) {
             sock->connectionClose();
             return -1;

--- a/wsgi/protocolhttp.h
+++ b/wsgi/protocolhttp.h
@@ -115,15 +115,15 @@ public:
 
     QByteArray websocket_message;
     QByteArray websocket_payload;
-    quint64 websocket_payload_size;
-    quint32 websocket_need;
-    quint32 websocket_mask;
+    quint64 websocket_payload_size = 0;
+    quint32 websocket_need = 0;
+    quint32 websocket_mask = 0;
     int last = 0;
     int beginLine = 0;
     int websocket_start_of_frame = 0;
     int websocket_phase = 0;
     quint8 websocket_continue_opcode = 0;
-    quint8 websocket_finn_opcode;
+    quint8 websocket_finn_opcode = 0;
     bool websocketUpgraded = false;
 
 protected:

--- a/wsgi/socket.h
+++ b/wsgi/socket.h
@@ -63,9 +63,9 @@ public:
 
     QString serverAddress;
     QHostAddress remoteAddress;
-    quint16 remotePort;
+    quint16 remotePort = 0;
     Cutelyst::Engine *engine;
-    Protocol *proto;
+    Protocol *proto = nullptr;
     ProtocolData *protoData = nullptr;
     qint8 processing = 0;
     bool isSecure;

--- a/wsgi/tcpserver.cpp
+++ b/wsgi/tcpserver.cpp
@@ -26,10 +26,10 @@
 using namespace CWSGI;
 
 TcpServer::TcpServer(const QString &serverAddress, Protocol *protocol, WSGI *wsgi, QObject *parent) : QTcpServer(parent)
+  , m_serverAddress(serverAddress)
   , m_wsgi(wsgi)
   , m_protocol(protocol)
 {
-    m_serverAddress = serverAddress;
     m_engine = qobject_cast<CWsgiEngine*>(parent);
 
     if (m_wsgi->tcpNodelay()) {

--- a/wsgi/tcpserverbalancer.h
+++ b/wsgi/tcpserverbalancer.h
@@ -47,11 +47,11 @@ public:
 
 private:
     QHostAddress m_address;
-    quint16 m_port;
+    quint16 m_port = 0;
     QString m_serverName;
     std::vector<TcpServer *> m_servers;
     WSGI *m_wsgi;
-    Protocol *m_protocol;
+    Protocol *m_protocol = nullptr;
     QSslConfiguration *m_sslConfiguration = nullptr;
     int m_currentServer = 0;
     bool m_balancer = false;

--- a/wsgi/wsgi_p.h
+++ b/wsgi/wsgi_p.h
@@ -63,7 +63,7 @@ public:
     std::vector<QObject *> servers;
     std::vector<CWsgiEngine *> engines;
     Cutelyst::Application *app = nullptr;
-    CWsgiEngine *engine;
+    CWsgiEngine *engine = nullptr;
 
     QVariantMap opt;
     QVariantMap config;


### PR DESCRIPTION
I fixed several warnings from cppcheck, including some uninitialized members during construction.

While doing this, I learned about the intense use of d_ptr (pimpl). Nearly every use of d_ptr required a memory allocation. I refactored this to be more like the Qt way of doing pimpl. That reduces the number of allocations.
If we now decide to depend upon the private header qobject_p.h (debian package qtbase5-private-dev) this can be decreased even further.
Example: ActionREST required four memory allocations due to d_ptr. Now that is reduced to two allocations (QObjectPrivate and ActionRESTPrivate). Using object_p.h we can reduce it to only one memory allocation.
Tell me what do you think.

ps: if this PR is going to be accepted, I can squash the individual commits into one or two.