### PR TITLE
Trigger socket close when worker shuts down, resulting in faster server termination

### DIFF
--- a/server/localserver.cpp
+++ b/server/localserver.cpp
@@ -155,6 +155,7 @@ void LocalServer::shutdown()
                         m_engine->serverShutdown();
                     }
                 });
+                socket->connectionClose();
             }
         }
     }

--- a/server/tcpserver.cpp
+++ b/server/tcpserver.cpp
@@ -103,6 +103,7 @@ void TcpServer::shutdown()
                         m_engine->serverShutdown();
                     }
                 });
+                socket->connectionClose();
             }
         }
     }

--- a/server/tcpsslserver.cpp
+++ b/server/tcpsslserver.cpp
@@ -95,6 +95,7 @@ void TcpSslServer::shutdown()
                         m_engine->serverShutdown();
                     }
                 }, Qt::QueuedConnection);
+                socket->connectionClose();
             }
         }
     }


### PR DESCRIPTION
Closes #301 

Currently there is a disconnect between any actively established sockets and the Engine during a shutdown. The engine shutdown is triggered and currently just waits for the sockets to finish doing their thing. Testing on my machine results in the engine waiting for a very long timeout (30 seconds) before the child processes have to be forcibly killed in order to shut down the server.

Instead, this fix invokes the appropriate methods to close the open sockets, result in the workers flushing their buffers and terminating rapidly, resulting in very fast shutdown (woohoo!).