### PR TITLE
Application: add default locale setting

### DIFF
--- a/Cutelyst/application.cpp
+++ b/Cutelyst/application.cpp
@@ -376,6 +376,7 @@ void Application::handleRequest(EngineRequest *request)
     priv->engineRequest = request;
     priv->response      = new Response(d->headers, request);
     priv->request       = new Request(request);
+    priv->locale        = d->defaultLocale;
 
     if (d->useStats) {
         priv->stats = new Stats(request);
@@ -633,6 +634,18 @@ QVector<QLocale> Application::loadTranslationsFromDirs(const QString &directory,
     }
 
     return locales;
+}
+
+QLocale Application::defaultLocale() const noexcept
+{
+    Q_D(const Application);
+    return d->defaultLocale;
+}
+
+void Application::setDefaultLocale(const QLocale &locale)
+{
+    Q_D(Application);
+    d->defaultLocale = locale;
 }
 
 void Cutelyst::ApplicationPrivate::setupHome()

--- a/Cutelyst/application.h
+++ b/Cutelyst/application.h
@@ -210,7 +210,7 @@ public:
      * @sa loadTranslationsFromDir() loadTranslationsFromDirs()
      * @sa @ref translations
      *
-     * @since Cutelyst 1.5.0
+     * @since %Cutelyst 1.5.0
      */
     void addTranslator(const QLocale &locale, QTranslator *translator);
 
@@ -223,7 +223,7 @@ public:
      *
      * @sa @ref translations
      *
-     * @since Cutelyst 1.5.0
+     * @since %Cutelyst 1.5.0
      */
     void addTranslator(const QString &locale, QTranslator *translator);
 
@@ -237,7 +237,7 @@ public:
      * @sa addTranslator()
      * @sa @ref translations
      *
-     * @since Cutelyst 1.5.0
+     * @since %Cutelyst 1.5.0
      */
     void addTranslators(const QLocale &locale, const QVector<QTranslator *> &translators);
 
@@ -253,7 +253,7 @@ public:
      * @sa Context::translate(), QTranslator::translate()
      * @sa @ref translations
      *
-     * @since Cutelyst 1.5.0
+     * @since %Cutelyst 1.5.0
      */
     QString translate(const QLocale &locale,
                       const char *context,
@@ -291,7 +291,7 @@ public:
      * @sa addTranslator(), loadTranslationsFromDir(), loadTranslationsFromDirs()
      * @sa @ref translations
      *
-     * @since Cuteylst 2.0.0
+     * @since %Cuteylst 2.0.0
      */
     void loadTranslations(const QString &filename,
                           const QString &directory = {},
@@ -329,7 +329,7 @@ public:
      * @sa addTranslator(), loadTranslationsFromDirs()
      * @sa @ref translations
      *
-     * @since Cuteylst 2.1.0
+     * @since %Cuteylst 2.1.0
      */
     QVector<QLocale> loadTranslationsFromDir(const QString &filename,
                                              const QString &directory = QString(),
@@ -360,9 +360,29 @@ public:
      * @sa addTranslator(), loadTranslationsFromDir()
      * @sa @ref translations
      *
-     * @since Cutelyst 2.1.0
+     * @since %Cutelyst 2.1.0
      */
     QVector<QLocale> loadTranslationsFromDirs(const QString &directory, const QString &filename);
+
+    /**
+     * Returns the default locale that will be set to the \link Context::locale() locale()\endlink
+     * of newly created Context objects. By default this will be QLocale(English, Latin, United
+     * States).
+     * @sa setDefaultLocale()
+     * @sa @ref translations
+     * @since %Cutelyst 4.0.0
+     */
+    [[nodiscard]] QLocale defaultLocale() const noexcept;
+
+    /**
+     * Sets the default locale that will be set to the \link Context::locale() locale()\endlink
+     * of newly created Context objects. By default this will be QLocale(English, Latin, United
+     * States).
+     * @sa defaultLocale()
+     * @sa @ref translations
+     * @since %Cutelyst 4.0.0
+     */
+    void setDefaultLocale(const QLocale &locale);
 
 protected:
     /**

--- a/Cutelyst/application_p.h
+++ b/Cutelyst/application_p.h
@@ -41,6 +41,7 @@ public:
     bool useStats;
     bool init = false;
     QHash<QLocale, QVector<QTranslator *>> translators;
+    QLocale defaultLocale{QLocale::English, QLocale::LatinScript, QLocale::UnitedStates};
 };
 
 } // namespace Cutelyst

--- a/Cutelyst/context.cpp
+++ b/Cutelyst/context.cpp
@@ -37,6 +37,7 @@ Context::Context(Application *app)
     d_ptr->response               = new Response(app->defaultHeaders(), req);
     d_ptr->request                = new Request(req);
     d_ptr->request->d_ptr->engine = d_ptr->engine;
+    d_ptr->locale                 = app->defaultLocale();
 }
 
 Context::~Context()

--- a/Cutelyst/context.h
+++ b/Cutelyst/context.h
@@ -508,9 +508,8 @@ public:
      * Returns the current locale to be used when processing a \ref plugins-view
      * or translating user messages.
      *
-     * If not explicity set by setLocale() it will use a default constructed QLocale
-     * that will either be the locale set by QLocale::setDefault() or QLocale::system()
-     * if no default locale has been set.
+     * If not explicity set by setLocale() it will use the default locale set via
+     * Application::setDefaultLocale().
      *
      * \sa \ref translations
      */
@@ -524,8 +523,8 @@ public:
      * so it’s up to the developer to decide which one to use.
      *
      * For example it’s possible to try to guess the user locale with
-     * the request header Accept-Language, and  or use the chained dispatcher to first
-     * match the locale as in "example.com/pt-br/some_action", and or store
+     * the request header Accept-Language, or use the chained dispatcher to first
+     * match the locale as in "example.com/pt-br/some_action", or store
      * the locale into a cookie or session.
      *
      * Be sure to set it as soon as possible so that all content can be properly localized.

--- a/Cutelyst/context_p.h
+++ b/Cutelyst/context_p.h
@@ -37,7 +37,7 @@ public:
 
     QStringList error;
     QVariantHash stash;
-    QLocale locale;
+    QLocale locale{QLocale::English, QLocale::LatinScript, QLocale::UnitedStates};
     QStack<Component *> stack;
     QVector<Plugin *> plugins;
     QVector<Component *> pendingAsync;

--- a/Cutelyst/testengine.cpp
+++ b/Cutelyst/testengine.cpp
@@ -9,7 +9,6 @@ using namespace Cutelyst;
 TestEngine::TestEngine(Application *app, const QVariantMap &opts)
     : Engine{app, 0, opts}
 {
-    QLocale::setDefault(QLocale(QLocale::English));
 }
 
 int TestEngine::workerId() const

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -45,6 +45,7 @@ qt_add_lupdate(cutelyst-skell
 qt_add_lrelease(cutelyst-skell
     TS_FILES ${cutelyst-skell_TS_FILES}
     QM_FILES_OUTPUT_VARIABLE cutelyst-skell_QM_FILES
+    OPTIONS -idbased
 )
 
 install(FILES ${cutelyst-skell_QM_FILES} DESTINATION ${I18NDIR})


### PR DESCRIPTION
The default locale of QLocale’s default constructor is not comparable to the QLocale objects constructed from strings or enums. The internal default will now be US english. The default locale set in application will now be used to populate the locale setting of the context.