### PR TITLE
WSGI: fix buffer overrun when path only consist of leading slash "/"

### DIFF
--- a/wsgi/hpack.cpp
+++ b/wsgi/hpack.cpp
@@ -242,8 +242,10 @@ inline bool validPseudoHeader(const QString &k, const QString &v, H2Stream *stre
     if (k == QLatin1String(":path")) {
         if (!stream->gotPath && !v.isEmpty()) {
             int leadingSlash = 0;
-            while (v[leadingSlash] == QLatin1Char('/')) {
-                ++leadingSlash;
+            if (v != QLatin1String("/")) {
+                while (v[leadingSlash] == QLatin1Char('/')) {
+                    ++leadingSlash;
+                }
             }
 
             int pos = v.indexOf(QLatin1Char('?'));


### PR DESCRIPTION
When accessing the root document e.g. http://www.example.com with Chrome the path only consists of "/". This patch fixes a buffer overrun in this case.