### PR TITLE
server/CMakeLists.txt: don't override CMAKE_EXE_LINKER_FLAGS

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -95,7 +95,7 @@ install(TARGETS Cutelyst${PROJECT_VERSION_MAJOR}Qt${QT_VERSION_MAJOR}Server
 add_executable(cutelystd main.cpp)
 
 if (JEMALLOC_FOUND)
-    set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} " -Wl,--no-as-needed")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed")
     target_link_libraries(cutelystd PRIVATE ${JEMALLOC_LIBRARIES})
 endif()
 


### PR DESCRIPTION
Don't override `CMAKE_EXE_LINKER_FLAGS` as this could break the build if
`CMAKE_EXE_LINKER_FLAGS` is already set by the user (for example to pass
`-latomic`)

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>