### PR TITLE
SameSite attribute for cookies

### DIFF
--- a/Cutelyst/CMakeLists.txt
+++ b/Cutelyst/CMakeLists.txt
@@ -90,9 +90,14 @@ set(cutelystqt_HEADERS
     plugin.h
     Plugin
     utils.h
-    Cookie
-    cookie.h
 )
+
+if (${QT_VERSION} VERSION_LESS "6.1.0")
+    list(APPEND cutelystqt_HEADERS
+        Cookie
+        cookie.h
+    )
+endif (${QT_VERSION} VERSION_LESS "6.1.0")
 
 set(cutelystqt_HEADERS_PRIVATE
     common.h

--- a/Cutelyst/CMakeLists.txt
+++ b/Cutelyst/CMakeLists.txt
@@ -44,6 +44,13 @@ set(cutelystqt_SRC
     plugin.cpp
 )
 
+if (${QT_VERSION} VERSION_LESS "6.1.0")
+    list(APPEND cutelystqt_SRC
+        cookie.cpp
+        cookie_p.h
+    )
+endif (${QT_VERSION} VERSION_LESS "6.1.0")
+
 set(cutelystqt_HEADERS
     paramsmultimap.h
     ParamsMultiMap
@@ -83,6 +90,8 @@ set(cutelystqt_HEADERS
     plugin.h
     Plugin
     utils.h
+    Cookie
+    cookie.h
 )
 
 set(cutelystqt_HEADERS_PRIVATE

--- a/Cutelyst/Cookie
+++ b/Cutelyst/Cookie
@@ -1,0 +1,1 @@
+#include "cookie.h"

--- a/Cutelyst/Plugins/CSRFProtection/csrfprotection.cpp
+++ b/Cutelyst/Plugins/CSRFProtection/csrfprotection.cpp
@@ -83,7 +83,7 @@ bool CSRFProtection::setup(Application *app)
         d->headerName = QStringLiteral(DEFAULT_HEADER_NAME);
     }
     const QString _sameSite = config.value(QLatin1String("cookie_same_site"), QStringLiteral("strict")).toString();
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 1, 0))
+#if QT_VERSION >= QT_VERSION_CHECK(6, 1, 0)
     if (_sameSite.compare(u"default", Qt::CaseInsensitive) == 0) {
         d->cookieSameSite = QNetworkCookie::SameSite::Default;
     } else if (_sameSite.compare(u"none", Qt::CaseInsensitive) == 0) {

--- a/Cutelyst/Plugins/CSRFProtection/csrfprotection.h
+++ b/Cutelyst/Plugins/CSRFProtection/csrfprotection.h
@@ -191,6 +191,15 @@ class CSRFProtectionPrivate;
  * which means browsers may ensure that the cookie is only sent with an HTTPS connection.
  * @endparblock
  *
+ * @par cookie_same_site
+ * @parblock
+ * String value, default: strict; acceptable values: default, none, lax, strict
+ *
+ * Defines the SameSite attribute of the CSRF cookie. See <A HREF="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">MDN</A>
+ * to learn more about SameSite cookies. This configuration key is available since
+ * Cutelyst 3.8.0 and is only available if Cutelyst is compiled against Qt 6.1.0 or newer.
+ * @endparblock
+ *
  * @par trusted_origins
  * @parblock
  * String list, default: empty

--- a/Cutelyst/Plugins/CSRFProtection/csrfprotection_p.h
+++ b/Cutelyst/Plugins/CSRFProtection/csrfprotection_p.h
@@ -7,6 +7,9 @@
 #define CSRFPROTECTION_P_H
 
 #include "csrfprotection.h"
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+#include "cookie.h"
+#endif
 
 #include <QRegularExpression>
 #include <QNetworkCookie>
@@ -45,6 +48,8 @@ public:
     static const QRegularExpression sanitizeRe;
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 1, 0))
     QNetworkCookie::SameSite cookieSameSite = QNetworkCookie::SameSite::Strict;
+#else
+    Cookie::SameSite cookieSameSite = Cookie::SameSite::Strict;
 #endif
     bool cookieHttpOnly {false};
     bool cookieSecure {false};

--- a/Cutelyst/Plugins/CSRFProtection/csrfprotection_p.h
+++ b/Cutelyst/Plugins/CSRFProtection/csrfprotection_p.h
@@ -9,6 +9,7 @@
 #include "csrfprotection.h"
 
 #include <QRegularExpression>
+#include <QNetworkCookie>
 
 namespace Cutelyst {
 
@@ -42,6 +43,9 @@ public:
     QString genericErrorMessage;
     QString genericContentType {QStringLiteral("text/plain; charset=utf8")};
     static const QRegularExpression sanitizeRe;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 1, 0))
+    QNetworkCookie::SameSite cookieSameSite = QNetworkCookie::SameSite::Strict;
+#endif
     bool cookieHttpOnly {false};
     bool cookieSecure {false};
     bool useSessions {false};

--- a/Cutelyst/Plugins/Session/session.cpp
+++ b/Cutelyst/Plugins/Session/session.cpp
@@ -56,7 +56,7 @@ bool Session::setup(Application *app)
     d->cookieHttpOnly = config.value(QLatin1String("cookie_http_only"), true).toBool();
     d->cookieSecure = config.value(QLatin1String("cookie_secure"), false).toBool();
     const QString _sameSite = config.value(QLatin1String("cookie_same_site"), QStringLiteral("strict")).toString();
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 1, 0))
+#if QT_VERSION >= QT_VERSION_CHECK(6, 1, 0)
     if (_sameSite.compare(u"default", Qt::CaseInsensitive) == 0) {
         d->cookieSameSite = QNetworkCookie::SameSite::Default;
     } else if (_sameSite.compare(u"none", Qt::CaseInsensitive) == 0) {

--- a/Cutelyst/Plugins/Session/session.h
+++ b/Cutelyst/Plugins/Session/session.h
@@ -88,6 +88,15 @@ class SessionPrivate;
  * If true, the session cookie will have the secure flag set so that the cookie is only
  * sent to the server with an encrypted request over the HTTPS protocol.
  * @endparblock
+ *
+ * @par cookie_same_site
+ * @parblock
+ * String value, default: strict; acceptable values: default, none, lax, strict
+ *
+ * Defines the SameSite attribute of the session cookie. See <A HREF="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">MDN</A>
+ * to learn more about SameSite cookies. This configuration key is available since
+ * Cutelyst 3.8.0 and is only available if Cutelyst is compiled against Qt 6.1.0 or newer.
+ * @endparblock
  */
 class CUTELYST_PLUGIN_SESSION_EXPORT Session : public Plugin
 {

--- a/Cutelyst/Plugins/Session/session_p.h
+++ b/Cutelyst/Plugins/Session/session_p.h
@@ -6,6 +6,9 @@
 #define SESSION_P_H
 
 #include "session.h"
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+#include "cookie.h"
+#endif
 
 #include <QtNetwork/QNetworkCookie>
 
@@ -39,6 +42,10 @@ public:
 
     static inline void updateSessionCookie(Context *c, const QNetworkCookie &updated);
     static inline QNetworkCookie makeSessionCookie(Session *session, Context *c, const QString &sid, const QDateTime &expires);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+    static inline void updateSessionCuteCookie(Context *c, const Cookie &updated);
+    static inline Cookie makeSessionCuteCookie(Session *session, Context *c, const QString &sid, const QDateTime &expires);
+#endif
     static inline void extendSessionId(Session *session, Context *c, const QString &sid, qint64 expires);
     static inline void setSessionId(Session *session, Context *c, const QString &sid);
 
@@ -50,6 +57,8 @@ public:
     QString sessionName;
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 1, 0))
     QNetworkCookie::SameSite cookieSameSite = QNetworkCookie::SameSite::Strict;
+#else
+    Cookie::SameSite cookieSameSite = Cookie::SameSite::Strict;
 #endif
     bool cookieHttpOnly = true;
     bool cookieSecure = false;

--- a/Cutelyst/Plugins/Session/session_p.h
+++ b/Cutelyst/Plugins/Session/session_p.h
@@ -48,6 +48,9 @@ public:
     qint64 expiryThreshold = 0;
     SessionStore *store = nullptr;
     QString sessionName;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 1, 0))
+    QNetworkCookie::SameSite cookieSameSite = QNetworkCookie::SameSite::Strict;
+#endif
     bool cookieHttpOnly = true;
     bool cookieSecure = false;
     bool verifyAddress = false;

--- a/Cutelyst/Plugins/Utils/LangSelect/langselect.cpp
+++ b/Cutelyst/Plugins/Utils/LangSelect/langselect.cpp
@@ -693,7 +693,7 @@ void LangSelectPrivate::setToCookie(Context *c, const QString &name) const
 {
     qCDebug(C_LANGSELECT) << "Storing selected locale in cookie with name" << name;
     QNetworkCookie cookie(name.toLatin1(), c->locale().bcp47Name().toLatin1());
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 1, 0))
+#if QT_VERSION >= QT_VERSION_CHECK(6, 1, 0)
     cookie.setSameSitePolicy(QNetworkCookie::SameSite::Lax);
 #endif
     c->res()->setCookie(cookie);

--- a/Cutelyst/Plugins/Utils/LangSelect/langselect.cpp
+++ b/Cutelyst/Plugins/Utils/LangSelect/langselect.cpp
@@ -692,7 +692,11 @@ void LangSelectPrivate::setToQuery(Context *c, const QString &key) const
 void LangSelectPrivate::setToCookie(Context *c, const QString &name) const
 {
     qCDebug(C_LANGSELECT) << "Storing selected locale in cookie with name" << name;
-    c->res()->setCookie(QNetworkCookie(name.toLatin1(), c->locale().bcp47Name().toLatin1()));
+    QNetworkCookie cookie(name.toLatin1(), c->locale().bcp47Name().toLatin1());
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 1, 0))
+    cookie.setSameSitePolicy(QNetworkCookie::SameSite::Lax);
+#endif
+    c->res()->setCookie(cookie);
 }
 
 void LangSelectPrivate::setToSession(Context *c, const QString &key) const

--- a/Cutelyst/cookie.cpp
+++ b/Cutelyst/cookie.cpp
@@ -24,10 +24,7 @@ Cookie::Cookie(const Cookie &other)
 
 }
 
-Cookie::~Cookie()
-{
-    d = nullptr;
-}
+Cookie::~Cookie() = default;
 
 Cookie &Cookie::operator=(const Cookie &other)
 {

--- a/Cutelyst/cookie.cpp
+++ b/Cutelyst/cookie.cpp
@@ -1,0 +1,135 @@
+/*
+ * SPDX-FileCopyrightText: (C) 2023 Matthias Fehring <mf@huessenbergnetz.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "cookie_p.h"
+#include <QLocale>
+#include <QUrl>
+#include <QHostAddress>
+#include <QDateTime>
+
+using namespace Cutelyst;
+
+Cookie::Cookie(const QByteArray &name, const QByteArray &value)
+    : QNetworkCookie(name, value), d(new CookiePrivate)
+{
+    qRegisterMetaType<Cookie>();
+    qRegisterMetaType<QList<Cookie>>();
+}
+
+Cookie::Cookie(const Cookie &other)
+    : QNetworkCookie(other), d(other.d)
+{
+
+}
+
+Cookie::~Cookie()
+{
+    d = nullptr;
+}
+
+Cookie &Cookie::operator=(const Cookie &other)
+{
+    QNetworkCookie::operator=(other);
+    d = other.d;
+    return *this;
+}
+
+bool Cookie::operator==(const Cookie &other) const
+{
+    if (QNetworkCookie::operator==(other) && d == other.d) {
+        return true;
+    }
+
+    return QNetworkCookie::operator==(other) && d->sameSite == other.d->sameSite;
+}
+
+Cookie::SameSite Cookie::sameSitePolicy() const
+{
+    return d->sameSite;
+}
+
+void Cookie::setSameSitePolicy(Cookie::SameSite sameSite)
+{
+    d->sameSite = sameSite;
+}
+
+namespace {
+QByteArray sameSiteToRawString(Cookie::SameSite samesite)
+{
+    switch (samesite) {
+    case Cookie::SameSite::None:
+        return QByteArrayLiteral("None");
+    case Cookie::SameSite::Lax:
+        return QByteArrayLiteral("Lax");
+    case Cookie::SameSite::Strict:
+        return QByteArrayLiteral("Strict");
+    case Cookie::SameSite::Default:
+        break;
+    }
+    return QByteArray();
+}
+} // namespace
+
+QByteArray Cookie::toRawForm(RawForm form) const
+{
+    QByteArray result;
+    if (name().isEmpty())
+        return result;          // not a valid cookie
+
+    result = name();
+    result += '=';
+    result += value();
+
+    if (form == Full) {
+        // same as above, but encoding everything back
+        if (isSecure())
+            result += "; secure";
+        if (isHttpOnly())
+            result += "; HttpOnly";
+        if (d->sameSite != SameSite::Default) {
+            result += "; SameSite=";
+            result += sameSiteToRawString(d->sameSite);
+        }
+        if (!isSessionCookie()) {
+            result += "; expires=";
+            result += QLocale::c().toString(expirationDate().toUTC(),
+                                            QStringLiteral("ddd, dd-MMM-yyyy hh:mm:ss 'GMT")).toLatin1();
+        }
+        if (!domain().isEmpty()) {
+            result += "; domain=";
+            if (domain().startsWith(u'.')) {
+                result += '.';
+                result += QUrl::toAce(domain().mid(1));
+            } else {
+                QHostAddress hostAddr(domain());
+                if (hostAddr.protocol() == QAbstractSocket::IPv6Protocol) {
+                    result += '[';
+                    result += domain().toUtf8();
+                    result += ']';
+                } else {
+                    result += QUrl::toAce(domain());
+                }
+            }
+        }
+        if (!path().isEmpty()) {
+            result += "; path=";
+            result += path().toUtf8();
+        }
+    }
+    return result;
+}
+
+#ifndef QT_NO_DEBUG_STREAM
+QDebug operator<<(QDebug s, const Cutelyst::Cookie &cookie)
+{
+    QDebugStateSaver saver(s);
+    Q_UNUSED(saver)
+    s.resetFormat().nospace();
+    s << "Cutelyst::Cookie(" << cookie.toRawForm(Cookie::Full) << ')';
+    return s;
+}
+#endif
+
+#include "moc_cookie.cpp"

--- a/Cutelyst/cookie.h
+++ b/Cutelyst/cookie.h
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: (C) 2023 Matthias Fehring <mf@huessenbergnetz.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef CUTELYST_COOKIE_H
+#define CUTELYST_COOKIE_H
+
+#include <Cutelyst/cutelyst_global.h>
+
+#include <QNetworkCookie>
+#include <QObject>
+
+namespace Cutelyst {
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 1, 0))
+
+CUTELYST_LIBRARY using Cookie = QNetworkCookie;
+
+#else
+class CookiePrivate;
+/*!
+ * \class Cookie cookie.h Cutelyst/Cookie
+ * \brief The %Cutelyst %Cookie
+ *
+ * This is a reimplementation of QNetworkCookie that adds support for the \a SameSite property.
+ *
+ * \since Cutelyst 3.8.0
+ */
+class CUTELYST_LIBRARY Cookie : public QNetworkCookie
+{
+    Q_GADGET
+public:
+    enum class SameSite {
+        Default,    /**< SameSite is not set. Can be interpreted as None or Lax by the browser. */
+        None,       /**< Cookies can be sent in all contexts. This used to be default, but recent browsers made Lax default, and will now require the cookie to be both secure and to set SameSite=None. */
+        Lax,        /**< Cookies are sent on first party requests and GET requests initiated by third party website. This is the default in modern browsers (since mid 2020). */
+        Strict      /**< Cookies will only be sent in a first-party context. */
+    };
+    Q_ENUM(SameSite)
+
+    /*!
+     * Create a new %Cookie object, initializing the cookie name to \a name and its value to \a value.
+     *
+     * A cookie is only valid if it has a name. However, the value is opaque to the application and being empty may have significance to the remote server.
+     */
+    explicit Cookie(const QByteArray &name = QByteArray(), const QByteArray &value = QByteArray());
+    /*!
+     * Creates a new %Cookie object by copying the contents of other.
+     */
+    Cookie(const Cookie &other);
+    /*!
+     * Destroys this %Cookie object.
+     */
+    ~Cookie();
+    /*!
+     * Move assigns the contents of the %Cookie object \a other to this object.
+     */
+    Cookie &operator=(Cookie &&other) noexcept { swap(other); return *this; }
+    /*!
+     * Copies the contents of the %Cookie object \a other to this object.
+     */
+    Cookie &operator=(const Cookie &other);
+
+    /*!
+     * Swaps this cookie with other. This function is very fast and never fails.
+     */
+    void swap(Cookie &other) noexcept
+    {
+        QNetworkCookie::swap(other);
+        d.swap(other.d);
+    }
+
+    /*!
+     * Returns true if this cookie is equal to \a other. This function only returns true if all fields of the cookie are the same.
+     *
+     * However, in some contexts, two cookies of the same name could be considered equal.
+     */
+    bool operator==(const Cookie &other) const;
+    /*!
+     * Returns true if this cookie is not equal to \a other.
+     */
+    inline bool operator!=(const Cookie &other) const
+    { return !(*this == other); }
+
+    /*!
+     * Returns the "SameSite" option if specified in the cookie string, SameSite::Default if not present.
+     */
+    SameSite sameSitePolicy() const;
+    /*!
+     * Sets the "SameSite" option of this cookie to \a sameSite.
+     */
+    void setSameSitePolicy(SameSite sameSite);
+
+    /*!
+     * Returns the raw form of this %Cookie. The QByteArray returned by this function is suitable for an HTTP header,
+     * either in a server response (the Set-Cookie header) or the client request (the Cookie header).
+     * You can choose from one of two formats, using \a form.
+     */
+    QByteArray toRawForm(RawForm form = Full) const;
+
+private:
+    QSharedDataPointer<CookiePrivate> d;
+};
+
+}
+
+Q_DECLARE_TYPEINFO(Cutelyst::Cookie, Q_MOVABLE_TYPE);
+
+#ifndef QT_NO_DEBUG_STREAM
+class QDebug;
+CUTELYST_LIBRARY QDebug operator<<(QDebug, const Cutelyst::Cookie &);
+#endif
+
+#endif
+
+#endif // CUTELYST_COOKIE_H

--- a/Cutelyst/cookie.h
+++ b/Cutelyst/cookie.h
@@ -13,17 +13,15 @@
 
 namespace Cutelyst {
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 1, 0))
-
-CUTELYST_LIBRARY using Cookie = QNetworkCookie;
-
-#else
 class CookiePrivate;
 /*!
  * \class Cookie cookie.h Cutelyst/Cookie
  * \brief The %Cutelyst %Cookie
  *
- * This is a reimplementation of QNetworkCookie that adds support for the \a SameSite property.
+ * This is an extension of QNetworkCookie that adds support for the \a SameSite property.
+ * QNetworkCookie added support for the SameSite property in Qt 6.1. So, if you are only
+ * using Qt 6.1 or newer, please use QNetworkCookie and the methods that take it as argument
+ * instead.
  *
  * \since Cutelyst 3.8.0
  */
@@ -110,8 +108,6 @@ Q_DECLARE_TYPEINFO(Cutelyst::Cookie, Q_MOVABLE_TYPE);
 #ifndef QT_NO_DEBUG_STREAM
 class QDebug;
 CUTELYST_LIBRARY QDebug operator<<(QDebug, const Cutelyst::Cookie &);
-#endif
-
 #endif
 
 #endif // CUTELYST_COOKIE_H

--- a/Cutelyst/cookie_p.h
+++ b/Cutelyst/cookie_p.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: (C) 2023 Matthias Fehring <mf@huessenbergnetz.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef CUTELYST_COOKIE_P_H
+#define CUTELYST_COOKIE_P_H
+
+#include "cookie.h"
+#include <QSharedData>
+
+namespace Cutelyst {
+
+class CookiePrivate : public QSharedData
+{
+public:
+    CookiePrivate() = default;
+
+    Cookie::SameSite sameSite = Cookie::SameSite::Default;
+};
+
+}
+
+#endif // CUTELYST_COOKIE_P_H

--- a/Cutelyst/enginerequest.cpp
+++ b/Cutelyst/enginerequest.cpp
@@ -99,6 +99,12 @@ void EngineRequest::finalizeCookies()
     for (const QNetworkCookie &cookie : cookies) {
         headers.pushHeader(QStringLiteral("SET_COOKIE"), QString::fromLatin1(cookie.toRawForm()));
     }
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+    const auto cuteCookies = res->cuteCookies();
+    for (const Cookie &cookie : cuteCookies) {
+        headers.pushHeader(QStringLiteral("SET_COOKIE"), QString::fromLatin1(cookie.toRawForm()));
+    }
+#endif
 }
 
 bool EngineRequest::finalizeHeaders()

--- a/Cutelyst/response.cpp
+++ b/Cutelyst/response.cpp
@@ -206,17 +206,41 @@ QVariant Response::cookie(const QByteArray &name) const
     return QVariant::fromValue(d->cookies.value(name));
 }
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+QVariant Response::cuteCookie(const QByteArray &name) const
+{
+    Q_D(const Response);
+    return QVariant::fromValue(d->cuteCookies.value(name));
+}
+#endif
+
 QList<QNetworkCookie> Response::cookies() const
 {
     Q_D(const Response);
     return d->cookies.values();
 }
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+QList<Cookie> Response::cuteCookies() const
+{
+    Q_D(const Response);
+    return d->cuteCookies.values();
+}
+#endif
+
 void Response::setCookie(const QNetworkCookie &cookie)
 {
     Q_D(Response);
     d->cookies.insert(cookie.name(), cookie);
 }
+
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+void Response::setCuteCookie(const Cookie &cookie)
+{
+    Q_D(Response);
+    d->cuteCookies.insert(cookie.name(), cookie);
+}
+#endif
 
 void Response::setCookies(const QList<QNetworkCookie> &cookies)
 {
@@ -226,11 +250,29 @@ void Response::setCookies(const QList<QNetworkCookie> &cookies)
     }
 }
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+void Response::setCuteCookies(const QList<Cookie> &cookies)
+{
+    Q_D(Response);
+    for (const Cookie &cookie : cookies) {
+        d->cuteCookies.insert(cookie.name(), cookie);
+    }
+}
+#endif
+
 int Response::removeCookies(const QByteArray &name)
 {
     Q_D(Response);
     return d->cookies.remove(name);
 }
+
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+int Response::removeCuteCookies(const QByteArray &name)
+{
+    Q_D(Response);
+    return d->cuteCookies.remove(name);
+}
+#endif
 
 void Response::redirect(const QUrl &url, quint16 status)
 {

--- a/Cutelyst/response.h
+++ b/Cutelyst/response.h
@@ -14,6 +14,9 @@ class QNetworkCookie;
 
 namespace Cutelyst {
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+class Cookie;
+#endif
 class Context;
 class Engine;
 class EngineRequest;
@@ -228,10 +231,29 @@ public:
      */
     QVariant cookie(const QByteArray &name) const;
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+    /**
+     * Returns the first Cookie matching the name or a
+     * null QVariant if not found.
+     *
+     * Please read the decription of the Cookie class before using this.
+     */
+    QVariant cuteCookie(const QByteArray &name) const;
+#endif
+
     /**
      * Returns a list of all cookies set
      */
     QList<QNetworkCookie> cookies() const;
+
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+    /**
+     * Returns a list of all %Cutelyst cookies set.
+     *
+     * Please read the decription of the Cookie class before using this.
+     */
+    QList<Cookie> cuteCookies() const;
+#endif
 
     /**
      * Defines a QNetworkCookie to be sent to the user-agent,
@@ -239,17 +261,47 @@ public:
      */
     void setCookie(const QNetworkCookie &cookie);
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+    /**
+     * Defines a Cookie to be sent to the user-agent,
+     * if a previous cookie->name() was set it will be replaced.
+     *
+     * Please read the decription of the Cookie class before using this.
+     */
+    void setCuteCookie(const Cookie &cookie);
+#endif
+
     /**
      * Defines a list of QNetworkCookie to be sent to the user-agent,
      * all previous matches to cookie->name() will be preserved.
      */
     void setCookies(const QList<QNetworkCookie> &cookies);
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+    /**
+     * Defines a list of Cookie to be sent to the user-agent,
+     * all previous matches to cookie->name() will be preserved.
+     *
+     * Please read the decription of the Cookie class before using this.
+     */
+    void setCuteCookies(const QList<Cookie> &cookies);
+#endif
+
     /**
      * Removes all cookies that matches name, returning
      * the number of cookies removed
      */
     int removeCookies(const QByteArray &name);
+
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+    /**
+     * Removes all cookies that matches name, returning
+     * the number of cookies removed.
+     *
+     * Please read the decription of the Cookie class before using this.
+     */
+    int removeCuteCookies(const QByteArray &name);
+#endif
 
     /**
      * Causes the response to redirect to the specified URL. The default status is 302.

--- a/Cutelyst/response_p.h
+++ b/Cutelyst/response_p.h
@@ -6,6 +6,9 @@
 #define CUTELYST_RESPONSE_P_H
 
 #include "response.h"
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+#include "cookie.h"
+#endif
 
 #include <QtCore/QUrl>
 #include <QtCore/QMap>
@@ -25,6 +28,9 @@ public:
 
     Headers headers;
     QMap<QByteArray, QNetworkCookie> cookies;
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+    QMap<QByteArray, Cookie> cuteCookies;
+#endif
     QByteArray bodyData;
     QUrl location;
     QIODevice *bodyIODevice = nullptr;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,10 @@ cutelyst_templates_unit_tests(
     testactionrenderview
 )
 
+if (${QT_VERSION} VERSION_LESS "6.1.0")
+    cute_test(testcookie "" "" "")
+endif (${QT_VERSION} VERSION_LESS "6.1.0")
+
 cute_test(testvalidator Cutelyst${PROJECT_VERSION_MAJOR}Qt${QT_VERSION_MAJOR}::Utils::Validator "" "")
 
 cute_test(testauthentication Cutelyst${PROJECT_VERSION_MAJOR}Qt${QT_VERSION_MAJOR}::Authentication Cutelyst${PROJECT_VERSION_MAJOR}Qt${QT_VERSION_MAJOR}::Session "")

--- a/tests/testauthentication.cpp
+++ b/tests/testauthentication.cpp
@@ -8,6 +8,9 @@
 
 #include "headers.h"
 #include "coverageobject.h"
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+#include "cookie.h"
+#endif
 
 #include <Cutelyst/Plugins/Authentication/authentication.h>
 #include <Cutelyst/Plugins/Authentication/authenticationuser.h>
@@ -129,7 +132,11 @@ public:
     C_ATTR(authenticate_user_cookie, :Local :AutoArgs)
     void authenticate_user_cookie(Context *c, const QString &realm) {
         Authentication::authenticate(c, c->request()->queryParameters(), realm);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 1, 0))
         const auto cookie = c->response()->cookie(QByteArrayLiteral("testauthentication_exec_session")).value<QNetworkCookie>();
+#else
+        const auto cookie = c->response()->cuteCookie(QByteArrayLiteral("testauthentication_exec_session")).value<Cookie>();
+#endif
         if (cookie.isHttpOnly() && cookie.path().compare(u"/") == 0) {
             c->response()->setBody(QStringLiteral("ok"));
             return;

--- a/tests/testcookie.cpp
+++ b/tests/testcookie.cpp
@@ -1,0 +1,173 @@
+#ifndef COOKIETEST_H
+#define COOKIETEST_H
+
+#include <QTest>
+#include <QLocale>
+
+#include "coverageobject.h"
+
+#include <Cutelyst/cookie.h>
+
+using namespace Cutelyst;
+
+class TestCookie : public CoverageObject
+{
+    Q_OBJECT
+public:
+    explicit TestCookie(QObject *parent = nullptr) : CoverageObject(parent) {}
+
+private Q_SLOTS:
+    void testDefaultConstructor();
+    void testConstructorWithArgs();
+    void testSetSameSite();
+    void testCopy();
+    void testMove();
+    void testCompare();
+    void testToRawForm();
+    void testToRawForm_data();
+};
+
+void TestCookie::testDefaultConstructor()
+{
+    Cookie c;
+    QVERIFY(c.domain().isEmpty());
+    QVERIFY(!c.isHttpOnly());
+    QVERIFY(!c.isSecure());
+    QVERIFY(c.isSessionCookie());
+    QVERIFY(c.name().isEmpty());
+    QVERIFY(c.path().isEmpty());
+    QCOMPARE(c.sameSitePolicy(), Cookie::SameSite::Default);
+    QVERIFY(c.value().isEmpty());
+}
+
+void TestCookie::testConstructorWithArgs()
+{
+    Cookie c(QByteArrayLiteral("foo"), QByteArrayLiteral("bar"));
+    QVERIFY(c.domain().isEmpty());
+    QVERIFY(!c.isHttpOnly());
+    QVERIFY(!c.isSecure());
+    QVERIFY(c.isSessionCookie());
+    QCOMPARE(c.name(), QByteArrayLiteral("foo"));
+    QVERIFY(c.path().isEmpty());
+    QCOMPARE(c.sameSitePolicy(), Cookie::SameSite::Default);
+    QCOMPARE(c.value(), QByteArrayLiteral("bar"));
+}
+
+void TestCookie::testSetSameSite()
+{
+    Cookie c(QByteArrayLiteral("foo"), QByteArrayLiteral("bar"));
+    c.setSameSitePolicy(Cookie::SameSite::Strict);
+    QCOMPARE(c.sameSitePolicy(), Cookie::SameSite::Strict);
+}
+
+void TestCookie::testCopy()
+{
+    // test copy constructor
+    {
+        Cookie c1(QByteArrayLiteral("foo"), QByteArrayLiteral("bar"));
+        c1.setPath(QStringLiteral("/"));
+        c1.setSameSitePolicy(Cookie::SameSite::Strict);
+        Cookie c2(c1);
+
+        QCOMPARE(c1.name(), c2.name());
+        QCOMPARE(c1.value(), c2.value());
+        QCOMPARE(c1.path(), c2.path());
+        QCOMPARE(c1.sameSitePolicy(), c2.sameSitePolicy());
+    }
+
+    // test copy assignment
+    {
+        Cookie c1(QByteArrayLiteral("foo"), QByteArrayLiteral("bar"));
+        c1.setPath(QStringLiteral("/"));
+        c1.setSameSitePolicy(Cookie::SameSite::Strict);
+        Cookie c2;
+        c2 = c1;
+
+        QCOMPARE(c1.name(), c2.name());
+        QCOMPARE(c1.value(), c2.value());
+        QCOMPARE(c1.path(), c2.path());
+        QCOMPARE(c1.sameSitePolicy(), c2.sameSitePolicy());
+    }
+}
+
+void TestCookie::testMove()
+{
+    // test move assignment
+    {
+        Cookie c1(QByteArrayLiteral("foo"), QByteArrayLiteral("bar"));
+        c1.setPath(QStringLiteral("/"));
+        c1.setSameSitePolicy(Cookie::SameSite::Strict);
+        Cookie c2(QByteArrayLiteral("key"), QByteArrayLiteral("val"));
+        c2.setPath(QStringLiteral("/path"));
+        c2.setSameSitePolicy(Cookie::SameSite::Lax);
+        c2 = std::move(c1);
+
+        QCOMPARE(c2.name(), QByteArrayLiteral("foo"));
+        QCOMPARE(c2.value(), QByteArrayLiteral("bar"));
+        QCOMPARE(c2.path(), QStringLiteral("/"));
+        QCOMPARE(c2.sameSitePolicy(), Cookie::SameSite::Strict);
+    }
+}
+
+void TestCookie::testCompare()
+{
+    Cookie c1(QByteArrayLiteral("foo"), QByteArrayLiteral("bar"));
+    c1.setPath(QStringLiteral("/"));
+    c1.setSameSitePolicy(Cookie::SameSite::Strict);
+    Cookie c2(QByteArrayLiteral("foo"), QByteArrayLiteral("bar"));
+    c2.setPath(QStringLiteral("/"));
+    c2.setSameSitePolicy(Cookie::SameSite::Strict);
+    Cookie c3 = c1;
+    Cookie c4(QByteArrayLiteral("key"), QByteArrayLiteral("val"));
+    c4.setPath(QStringLiteral("/path"));
+    c4.setSameSitePolicy(Cookie::SameSite::Lax);
+
+    QVERIFY(c1 == c2);
+    QVERIFY(c1 == c3);
+    QVERIFY(c1 != c4);
+}
+
+void TestCookie::testToRawForm()
+{
+    QFETCH(Cookie, cookie);
+    QFETCH(QByteArray, result);
+
+    QCOMPARE(cookie.toRawForm(), result);
+}
+
+void TestCookie::testToRawForm_data()
+{
+    QTest::addColumn<Cookie>("cookie");
+    QTest::addColumn<QByteArray>("result");
+
+    Cookie c(QByteArrayLiteral("foo"), QByteArrayLiteral("bar"));
+    QTest::newRow("1") << c << QByteArrayLiteral("foo=bar");
+
+    c.setSecure(true);
+    QTest::newRow("2") << c << QByteArrayLiteral("foo=bar; secure");
+
+    c.setHttpOnly(true);
+    QTest::newRow("3") << c << QByteArrayLiteral("foo=bar; secure; HttpOnly");
+
+    c.setSameSitePolicy(Cookie::SameSite::Strict);
+    QTest::newRow("4") << c << QByteArrayLiteral("foo=bar; secure; HttpOnly; SameSite=Strict");
+
+    const auto expire = QDateTime::currentDateTimeUtc().addDays(1);
+    c.setExpirationDate(expire);
+    QByteArray result = QByteArrayLiteral("foo=bar; secure; HttpOnly; SameSite=Strict; expires=");
+    result.append(QLocale::c().toString(expire, QStringLiteral("ddd, dd-MMM-yyyy hh:mm:ss 'GMT")).toLatin1());
+    QTest::newRow("5") << c << result;
+
+    c.setExpirationDate(QDateTime());
+    c.setDomain(QStringLiteral("example.net"));
+    QTest::newRow("6") << c << QByteArrayLiteral("foo=bar; secure; HttpOnly; SameSite=Strict; domain=example.net");
+
+    c.setPath(QStringLiteral("/somewhere"));
+    QTest::newRow("7") << c << QByteArrayLiteral("foo=bar; secure; HttpOnly; SameSite=Strict; domain=example.net; path=/somewhere");
+}
+
+QTEST_MAIN(TestCookie)
+
+#include "testcookie.moc"
+
+#endif


### PR DESCRIPTION
This adds the SameSite attribute to some cookies set by plugins like Session, CSRFProtection and LangSelect if compiled against Qt 6.1+. For the Session and CSRFProtection plugins the attribute is configurable and set to Strict by default. For the LangSelect plugin the attribute is set to Lax.

I am not sure if Strict might be to hard as default. Maybe Lax as default would be better for backwards compatibility as browsers should use Lax for Cookies without SameSite attribute. What do you think @dantti ?