### PR TITLE
Deflate view output if it's larger than minimal size  and accepted by client

### DIFF
--- a/Cutelyst/view.cpp
+++ b/Cutelyst/view.cpp
@@ -57,8 +57,16 @@ bool View::doExecute(Context *c)
             qCCritical(CUTELYST_VIEW) << error;
         }
     }
-    response->setBody(output);
-
+    auto acceptEncoding = c->req()->header(QStringLiteral("Accept-Encoding"));
+    if (output.count() > 1024 &&  acceptEncoding.contains(QLatin1String("deflate"), Qt::CaseInsensitive)) {
+        QByteArray compressedData = qCompress(output, 9);
+        compressedData.remove(0, 6);
+        compressedData.chop(4);
+        response->headers().setContentEncoding(QStringLiteral("deflate"));
+        response->setBody(compressedData);
+    } else {
+        response->setBody(output);
+    }
     return !c->error();
 }
 

--- a/Cutelyst/view.h
+++ b/Cutelyst/view.h
@@ -26,6 +26,7 @@
 namespace Cutelyst {
 
 class Context;
+class ViewPrivate;
 
 /*! \class View view.h Cutelyst/View
  * @brief %Cutelyst %View abstract view component
@@ -33,6 +34,7 @@ class Context;
 class CUTELYST_LIBRARY View : public Component
 {
     Q_OBJECT
+    Q_DECLARE_PRIVATE(View)
 public:
     /**
      * The base implementation for a View class, a name
@@ -54,12 +56,20 @@ public:
      */
     virtual QByteArray render(Context *c) const = 0;
 
+    /**
+     * Set deflate minimal size to @p minSize.
+     * When @p minSize is not negative and view render output is larger than @p minSize,
+     * if ACCEPT_ENCODING contains 'deflate', then deflate view render output.
+     * To disable Deflate, set @p minSize to a negative integer.
+     */
+    void setMinimalSizeToDeflate(qint32 minSize = -1);
 private:
     /**
      * This is used by Component execute() when
      * using an ActionView
      */
     bool doExecute(Context *c) final;
+    ViewPrivate* d_ptr;
 };
 
 }


### PR DESCRIPTION
There is StaticCompressed plugin that does good job for css and js files. But the generated view output is in plain text. This commit allows view output to be compressed if it's larger than 1KB(hmm, I don't know how many is best, let me know if you have suggestions). 