### PR TITLE
Add Context::qtTrId() method to support ID based translations

### DIFF
--- a/Cutelyst/action.cpp
+++ b/Cutelyst/action.cpp
@@ -230,45 +230,112 @@ bool Action::doExecute(Context *c)
         bool methodRet;
 
         if (d->listSignature) {
-            ret = d->method.invoke(d->controller,
-                                   Qt::DirectConnection,
-                                   qReturnArg(methodRet),
-                                   c,
-                                   args);
+            ret = d->method.invoke(
+                d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args);
         } else {
             switch (d->method.parameterCount()) {
             case 0:
                 ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet));
                 break;
             case 1:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c);
+                ret =
+                    d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c);
                 break;
             case 2:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0));
+                ret = d->method.invoke(
+                    d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0));
                 break;
             case 3:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       qReturnArg(methodRet),
+                                       c,
+                                       args.value(0),
+                                       args.value(1));
                 break;
             case 4:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       qReturnArg(methodRet),
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2));
                 break;
             case 5:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2), args.value(3));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       qReturnArg(methodRet),
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2),
+                                       args.value(3));
                 break;
             case 6:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       qReturnArg(methodRet),
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2),
+                                       args.value(3),
+                                       args.value(4));
                 break;
             case 7:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       qReturnArg(methodRet),
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2),
+                                       args.value(3),
+                                       args.value(4),
+                                       args.value(5));
                 break;
             case 8:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5), args.value(6));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       qReturnArg(methodRet),
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2),
+                                       args.value(3),
+                                       args.value(4),
+                                       args.value(5),
+                                       args.value(6));
                 break;
             case 9:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5), args.value(6), args.value(7));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       qReturnArg(methodRet),
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2),
+                                       args.value(3),
+                                       args.value(4),
+                                       args.value(5),
+                                       args.value(6),
+                                       args.value(7));
                 break;
             default:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, qReturnArg(methodRet), c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5), args.value(6), args.value(7), args.value(8));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       qReturnArg(methodRet),
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2),
+                                       args.value(3),
+                                       args.value(4),
+                                       args.value(5),
+                                       args.value(6),
+                                       args.value(7),
+                                       args.value(8));
                 break;
             }
         }
@@ -285,10 +352,7 @@ bool Action::doExecute(Context *c)
         return false;
     } else {
         if (d->listSignature) {
-            ret = d->method.invoke(d->controller,
-                                   Qt::DirectConnection,
-                                   c,
-                                   args);
+            ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args);
         } else {
             switch (d->method.parameterCount()) {
             case 0:
@@ -301,28 +365,85 @@ bool Action::doExecute(Context *c)
                 ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0));
                 break;
             case 3:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1));
+                ret = d->method.invoke(
+                    d->controller, Qt::DirectConnection, c, args.value(0), args.value(1));
                 break;
             case 4:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2));
                 break;
             case 5:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2), args.value(3));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2),
+                                       args.value(3));
                 break;
             case 6:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2),
+                                       args.value(3),
+                                       args.value(4));
                 break;
             case 7:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2),
+                                       args.value(3),
+                                       args.value(4),
+                                       args.value(5));
                 break;
             case 8:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5), args.value(6));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2),
+                                       args.value(3),
+                                       args.value(4),
+                                       args.value(5),
+                                       args.value(6));
                 break;
             case 9:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5), args.value(6), args.value(7));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2),
+                                       args.value(3),
+                                       args.value(4),
+                                       args.value(5),
+                                       args.value(6),
+                                       args.value(7));
                 break;
             default:
-                ret = d->method.invoke(d->controller, Qt::DirectConnection, c, args.value(0), args.value(1), args.value(2), args.value(3), args.value(4), args.value(5), args.value(6), args.value(7), args.value(8));
+                ret = d->method.invoke(d->controller,
+                                       Qt::DirectConnection,
+                                       c,
+                                       args.value(0),
+                                       args.value(1),
+                                       args.value(2),
+                                       args.value(3),
+                                       args.value(4),
+                                       args.value(5),
+                                       args.value(6),
+                                       args.value(7),
+                                       args.value(8));
                 break;
             }
         }

--- a/Cutelyst/action_p.h
+++ b/Cutelyst/action_p.h
@@ -18,7 +18,7 @@ public:
     QMultiMap<QString, QString> attributes;
     Controller *controller = nullptr;
 #if (QT_VERSION < QT_VERSION_CHECK(6, 5, 0))
-    QStringList emptyArgs  = {
+    QStringList emptyArgs = {
         QString(),
         QString(),
         QString(),

--- a/Cutelyst/context.h
+++ b/Cutelyst/context.h
@@ -506,6 +506,40 @@ public:
                       const char *sourceText,
                       const char *disambiguation = nullptr,
                       int n                      = -1) const;
+    /**
+     * Finds and returns a translated string.
+     *
+     * Returns a translated string identified by \a id. If no matching string is found,
+     * the \a id itself is returned. This can be used similar to Qt’s global %qtTrId()
+     * function.
+     *
+     * If \a n >= 0, all occurences of %%n in the resulting string are replaced with a
+     * decimal representationof \a n. In addition, appending \a n’s value, the translation
+     * may vary.
+     *
+     * Meta data and comments can be passed as documented for QObject::tr(). In addition,
+     * it is possible to supply a source string template like that:
+     *
+     * <pre>//% &lt;C string&gt;</pre>
+     *
+     * or
+     *
+     * <pre>\begincomment% &lt;C string&gt; \endcomment</pre>
+     *
+     * Example:
+     * \code{.cpp}
+     * void MyController::index(Context *c)
+     * {
+     *      //% "%n fooish bar(s) found.\n"
+     *      //% "Do you want to continue?"
+     *      c->res()->setBody(c->qtTrId("my-app-translation-id", n));
+     * }
+     * \endcode
+     *
+     * Creating QM files suitable for use with this function requires passing the \c -idbased
+     * option to the \c lrelease tool.
+     */
+    inline QString qtTrId(const char *id, int n = -1) const;
 
 public Q_SLOTS:
     /*!
@@ -547,6 +581,11 @@ inline QUrl Context::uriFor(Action *action, const ParamsMultiMap &queryValues) c
 inline QUrl Context::uriForAction(const QString &path, const ParamsMultiMap &queryValues) const
 {
     return uriForAction(path, QStringList(), QStringList(), queryValues);
+}
+
+inline QString Context::qtTrId(const char *id, int n) const
+{
+    return translate(nullptr, id, nullptr, n);
 }
 
 } // namespace Cutelyst

--- a/Cutelyst/context.h
+++ b/Cutelyst/context.h
@@ -514,7 +514,7 @@ public:
      * function.
      *
      * If \a n >= 0, all occurences of %%n in the resulting string are replaced with a
-     * decimal representationof \a n. In addition, appending \a n’s value, the translation
+     * decimal representation of \a n. In addition, appending \a n’s value, the translation
      * may vary.
      *
      * Meta data and comments can be passed as documented for QObject::tr(). In addition,
@@ -538,6 +538,8 @@ public:
      *
      * Creating QM files suitable for use with this function requires passing the \c -idbased
      * option to the \c lrelease tool.
+     *
+     * \since Cutelyst 3.9.0
      */
     inline QString qtTrId(const char *id, int n = -1) const;
 


### PR DESCRIPTION
This adds Context::qtTrId() method that works similar to Qt’s global qtTrId() function and supports ID based translations without specifying a context like with Context::translate().