### PR TITLE
Grantlee plugin support CUTELYST_PLUGINS_DIR env var 

### DIFF
--- a/Cutelyst/Plugins/View/Grantlee/grantleeview.cpp
+++ b/Cutelyst/Plugins/View/Grantlee/grantleeview.cpp
@@ -43,7 +43,13 @@ GrantleeView::GrantleeView(QObject *parent, const QString &name) : View(parent, 
 
     d->engine = new Grantlee::Engine(this);
     d->engine->addTemplateLoader(d->loader);
-    d->engine->addPluginPath(QStringLiteral(CUTELYST_PLUGINS_DIR));
+    
+	// Set also the paths from CUTELYST_PLUGINS_DIR env variable as plugin paths of grantlee engine 
+	const QByteArrayList dirs = QByteArrayList{ QByteArrayLiteral(CUTELYST_PLUGINS_DIR) } + qgetenv("CUTELYST_PLUGINS_DIR").split(';');
+	for (const QByteArray &dir : dirs) {
+		d->engine->addPluginPath(QString::fromLocal8Bit(dir));
+	}
+
     d->engine->addDefaultLibrary(QStringLiteral("grantlee_cutelyst"));
 
     auto app = qobject_cast<Application *>(parent);

--- a/Cutelyst/Plugins/View/Grantlee/grantleeview.cpp
+++ b/Cutelyst/Plugins/View/Grantlee/grantleeview.cpp
@@ -44,11 +44,11 @@ GrantleeView::GrantleeView(QObject *parent, const QString &name) : View(parent, 
     d->engine = new Grantlee::Engine(this);
     d->engine->addTemplateLoader(d->loader);
     
-	// Set also the paths from CUTELYST_PLUGINS_DIR env variable as plugin paths of grantlee engine 
-	const QByteArrayList dirs = QByteArrayList{ QByteArrayLiteral(CUTELYST_PLUGINS_DIR) } + qgetenv("CUTELYST_PLUGINS_DIR").split(';');
-	for (const QByteArray &dir : dirs) {
-		d->engine->addPluginPath(QString::fromLocal8Bit(dir));
-	}
+    // Set also the paths from CUTELYST_PLUGINS_DIR env variable as plugin paths of grantlee engine
+    const QByteArrayList dirs = QByteArrayList{ QByteArrayLiteral(CUTELYST_PLUGINS_DIR) } + qgetenv("CUTELYST_PLUGINS_DIR").split(';');
+    for (const QByteArray &dir : dirs) {
+        d->engine->addPluginPath(QString::fromLocal8Bit(dir));
+    }
 
     d->engine->addDefaultLibrary(QStringLiteral("grantlee_cutelyst"));
 


### PR DESCRIPTION
When setting up grantlee plugin paths do this also for the paths of the env variable CUTELYST_PLUGINS_DIR

This makes it possible to use grantlee plugin when the hard coded plugin path doesn't exists on the target system and CUTELYST_PLUGINS_DIR env var is properly setup