### PR TITLE
CSRFProtection plugin: add constructor with default config

### DIFF
--- a/Cutelyst/Plugins/CSRFProtection/csrfprotection_p.h
+++ b/Cutelyst/Plugins/CSRFProtection/csrfprotection_p.h
@@ -48,6 +48,7 @@ public:
     static const QString stashKeyProcessingDone;
     static const QString stashKeyCheckPassed;
 
+    QVariantMap defaultConfig;
     QStringList trustedOrigins;
     static const QByteArrayList secureMethods;
     QStringList ignoredNamespaces;


### PR DESCRIPTION
Add a constructor that takes a QVariantMap to override the default values for config file entries.