### PR TITLE
Remove Unneeded qtTranslator

### DIFF
--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -419,19 +419,6 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName(QStringLiteral("cutelyst"));
     QCoreApplication::setApplicationVersion(QStringLiteral(VERSION));
 
-    QTranslator qtTranslator;
-    bool loadedTr = qtTranslator.load(QLatin1String("qt_") % QLocale::system().name(),
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-                                      QLibraryInfo::location(QLibraryInfo::TranslationsPath));
-#else
-                                      QLibraryInfo::path(QLibraryInfo::TranslationsPath));
-#endif
-    if (!loadedTr) {
-        std::cerr << qUtf8Printable(QCoreApplication::translate("cutelystcmd", "Error: could not load translations")) << std::endl;
-    }
-
-    QCoreApplication::installTranslator(&qtTranslator);
-
     QTranslator appTranslator;
     if (appTranslator.load(QLocale(), QStringLiteral("cutelystcmd"), QStringLiteral("."), QStringLiteral(I18NDIR))) {
         QCoreApplication::installTranslator(&appTranslator);


### PR DESCRIPTION
For some reason there are two translators installed.  The qtTranslator
keeps throwing an error as it cannot find a global "qt_" prefixed
translation file.  The second translator works just fine as it searches
through the I18N folder.