### PR TITLE
[Session Plugin] load config file options

### DIFF
--- a/Cutelyst/Plugins/Session/CutelystQt5Session.5.in
+++ b/Cutelyst/Plugins/Session/CutelystQt5Session.5.in
@@ -26,6 +26,18 @@ If enabled, the plugin will check if the IP address of the requesting user match
 .RS 4
 If true, the plugin will check if the user agent of the requesting user matches the user agent stored in the session data. In case of a mismatch, the session will be deleted.
 .RE
+.PP
+.I cookie_http_only
+(boolean value, default: true)
+.RS 4
+If true, the session cookie will have the httpOnly flag set so that the cookie is not accessible to JavaScript's Document.cookie API.
+.RE
+.PP
+.I cookie_secure
+(boolean value, default: false)
+.RS 4
+If true, the session cookie will have the secure flag set so that the cookie is only sent to the server with an encrypted request over the HTTPS protocol.
+.RE
 .SH EXAMPLES
 .RS 0
 [Cutelyst_Session_Plugin]

--- a/Cutelyst/Plugins/Session/session.cpp
+++ b/Cutelyst/Plugins/Session/session.cpp
@@ -66,6 +66,8 @@ bool Session::setup(Application *app)
     d->expiryThreshold = config.value(QLatin1String("expiry_threshold"), 0).toLongLong();
     d->verifyAddress = config.value(QLatin1String("verify_address"), false).toBool();
     d->verifyUserAgent = config.value(QLatin1String("verify_user_agent"), false).toBool();
+    d->cookieHttpOnly = config.value(QLatin1String("cookie_http_only"), true).toBool();
+    d->cookieSecure = config.value(QLatin1String("cookie_secure"), false).toBool();
 
     connect(app, &Application::afterDispatch, this, &SessionPrivate::_q_saveSession);
     connect(app, &Application::postForked, this, [=] {

--- a/Cutelyst/Plugins/Session/session.h
+++ b/Cutelyst/Plugins/Session/session.h
@@ -56,6 +56,52 @@ public:
 };
 
 class SessionPrivate;
+/**
+ * Plugin providing methods for session management.
+ *
+ * <H3>Configuration file options</H3>
+ *
+ * There are some options you can set in your application configuration file in the @c Cutelyst_Session_Plugin section.
+ *
+ * @par expires
+ * @parblock
+ * Integer value, default: 7200
+ *
+ * Expiration duration of the session in seconds.
+ * @endparblock
+ *
+ * @par verify_address
+ * @parblock
+ * Boolean value, default: false
+ *
+ * If enabled, the plugin will check if the IP address of the requesting user matches the
+ * address stored in the session data. In case of a mismatch, the session will be deleted.
+ * @endparblock
+ *
+ * @par verify_user_agent
+ * @parblock
+ * Boolean value, default: false
+ *
+ * If true, the plugin will check if the user agent of the requesting user matches the user
+ * agent stored in the session data. In case of a mismatch, the session will be deleted.
+ * @endparblock
+ *
+ * @par cookie_http_only
+ * @parblock
+ * Boolean value, default: true
+ *
+ * If true, the session cookie will have the httpOnly flag set so that the cookie is not
+ * accessible to JavaScript's Document.cookie API.
+ * @endparblock
+ *
+ * @par cookie_secure
+ * @parblock
+ * Boolean value, default: false
+ *
+ * If true, the session cookie will have the secure flag set so that the cookie is only
+ * sent to the server with an encrypted request over the HTTPS protocol.
+ * @endparblock
+ */
 class CUTELYST_PLUGIN_SESSION_EXPORT Session : public Plugin
 {
     Q_OBJECT
@@ -68,10 +114,7 @@ public:
     virtual ~Session();
 
     /**
-     * If config has
-     * [Cutelyst_Session_Plugin]
-     * expires = 1234
-     * it will change the default expires which is 7200 (two hours)
+     * Sets up the plugin and loads the configuration.
      */
     virtual bool setup(Application *app) final;
 


### PR DESCRIPTION
There are some options for the plugin like `cookieSecure` and `cookieHttpOnly` that are not configurable from the configuration file because no entries for them are loaded from the config file. This adds the loading of the two config file entries `cookie_http_only` and `cookie_secure` to the setup() method.

This will also update the man pages and API docs for this config entries.