### PR TITLE
Set isSecure on CTor

### DIFF
--- a/Cutelyst/view.cpp
+++ b/Cutelyst/view.cpp
@@ -57,8 +57,16 @@ bool View::doExecute(Context *c)
             qCCritical(CUTELYST_VIEW) << error;
         }
     }
-    response->setBody(output);
-
+    auto acceptEncoding = c->req()->header(QStringLiteral("Accept-Encoding"));
+    if (output.count() > 1024 &&  acceptEncoding.contains(QLatin1String("deflate"), Qt::CaseInsensitive)) {
+        QByteArray compressedData = qCompress(output, 9);
+        compressedData.remove(0, 6);
+        compressedData.chop(4);
+        response->headers().setContentEncoding(QStringLiteral("deflate"));
+        response->setBody(compressedData);
+    } else {
+        response->setBody(output);
+    }
     return !c->error();
 }
 

--- a/wsgi/protocolhttp.cpp
+++ b/wsgi/protocolhttp.cpp
@@ -337,7 +337,7 @@ void ProtocolHttp::parseHeader(const char *ptr, const char *end, Socket *sock) c
 
 ProtoRequestHttp::ProtoRequestHttp(Socket *sock, int bufferSize) : ProtocolData(sock, bufferSize)
 {
-
+    isSecure = sock->isSecure;
 }
 
 ProtoRequestHttp::~ProtoRequestHttp()


### PR DESCRIPTION
In https mode, when redirect, Request::uri doesn't  return a https scheme url. And the scheme is controlled by d->engineRequest->isSecure. Howerver, ProtoRequestHttp doesn't set isSecure to match Socket's. The change sets isSecure when ProtoRequestHttp is constructed. I'm new to this project, don't know if there is any side-effect.