### PR TITLE
StaticCompressed plugin: add constructor with deafult config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,8 @@ if (BUILD_DOCS)
             "gr_tag{1}=<tt>{%&nbsp\;\\1&nbsp\;%}</tt>"
             "gr_var{1}=<tt>{{&nbsp\;\\1&nbsp\;}}</tt>"
             "accessors=\\par Accessors:^^"
+            "configblock{3}=\\par \\1^^\\parblock^^<tt>Type: \\2<br>Default: \\3</tt> ^^"
+            "endconfigblock=\\endparblock"
         )
         set(DOXYGEN_BUILTIN_STL_SUPPORT "YES")
         # Build related configuration options

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed.h
@@ -23,22 +23,22 @@ class StaticCompressedPrivate;
  * HREF="https://en.wikipedia.org/wiki/Brotli">Brotli</A> compression algorithm and to use <A
  * HREF="https://en.wikipedia.org/wiki/Zopfli">Zopfli</A> for @a gzip compression. Beside
  * compressing the raw data on the fly and store the result in a cache directory, it supports
- * pre-compressed files distinguished by file extension in the static source directories. The plugin
- * uses the @a Accept-Encoding HTTP request header to determine the compression methods supported by
- * the user agent. If you do not need this, use the StaticSimple plugin to deliver your static
- * files.
+ * pre-compressed files distinguished by file extension in the static source directories. The
+ * plugin uses the @a Accept-Encoding HTTP request header to determine the compression methods
+ * supported by the user agent. If you do not need this, use the StaticSimple plugin to serve
+ * your static files.
  *
  * <H3>Compression formats</H3>
  *
  * Support for @a gzip and @a DEFLATE compression format is built in by using the
  * @link QByteArray::qCompress() qCompress()@endlink function. To enable suport for
  * <A HREF="https://en.wikipedia.org/wiki/Brotli">Brotli</A>, build
- * with @c-DPLUGIN_STATICCOMPRESSED_BROTLI@c:BOOL=ON and have the
+ * with <TT>-DPLUGIN_STATICCOMPRESSED_BROTLI:BOOL=ON</TT> and have the
  * <A HREF="https://github.com/google/brotli">libbrotlienc</A> development and header files
  * available.
  *
  * To use <A HREF="https://en.wikipedia.org/wiki/Zopfli">Zopfli</A> for the @a gzip compression,
- * build with @c-DPLUGIN_STATICCOMPRESSED_ZOPFLI@c:BOOL=ON and have the <A
+ * build with <TT>-DPLUGIN_STATICCOMPRESSED_ZOPFLI:BOOL=ON</TT> and have the <A
  * HREF="https://github.com/google/zopfli">libzopfli</A> development and header files available.
  * Also set the configuration key @c use_zopfli to @c true. Be aware that @a Zopfli gives better
  * compression rate than default @a gzip but is also much slower. So @a Zopfli is disabled by
@@ -46,23 +46,23 @@ class StaticCompressedPrivate;
  *
  * <H3>On the fly compression</H3>
  *
- * Static files of the configured @c mime_types or with the configured @c suffixes can be compressed
- * on the fly into a format that is accepted by the requesting user agent. The compressed data is
- * saved into files in the @c cache_diretory specified in the configuration. The cache file name
- * will be the MD5 hash sum of the original local file path together with the file extension
- * indicating the compression format
- * (.br for Brotli, .gz for gzip/Zopfli and .deflate for DEFLATE). If the modification time of the
- * original file is newer than the modification time of the cached compressed file, the file will be
- * compressed again. It is safe to clean the content of the cache directory - the files will than be
- * recompressed on the next request. On the fly compression can be disabled by setting @c
- * on_the_fly_compression to @c false in the configuration file.
+ * Static files of the <A HREF="#configfile">configured</A> @c mime_types or with the configured
+ * @c suffixes can be compressed on the fly into a format that is accepted by the requesting user
+ * agent. The compressed data is saved into files in the @c cache_diretory specified in the
+ * configuration. The cache file name will be the MD5 hash sum of the original local file path
+ * together with the file extension indicating the compression format (.br for Brotli, .gz for
+ * gzip/Zopfli and .deflate for DEFLATE). If the modification time of the original file is newer
+ * than the modification time of the cached compressed file, the file will be compressed again.
+ * It is safe to clean the content of the cache directory - the files will then be recompressed
+ * on the next request. On the fly compression can be disabled by setting @c on_the_fly_compression
+ * to @c false in the configuration file.
  *
  * <H3>Pre-compressed files</H3>
  *
  * Beside the cached on the fly compression it is also possible to serve pre-compressed static
- * files that are saved in the same place as the original files are. The %StaticCompressed plugin
- * will try to find a compressed file at the same path as the original file appended by an extension
- * indicating the compression method. So if you have for example boostrap.min.css and
+ * files that are available from the same directories as the original files. The %StaticCompressed
+ * plugin will try to find a compressed file at the same path as the original file appended by an
+ * extension indicating the compression method. So if you have for example boostrap.min.css and
  * bootstrap.min.css.gz in your static files directory, the plugin will serve the compressed
  * variant if the requesting user agent supports the gzip encoding. The delivery of pre-compressed
  * files can be disabled by setting @c check_pre_compressed to @c false in the configuration file.
@@ -81,28 +81,50 @@ class StaticCompressedPrivate;
  * set setServeDirsOnly() to @c true (since %Cutelyst 4.0.0) to only serve files beginning with
  * these paths. Have a look at setDirs() to learn more.
  *
- * <H3>Runtime configuration</H3>
+ * <H3 ID="configfile">Runtime configuration</H3>
  *
- * The plugin offers some configuration options that can be set in the Cutelyst application
- * configuration file in the @c Cutelyst_StaticCompressed_Plugin section.
- * @li @c cache_directory - string value, sets the directory where on the fly compressed data is
- * saved (default: QStandardPaths::CacheLocation + /compressed-static)
- * @li @c mime_types - string value, comma separated list of MIME types that should be compressed
- * (default: text/css,application/javascript,text/javascript)
- * @li @c suffixes - string value, comma separted list of file suffixes/extensions that should be
- * compressed (default: js.map,css.map,min.js.map,min.css.map)
- * @li @c check_pre_compressed - boolean value, enables or disables the check for pre compressed
- * files (default: true)
- * @li @c on_the_fly_compression - boolean value, enables or disables the compression on the fly
- * (default: true)
- * @li @c zlib_compression_level - integer value, compression level for built in zlib based
- * compression between 0 and 9, with 9 corresponding to the greatest compression (default: 9)
- * @li @c brotli_quality_level - integer value, quality level for optional @a Brotli compression
- * between 0 and 11, with 11 corresponding to the greates compression (default: 11)
- * @li @c use_zopfli - boolean value, enables the optional use of @a Zopfli for the @a gzip
- * compression if available
- * @li @c zopfli_iterations - integer value, number of iterations used for @a Zopfli compression,
- * more gives more compression but is slower (default: 15)
+ * The plugin offers some configuration options that can be set in the %Cutelyst application
+ * configuration file in the @c Cutelyst_StaticCompressed_Plugin section. You can override the
+ * defaults by setting a QVariantMap with selected default values to the constructor.
+ *
+ * @configblock{cache_directory,string,QStandardPaths::CacheLocation + /compressed-static}
+ * Sets the directory path where on the fly compressed data is saved.
+ * @endconfigblock
+ *
+ * @configblock{mime_types,string,text/css\,application/javascript\,text/javascript}
+ * Comma separated list of MIME types that should be compressed.
+ * @endconfigblock
+ *
+ * @configblock{suffixes,string,js.map\,css.map\,min.js.map\,min.css.map}
+ * Comma separted list of file suffixes/extensions that should be compressed.
+ * @endconfigblock
+ *
+ * @configblock{check_pre_compressed,bool,true}
+ * Enables or disables the check for pre compressed files.
+ * @endconfigblock
+ *
+ * @configblock{on_the_fly_compression,bool,true}
+ * Enables or disables the compression on the fly.
+ * @endconfigblock
+ *
+ * @configblock{zlib_compression_level,integer,9}
+ * Compression level for built in zlib based compression between 0 and 9, with 9 corresponding
+ * to the best compression.
+ * @endconfigblock
+ *
+ * @configblock{brotli_quality_level,integer,11}
+ * Quality level for @a Brotli compression between 0 and 11, with 11 corresponding to the
+ * best compression.
+ * @endconfigblock
+ *
+ * @configblock{use_zopfli,bool,false}
+ * Enables the optional use of @a Zopfli for the @a gzip compression. Note that @a Zopfli gives
+ * much better compression results for the cost of a slower compression.
+ * @endconfigblock
+ *
+ * @configblock{zopfli_iterations,integer,15}
+ * Number of iterations used for @a Zopfli compression, more gives better compression but is slower.
+ * @endconfigblock
  *
  * <H3>Usage example</H3>
  *
@@ -114,7 +136,9 @@ class StaticCompressedPrivate;
  *     // other initialization stuff
  *     // ...
  *
- *     auto staticCompressed = new StaticCompressed(this);
+ *     // constructs a new plugin and sets the default value for
+ *     // the config file option use_zopfli to true
+ *     auto staticCompressed = new StaticCompressed(this, {{"use_zopfli", true}});
  *     staticCompressed->setIncludePaths({QStringLiteral("/path/to/my/static/files")});
  *
  *     // maybe more initialization stuff
@@ -136,6 +160,9 @@ class StaticCompressedPrivate;
  * \c CUTELYST_STATICCOMPRESSED_WITH_BROTLI are defined if you need to know that the plugin supports
  * that compressions.
  *
+ * @par Logging category
+ * @c cutelyst.plugin.csrfprotection
+ *
  * @since %Cutelyst 1.11.0
  * @sa StaticSimple
  * @headerfile "" <Cutelyst/Plugins/StaticCompressed/StaticCompressed>
@@ -148,9 +175,19 @@ class CUTELYST_PLUGIN_STATICCOMPRESSED_EXPORT // clazy:exclude=ctor-missing-pare
     Q_DISABLE_COPY(StaticCompressed)
 public:
     /**
-     * Constructs a new StaticCompressed object with the given @a parent.
+     * Constructs a new %StaticCompressed plugin with the given @a parent.
      */
     explicit StaticCompressed(Application *parent);
+
+    /**
+     * Constructs a new %StaticCompressed plugin with the given @a parent and @a defaultConfig.
+     *
+     * Use the @a defaultConfig to set default values for the configuration entries from
+     * the <A HREF="#configfile">configuration file</A>.
+     *
+     * @since %Cutelyst 4.0.0
+     */
+    StaticCompressed(Application *parent, const QVariantMap &defaultConfig);
 
     /**
      * Deconstructs the StaticCompressed object.
@@ -204,7 +241,7 @@ public:
 
     /**
      * Configures the plugin by reading the @c Cutelyst_StaticCompressed_Plugin section
-     * from the Cutelyst application configuration file and connects to the
+     * from the %Cutelyst application configuration file and connects to the
      * Application::beforePrepareAction() signal. Returns @c false if the cache directory
      * can not be created or if it not exists.
      */

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
@@ -36,6 +36,7 @@ public:
     [[nodiscard]] bool compressBrotli(const QString &inputPath, const QString &outputPath) const;
 #endif
 
+    QVariantMap defaultConfig;
     QStringList dirs;
     QStringList mimeTypes;
     QStringList suffixes;


### PR DESCRIPTION
Add a constructor that takes a QVariantMap to override the default values for config file entries.