### PR TITLE
Fix Headers::removeHeader() and add tests

### DIFF
--- a/Cutelyst/headers.cpp
+++ b/Cutelyst/headers.cpp
@@ -460,7 +460,7 @@ void Headers::pushHeader(const QByteArray &key, const QByteArrayList &values)
 void Headers::removeHeader(QByteArrayView key)
 {
     m_data.removeIf(
-        [key](HeaderKeyValue entry) { return key.compare(entry.key, Qt::CaseInsensitive); });
+        [key](HeaderKeyValue entry) { return key.compare(entry.key, Qt::CaseInsensitive) == 0; });
 }
 
 bool Headers::contains(QByteArrayView key) const

--- a/tests/testheaders.cpp
+++ b/tests/testheaders.cpp
@@ -140,6 +140,12 @@ void TestHeaders::testCombining()
     headers.clear();
     headers.setContentDispositionAttachment("foo.txt");
     QCOMPARE(headers.contentDisposition(), "attachment; filename=\"foo.txt\"");
+
+    headers.setHeader("x-hbn-foo", "bar");
+    QVERIFY(headers.contains("x-hbn-foo"));
+
+    headers.removeHeader("x-hbn-foo");
+    QVERIFY(!headers.contains("x-hbn-foo"));
 }
 
 QTEST_MAIN(TestHeaders)


### PR DESCRIPTION
The compare in the lambda for the QVector::removeIf missed the 0 to compare against. I also added a test for Headers::removeHeader(). This also fixes the issues with the tests for the LangSelect and CSRFProtection plugins that relied on Headers::removeHeader().