### PR TITLE
Handle FreeBSD nicely

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,31 @@ if(UNIX AND NOT (APPLE OR HAIKU))
 endif()
 
 if (LINUX)
-    add_subdirectory(EventLoopEPoll)
+    if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+        # FreeBSD isn't Linux, but it gets claimed as Linux, because it is
+        # UNIX and not APPLE (see just above).
+        #
+        # Try to find the EPOLL implementation from libepoll-shim; while
+        # epoll.h is found, and timerfd.h is found, the FreeBSD implementation
+        # in timerfd is insufficient (missing timerfd_gettime), and besides
+        # that there is also no eventfd.h in the FreeBSD shims.
+        #
+        # So, do the work of finding EPOLL, but don't use that subdirectory.
+        # Also, decide that we're not Linux after all.
+        find_file(EPOLL_H sys/epoll.h
+            HINTS libepoll-shim /usr/local/include/libepoll-shim
+        )
+        if (EPOLL_H)
+            get_filename_component(EPOLL_SYS_DIR ${EPOLL_H} DIRECTORY)
+            get_filename_component(EPOLL_DIR ${EPOLL_SYS_DIR} DIRECTORY)
+            include_directories(${EPOLL_DIR})
+            # add_subdirectory(EventLoopEPoll)
+        endif()
+        set(LINUX FALSE)
+    else()
+        # Real Linux
+        add_subdirectory(EventLoopEPoll)
+    endif()
 endif()
 
 add_subdirectory(wsgi)


### PR DESCRIPTION
This is a patch that I've been carrying in packaging for some time: FreeBSD is UNIX and not APPLE OR HAIKU, so it is detected as Linux. It isn't, though, and the available epoll shim (FreeBSD does that a lot: once Linux has created  some arbitrary API and everyone is using it, build a shim for that API to the services available in the BSD world) doesn't have the whole API used.

So futz around a bit, but conclude: FreeBSD isn't Linux. Some time in future that commented-out line could be added if the shim is extended enough.