### PR TITLE
make header enginerequest.h available for external unit tests

### DIFF
--- a/Cutelyst/CMakeLists.txt
+++ b/Cutelyst/CMakeLists.txt
@@ -64,6 +64,7 @@ set(cutelystqt_HEADERS
     dispatchtype.h
     DispatchType
     engine.h
+    enginerequest.h
     Engine
     headers.h
     Headers

--- a/Cutelyst/enginerequest.h
+++ b/Cutelyst/enginerequest.h
@@ -15,6 +15,14 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
+/*!
+ * \file
+ * \warning
+ * This header file is part of the internal private api.
+ * It is meant to be used by unit tests. See TestEngineConnection in tests/coverageobject.cpp
+ * for an example on how to use it.
+ */
 #ifndef ENGINEREQUEST_H
 #define ENGINEREQUEST_H
 


### PR DESCRIPTION
I had a need to test an endpoint. This is a quick fix to be able to unit tests endpoints until a full public API like TestEngine (see #176) is available.