### PR TITLE
Set isSecure on ProtoRequestHttp CTor

### DIFF
--- a/wsgi/protocolhttp.cpp
+++ b/wsgi/protocolhttp.cpp
@@ -337,7 +337,7 @@ void ProtocolHttp::parseHeader(const char *ptr, const char *end, Socket *sock) c
 
 ProtoRequestHttp::ProtoRequestHttp(Socket *sock, int bufferSize) : ProtocolData(sock, bufferSize)
 {
-
+    isSecure = sock->isSecure;
 }
 
 ProtoRequestHttp::~ProtoRequestHttp()


### PR DESCRIPTION
In https mode, when redirect, Request::uri doesn't return a https scheme url. And the scheme is controlled by d->engineRequest->isSecure. Howerver, ProtoRequestHttp doesn't set isSecure to match Socket's. The change sets isSecure when ProtoRequestHttp is constructed. I'm new to this project, don't know if there is any side-effect.