### PR TITLE
Replace C-style typedef with regular C++

### DIFF
--- a/wsgi/unixfork.h
+++ b/wsgi/unixfork.h
@@ -24,12 +24,12 @@
 
 #include "abstractfork.h"
 
-typedef struct {
+struct Worker {
     bool null = true;
     int id;
     int restart = 0;
     int respawn = 0;
-} Worker;
+};
 
 namespace CWSGI {
 class WSGI;


### PR DESCRIPTION
This resolves a warning from clang:

```
In file included from /usr/home/adridg/src/git/cutelyst/wsgi/unixfork.cpp:18:
/usr/home/adridg/src/git/cutelyst/wsgi/unixfork.h:27:15: warning: anonymous non-C-compatible type given name for linkage purposes by typedef declaration; add a tag name here [-Wnon-c-typedef-for-linkage]
typedef struct {
              ^
               Worker
/usr/home/adridg/src/git/cutelyst/wsgi/unixfork.h:28:17: note: type is not C-compatible due to this default member initializer
    bool null = true;
                ^~~~
/usr/home/adridg/src/git/cutelyst/wsgi/unixfork.h:32:3: note: type is given name 'Worker' for linkage purposes by this typedef declaration
} Worker;
  ^
```

It's because of the C-style typedef (that looks like it is a leftover from the original WSGI code).