### PR TITLE
wsgi: Support loading config files without using parseCommandLine

### DIFF
--- a/wsgi/wsgi.cpp
+++ b/wsgi/wsgi.cpp
@@ -504,6 +504,26 @@ void WSGI::parseCommandLine(const QStringList &arguments)
     d->threadBalancer = parser.isSet(threadBalancerOpt);
 }
 
+void WSGI::loadConfig(const QStringList& configFiles, bool json)
+{
+	Q_D(WSGI);
+
+	for (const QString &config : configFiles) {
+		d->loadConfig(config, json);
+	}
+
+	if (json)
+	{	
+		setJson(configFiles);
+	}
+	else
+	{	
+		setIni(configFiles);
+	}
+
+	d->applyConfig(d->opt);
+}
+
 int WSGI::exec(Cutelyst::Application *app)
 {
     Q_D(WSGI);

--- a/wsgi/wsgi.h
+++ b/wsgi/wsgi.h
@@ -46,6 +46,12 @@ public:
     void parseCommandLine(const QStringList &args);
 
     /**
+    * Loads configuration files \p configFiles.
+    * The files are either interpreted as json or ini format depending value of \p json
+    */
+    void loadConfig(const QStringList& configFiles, bool json);
+
+    /**
      * This function will start the WSGI server.
      *
      * If an application is provided it will ignore the value of


### PR DESCRIPTION
Extended wsgi to support loading configuration files without using parseCommandLine.
This makes it easier to use cutelyst config files when embedding wsgi into a application.