### PR TITLE
CuteleeView: use insertDefaultLibrary() for internal Cutelyst tags and add translations

### DIFF
--- a/Cutelyst/Plugins/View/Cutelee/cuteleeview.cpp
+++ b/Cutelyst/Plugins/View/Cutelee/cuteleeview.cpp
@@ -50,7 +50,7 @@ CuteleeView::CuteleeView(QObject *parent, const QString &name) : View(new Cutele
         d->engine->addPluginPath(QString::fromLocal8Bit(dir));
     }
 
-    d->engine->insertLibrary(QStringLiteral("cutelee_cutelyst"), new CutelystCutelee(d->engine));
+    d->engine->insertDefaultLibrary(QStringLiteral("cutelee_cutelyst"), new CutelystCutelee(d->engine));
 
     auto app = qobject_cast<Application *>(parent);
     if (app) {

--- a/Messages.sh
+++ b/Messages.sh
@@ -22,6 +22,8 @@ $QT5LUPDATE -no-obsolete -locations none -source-language en -target-language $L
 
 $QT5LUPDATE -no-obsolete -locations none -source-language en -target-language $LANG Cutelyst/Plugins/CSRFProtection -ts i18n/plugin_csrfprotection.$LANG.ts
 
+$QT5LUPDATE -no-obsolete -locations none -source-language en -target-language $LANG Cutelyst/Plugins/View/Cutelee -ts i18n/plugin_view_cutelee.$LANG.ts
+
 $QT5LUPDATE -no-obsolete -locations none -source-language en -target-language $LANG Cutelyst/Plugins/View/Grantlee -ts i18n/plugin_view_grantlee.$LANG.ts
 
 $QT5LUPDATE -no-obsolete -locations none -source-language en -target-language $LANG Cutelyst/Plugins/Utils/Validator -ts i18n/plugin_utils_validator.$LANG.ts

--- a/i18n/CMakeLists.txt
+++ b/i18n/CMakeLists.txt
@@ -13,6 +13,7 @@ if (LRELEASE_CMD)
         cutelystcore
         plugin_memcached
         plugin_csrfprotection
+        plugin_view_cutelee
         plugin_view_grantlee
         plugin_utils_validator)
 

--- a/i18n/plugin_view_cutelee.de.ts
+++ b/i18n/plugin_view_cutelee.de.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de" sourcelanguage="en">
+<context>
+    <name>Cutelyst::CuteleeView</name>
+    <message>
+        <source>Internal server error.</source>
+        <translation>Interner Server-Fehler.</translation>
+    </message>
+</context>
+</TS>

--- a/i18n/plugin_view_cutelee.en.ts
+++ b/i18n/plugin_view_cutelee.en.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en" sourcelanguage="en">
+<context>
+    <name>Cutelyst::CuteleeView</name>
+    <message>
+        <source>Internal server error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Use Cutelee::Engine::insertDefaultLibrary() to insert the Cutelyst specific Cutelee tags into every template by default to get a behavior like on our GrantleeView.

Enable translations for CuteleeView.