### PR TITLE
Fix ProtoRequestHttp2, now passes h2spec tests

### DIFF
--- a/wsgi/protocolhttp2.cpp
+++ b/wsgi/protocolhttp2.cpp
@@ -844,7 +844,7 @@ qint64 H2Stream::doWrite(const char *data, qint64 len)
 //        qCDebug(CWSGI_H2) << "H2Stream::doWrite" << len << streamId << "availableWindowSize" << availableWindowSize
 //                          << "remaining data" << remainingData
 //                          << "stream" << this << protoRequest;
-
+        availableWindowSize = qMin(availableWindowSize, (qint64) protoRequest->settingsMaxFrameSize);
         if (availableWindowSize == 0) {
             if (!loop) {
                 loop = new QEventLoop;

--- a/wsgi/protocolhttp2.cpp
+++ b/wsgi/protocolhttp2.cpp
@@ -102,7 +102,8 @@ enum Settings {
     SETTINGS_MAX_CONCURRENT_STREAMS = 0x3,
     SETTINGS_INITIAL_WINDOW_SIZE = 0x4,
     SETTINGS_MAX_FRAME_SIZE = 0x5,
-    SETTINGS_MAX_HEADER_LIST_SIZE = 0x6
+    SETTINGS_MAX_HEADER_LIST_SIZE = 0x6,
+    SETTINGS_ENABLE_CONNECT_PROTOCOL = 0x8,
 };
 
 #define PREFACE_SIZE 24
@@ -156,6 +157,7 @@ void ProtocolHttp2::parse(Socket *sock, QIODevice *io) const
                             request->connState = ProtoRequestHttp2::H2Frames;
 
                             sendSettings(io, {
+                                             { SETTINGS_ENABLE_CONNECT_PROTOCOL, 0 },
                                              { SETTINGS_MAX_FRAME_SIZE, m_maxFrameSize },
                                              { SETTINGS_HEADER_TABLE_SIZE, m_headerTableSize },
                                          });

--- a/wsgi/tcpserverbalancer.cpp
+++ b/wsgi/tcpserverbalancer.cpp
@@ -129,7 +129,7 @@ bool TcpServerBalancer::listen(const QString &line, Protocol *protocol, bool sec
         m_sslConfiguration->setPrivateKey(key);
         m_sslConfiguration->setPeerVerifyMode(QSslSocket::VerifyNone); // prevent asking for client certificate
         if (m_wsgi->httpsH2()) {
-            m_sslConfiguration->setAllowedNextProtocols({ QByteArrayLiteral("h2") });
+            m_sslConfiguration->setAllowedNextProtocols({ QByteArrayLiteral("h2"), QSslConfiguration::NextProtocolHttp1_1});
         }
     }
 #endif // QT_NO_SSL


### PR DESCRIPTION
- Let sendGoAway and sendRstStream return error, so that socket can then close connection in ProtocolHttp2::parse(). 
- Handle more Stream state exceptions. 
- In case of small window size, H2Stream::doWrite may write partial data, and need to add offset to data. If I misunderstand it, please correct me.