### PR TITLE
Fixed endless loop when more then one config files should be loaded

### DIFF
--- a/wsgi/wsgi.cpp
+++ b/wsgi/wsgi.cpp
@@ -1557,11 +1557,11 @@ void WSGIPrivate::loadConfig(const QString &file, bool json)
     auto it = config.begin();
     while (it != config.end()) {
         auto itLoaded = loadedConfig.find(it.key());
-        while (itLoaded == loadedConfig.end()) {
+        while (itLoaded != loadedConfig.end()) {
             QVariantMap loadedMap = itLoaded.value().toMap();
             loadedMap.unite(it.value().toMap());
             it.value() = loadedMap;
-            loadedConfig.erase(itLoaded);
+            itLoaded = loadedConfig.erase(itLoaded);
         }
         ++it;
     }


### PR DESCRIPTION
When multiple config files should be loaded an endless loop occures while merging the config data