### PR TITLE
Validator plugin: fix missing implementation for ValidatorResult::errors

### DIFF
--- a/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorresult.cpp
@@ -60,6 +60,11 @@ QHash<QString, QStringList> ValidatorResult::errors() const
     return d->errors;
 }
 
+QStringList ValidatorResult::errors(const QString &field) const
+{
+    return d->errors.value(field);
+}
+
 bool ValidatorResult::hasErrors(const QString &field) const
 {
     return d->errors.contains(field);


### PR DESCRIPTION
ValidatorResult::errors(const QString &field) had no implementation.