### PR TITLE
core: Make the ActionChain class public

### DIFF
--- a/Cutelyst/ActionChain
+++ b/Cutelyst/ActionChain
@@ -1,0 +1,1 @@
+#include "actionchain.h"

--- a/Cutelyst/CMakeLists.txt
+++ b/Cutelyst/CMakeLists.txt
@@ -17,7 +17,6 @@ set(cutelystqt_SRC
     context_p.h
     action.cpp
     actionchain.cpp
-    actionchain.h
     actionchain_p.h
     action_p.h
     enginerequest.cpp
@@ -49,6 +48,8 @@ set(cutelystqt_HEADERS
     ParamsMultiMap
     action.h
     Action
+    actionchain.h
+    ActionChain
     application.h
     Application
     async.h


### PR DESCRIPTION
The class is already documented as a public class, and is needed to
implement chained dispatchers.