### PR TITLE
Use variadic version of QMetaMethod::invoke() on Qt 6.5 (closes #391)

### DIFF
--- a/Cutelyst/action.cpp
+++ b/Cutelyst/action.cpp
@@ -141,6 +141,9 @@ bool Action::doExecute(Context *c)
     }
 
     bool ret;
+
+#if (QT_VERSION < QT_VERSION_CHECK(6, 5, 0))
+
     if (d->evaluateBool) {
         bool methodRet;
 
@@ -207,6 +210,139 @@ bool Action::doExecute(Context *c)
         c->setState(ret);
         return ret;
     }
+
+#else
+
+    /*
+     * Qt 6.5 introduced a new variadic version of QMetaMethod::invoke() that
+     * does not work with our current implementation above. The following code
+     * is a fast fix to use the new version but there might be better / more elegant
+     * approaches.
+     *
+     * See: https://codereview.qt-project.org/c/qt/qtbase/+/422745
+     *
+     * TODO: check for more flexible implementation
+     */
+
+    if (d->evaluateBool) {
+        bool methodRet;
+
+        if (d->listSignature) {
+
+            QStringList args = c->request()->args();
+
+            ret = d->method.invoke(d->controller,
+                                   Qt::DirectConnection,
+                                   qReturnArg(methodRet),
+                                   c,
+                                   args);
+        } else {
+            QStringList args = c->request()->args();
+            // Fill the missing arguments
+            args.append(d->emptyArgs);
+
+            switch (d->method.parameterCount()) {
+            case 0:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet));
+                break;
+            case 1:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c);
+                break;
+            case 2:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0));
+                break;
+            case 3:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1));
+                break;
+            case 4:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2));
+                break;
+            case 5:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2), args.value(3));
+                break;
+            case 6:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4));
+                break;
+            case 7:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5));
+                break;
+            case 8:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5), args.value(6));
+                break;
+            case 9:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5), args.value(6), args.value(7));
+                break;
+            default:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5), args.value(6), args.value(7), args.value(8));
+                break;
+            }
+        }
+
+        if (ret) {
+            c->setState(methodRet);
+            return methodRet;
+        }
+
+        // The method failed to be called which means we should detach
+        c->detach();
+        c->setState(false);
+
+        return false;
+    } else {
+        if (d->listSignature) {
+
+            QStringList args = c->request()->args();
+
+            ret = d->method.invoke(d->controller,
+                                   Qt::DirectConnection,
+                                   c,
+                                   args);
+        } else {
+            QStringList args = c->request()->args();
+            // Fill the missing arguments
+            args.append(d->emptyArgs);
+
+            switch (d->method.parameterCount()) {
+            case 0:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection);
+                break;
+            case 1:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, c);
+                break;
+            case 2:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0));
+                break;
+            case 3:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1));
+                break;
+            case 4:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2));
+                break;
+            case 5:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2), args.value(3));
+                break;
+            case 6:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4));
+                break;
+            case 7:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5));
+                break;
+            case 8:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5), args.value(6));
+                break;
+            case 9:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5), args.value(6), args.value(7));
+                break;
+            default:
+                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5), args.value(6), args.value(7), args.value(8));
+                break;
+            }
+        }
+        c->setState(ret);
+        return ret;
+    }
+
+#endif
 }
 
 #include "moc_action.cpp"

--- a/Cutelyst/action.cpp
+++ b/Cutelyst/action.cpp
@@ -224,23 +224,18 @@ bool Action::doExecute(Context *c)
      * TODO: check for more flexible implementation
      */
 
+    const QStringList args = c->request()->args();
+
     if (d->evaluateBool) {
         bool methodRet;
 
         if (d->listSignature) {
-
-            QStringList args = c->request()->args();
-
             ret = d->method.invoke(d->controller,
                                    Qt::DirectConnection,
                                    qReturnArg(methodRet),
                                    c,
                                    args);
         } else {
-            QStringList args = c->request()->args();
-            // Fill the missing arguments
-            args.append(d->emptyArgs);
-
             switch (d->method.parameterCount()) {
             case 0:
                 ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet));
@@ -290,18 +285,11 @@ bool Action::doExecute(Context *c)
         return false;
     } else {
         if (d->listSignature) {
-
-            QStringList args = c->request()->args();
-
             ret = d->method.invoke(d->controller,
                                    Qt::DirectConnection,
                                    c,
                                    args);
         } else {
-            QStringList args = c->request()->args();
-            // Fill the missing arguments
-            args.append(d->emptyArgs);
-
             switch (d->method.parameterCount()) {
             case 0:
                 ret = d->method.invoke(d->controller, Qt::DirectConnection);

--- a/Cutelyst/action_p.h
+++ b/Cutelyst/action_p.h
@@ -19,6 +19,7 @@ public:
     QMetaMethod method;
     QMultiMap<QString, QString> attributes;
     Controller *controller = nullptr;
+#if (QT_VERSION < QT_VERSION_CHECK(6, 5, 0))
     QStringList emptyArgs  = {
          QString(),
          QString(),
@@ -30,6 +31,7 @@ public:
          QString(),
          QString(),
     };
+#endif
     qint8 numberOfArgs     = -1;
     qint8 numberOfCaptures = -1;
     bool evaluateBool      = false;


### PR DESCRIPTION
Qt 6.5 introduced a new variadic version of QMetaMethod::invoke() that does not work with our current implementation. This adds a fast fix to use the new variadic version of QMetaMethod::invoke() on Qt 6.5+ but there might be better / more elegant approaches to fix the issue.