### PR TITLE
StaticCompressed plugin: add support for Zstandard compression and other improvements

### DIFF
--- a/Cutelyst/Plugins/StaticCompressed/CMakeLists.txt
+++ b/Cutelyst/Plugins/StaticCompressed/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_dependent_option(PLUGIN_STATICCOMPRESSED_ZOPFLI "Enables the use of zofpli instead of zlib for gzip compression" OFF "PLUGIN_STATICCOMPRESSED" OFF)
 cmake_dependent_option(PLUGIN_STATICCOMPRESSED_BROTLI "Enables the support of the brotli compression format" OFF "PLUGIN_STATICCOMPRESSED" OFF)
-cmake_dependent_option(PLUGIN_STATICCOMPRESSED_ZSTD "Enabled th support of the Zstandard compression format" OFF "PLUGIN_STATICCOMPRESSED" OFF)
+cmake_dependent_option(PLUGIN_STATICCOMPRESSED_ZSTD "Enables the support of the Zstandard compression format" OFF "PLUGIN_STATICCOMPRESSED" OFF)
 
 set(plugin_staticcompressed_SRC
     staticcompressed.cpp
@@ -74,7 +74,7 @@ endif (PLUGIN_STATICCOMPRESSED_BROTLI)
 
 if (PLUGIN_STATICCOMPRESSED_ZSTD)
     find_package(PkgConfig REQUIRED)
-    pkg_search_module(Zstd REQUIRED IMPORTED_TARGET libzstd)
+    pkg_search_module(Zstd REQUIRED IMPORTED_TARGET libzstd>=1.4.0)
     message(STATUS "PLUGIN: StaticCompressed, enable Zstandard")
     target_link_libraries(Cutelyst${PROJECT_VERSION_MAJOR}Qt${QT_VERSION_MAJOR}StaticCompressed
         PRIVATE

--- a/Cutelyst/Plugins/StaticCompressed/CMakeLists.txt
+++ b/Cutelyst/Plugins/StaticCompressed/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 cmake_dependent_option(PLUGIN_STATICCOMPRESSED_ZOPFLI "Enables the use of zofpli instead of zlib for gzip compression" OFF "PLUGIN_STATICCOMPRESSED" OFF)
 cmake_dependent_option(PLUGIN_STATICCOMPRESSED_BROTLI "Enables the support of the brotli compression format" OFF "PLUGIN_STATICCOMPRESSED" OFF)
+cmake_dependent_option(PLUGIN_STATICCOMPRESSED_ZSTD "Enabled th support of the Zstandard compression format" OFF "PLUGIN_STATICCOMPRESSED" OFF)
 
 set(plugin_staticcompressed_SRC
     staticcompressed.cpp
@@ -70,6 +71,22 @@ if (PLUGIN_STATICCOMPRESSED_BROTLI)
     set(PLUGIN_STATICCOMPRESSED_PKGCONF_DEFINES "${PLUGIN_STATICCOMPRESSED_PKGCONF_DEFINES} -DCUTELYST_STATICCOMPRESSED_WITH_BROTLI")
     set(PLUGIN_STATICCOMPRESSED_PKGCONF_PRIV_REQ "${PLUGIN_STATICCOMPRESSED_PKGCONF_PRIV_REQ} libbrotlienc")
 endif (PLUGIN_STATICCOMPRESSED_BROTLI)
+
+if (PLUGIN_STATICCOMPRESSED_ZSTD)
+    find_package(PkgConfig REQUIRED)
+    pkg_search_module(Zstd REQUIRED IMPORTED_TARGET libzstd)
+    message(STATUS "PLUGIN: StaticCompressed, enable Zstandard")
+    target_link_libraries(Cutelyst${PROJECT_VERSION_MAJOR}Qt${QT_VERSION_MAJOR}StaticCompressed
+        PRIVATE
+            PkgConfig::Zstd
+    )
+    target_compile_definitions(Cutelyst${PROJECT_VERSION_MAJOR}Qt${QT_VERSION_MAJOR}StaticCompressed
+        PUBLIC
+            CUTELYST_STATICCOMPRESSED_WITH_ZSTD
+    )
+    set(PLUGIN_STATICCOMPRESSED_PKGCONF_DEFINES "${PLUGIN_STATICCOMPRESSED_PKGCONF_DEFINES} -DCUTELYST_STATICCOMPRESSED_WITH_ZSTD")
+    set(PLUGIN_STATICCOMPRESSED_PKGCONF_PRIV_REQ "${PLUGIN_STATICCOMPRESSED_PKGCONF_PRIV_REQ} libzstd")
+endif (PLUGIN_STATICCOMPRESSED_ZSTD)
 
 set_property(TARGET Cutelyst${PROJECT_VERSION_MAJOR}Qt${QT_VERSION_MAJOR}StaticCompressed PROPERTY PUBLIC_HEADER ${plugin_staticcompressed_HEADERS})
 install(TARGETS Cutelyst${PROJECT_VERSION_MAJOR}Qt${QT_VERSION_MAJOR}StaticCompressed

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed.cpp
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed.cpp
@@ -838,12 +838,12 @@ bool StaticCompressedPrivate::loadZstdConfig(const QVariantMap &conf)
         conf.value(u"zstd_compression_level"_qs,
                    defaultConfig.value(u"zstd_compression_level"_qs, zstd.compressionLevelDefault))
             .toInt(&ok);
-    if (!ok || zstd.compressionLevel < zstd.compressionLevelMin ||
-        zstd.compressionLevel > zstd.compressionLevelMax) {
+    if (!ok || zstd.compressionLevel < ZSTD_minCLevel() ||
+        zstd.compressionLevel > ZSTD_maxCLevel()) {
         qCWarning(C_STATICCOMPRESSED).nospace()
             << "Invalid value for zstd_compression_level. Has to be an integer value between "
-            << zstd.compressionLevelMin << " and " << zstd.compressionLevelMax
-            << " inclusive. Using default value " << zstd.compressionLevelDefault;
+            << ZSTD_minCLevel() << " and " << ZSTD_maxCLevel() << " inclusive. Using default value "
+            << zstd.compressionLevelDefault;
         zstd.compressionLevel = zstd.compressionLevelDefault;
     }
 

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed.cpp
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed.cpp
@@ -126,35 +126,7 @@ bool StaticCompressed::setup(Application *app)
     qCInfo(C_STATICCOMPRESSED) << "Compress static files on the fly:" << d->onTheFlyCompression;
 
     QStringList supportedCompressions{u"deflate"_qs, u"gzip"_qs};
-
-    bool ok = false;
-    d->zlibCompressionLevel =
-        config
-            .value(u"zlib_compression_level"_qs,
-                   d->defaultConfig.value(u"zlib_compression_level"_qs,
-                                          StaticCompressedPrivate::zlibCompressionLevelDefault))
-            .toInt(&ok);
-    if (!ok) {
-        qCWarning(C_STATICCOMPRESSED).nospace()
-            << "Invalid value set for zlib_compression_level. "
-               "Has to to be an integer value between "
-            << StaticCompressedPrivate::zlibCompressionLevelMin << " and "
-            << StaticCompressedPrivate::zlibCompressionLevelMax
-            << " inclusive. Using default value "
-            << StaticCompressedPrivate::zlibCompressionLevelDefault;
-    }
-
-    if (d->zlibCompressionLevel < StaticCompressedPrivate::zlibCompressionLevelMin ||
-        d->zlibCompressionLevel > StaticCompressedPrivate::zlibCompressionLevelMax) {
-        qCWarning(C_STATICCOMPRESSED).nospace()
-            << "Invalid value " << d->zlibCompressionLevel
-            << " set for zlib_compression_level. Value hat to be between "
-            << StaticCompressedPrivate::zlibCompressionLevelMin << " and "
-            << StaticCompressedPrivate::zlibCompressionLevelMax
-            << " inclusive. Using default value "
-            << StaticCompressedPrivate::zlibCompressionLevelDefault;
-        d->zlibCompressionLevel = StaticCompressedPrivate::zlibCompressionLevelDefault;
-    }
+    d->loadZlibConfig(config);
 
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZOPFLI
     d->loadZopfliConfig(config);
@@ -192,7 +164,7 @@ void StaticCompressedPrivate::beforePrepareAction(Context *c, bool *skipMethod)
     // TODO mid(1) quick fix for path now having leading slash
     const QString path = c->req()->path().mid(1);
 
-    for (const QString &dir : dirs) {
+    for (const QString &dir : std::as_const(dirs)) {
         if (path.startsWith(dir)) {
             if (!locateCompressedFile(c, path)) {
                 Response *res = c->response();
@@ -439,58 +411,44 @@ QString StaticCompressedPrivate::locateCacheFile(const QString &origPath,
     return compressedPath;
 }
 
-// clang-format off
-static constexpr std::array<quint32, 256> crc_32_tab { /* CRC polynomial 0xedb88320 */
-    0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
-    0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
-    0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,
-    0xf3b97148, 0x84be41de, 0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
-    0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec, 0x14015c4f, 0x63066cd9,
-    0xfa0f3d63, 0x8d080df5, 0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
-    0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b, 0x35b5a8fa, 0x42b2986c,
-    0xdbbbc9d6, 0xacbcf940, 0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
-    0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423,
-    0xcfba9599, 0xb8bda50f, 0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
-    0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d, 0x76dc4190, 0x01db7106,
-    0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
-    0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818, 0x7f6a0dbb, 0x086d3d2d,
-    0x91646c97, 0xe6635c01, 0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
-    0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457, 0x65b0d9c6, 0x12b7e950,
-    0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
-    0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2, 0x4adfa541, 0x3dd895d7,
-    0xa4d1c46d, 0xd3d6f4fb, 0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
-    0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9, 0x5005713c, 0x270241aa,
-    0xbe0b1010, 0xc90c2086, 0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
-    0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17, 0x2eb40d81,
-    0xb7bd5c3b, 0xc0ba6cad, 0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
-    0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683, 0xe3630b12, 0x94643b84,
-    0x0d6d6a3e, 0x7a6a5aa8, 0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
-    0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb,
-    0x196c3671, 0x6e6b06e7, 0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
-    0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5, 0xd6d6a3e8, 0xa1d1937e,
-    0x38d8c2c4, 0x4fdff252, 0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
-    0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60, 0xdf60efc3, 0xa867df55,
-    0x316e8eef, 0x4669be79, 0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
-    0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f, 0xc5ba3bbe, 0xb2bd0b28,
-    0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
-    0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a, 0x9c0906a9, 0xeb0e363f,
-    0x72076785, 0x05005713, 0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
-    0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21, 0x86d3d2d4, 0xf1d4e242,
-    0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
-    0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c, 0x8f659eff, 0xf862ae69,
-    0x616bffd3, 0x166ccf45, 0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
-    0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db, 0xaed16a4a, 0xd9d65adc,
-    0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
-    0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693,
-    0x54de5729, 0x23d967bf, 0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
-    0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
-};
-// clang-format on
+void StaticCompressedPrivate::loadZlibConfig(const QVariantMap &conf)
+{
+    bool ok = false;
+    zlib.compressionLevel =
+        conf.value(u"zlib_compression_level"_qs,
+                   defaultConfig.value(u"zlib_compression_level"_qs, zlib.compressionLevelDefault))
+            .toInt(&ok);
+
+    if (!ok || zlib.compressionLevel < zlib.compressionLevelMin ||
+        zlib.compressionLevel > zlib.compressionLevelMax) {
+        qCWarning(C_STATICCOMPRESSED).nospace()
+            << "Invalid value set for zlib_compression_level. Value hat to be between "
+            << zlib.compressionLevelMin << " and " << zlib.compressionLevelMax
+            << " inclusive. Using default value " << zlib.compressionLevelDefault;
+        zlib.compressionLevel = zlib.compressionLevelDefault;
+    }
+}
+
+static constexpr std::array<quint32, 256> crc32Tab = []() {
+    std::array<quint32, 256> tab{0};
+    for (int n = 0; n < 256; n++) {
+        auto c = static_cast<quint32>(n);
+        for (int k = 0; k < 8; k++) {
+            if (c & 1) {
+                c = 0xedb88320L ^ (c >> 1);
+            } else {
+                c = c >> 1;
+            }
+        }
+        tab[n] = c;
+    }
+    return tab;
+}();
 
 quint32 updateCRC32(unsigned char ch, quint32 crc)
 {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    return (crc_32_tab[((crc) ^ (quint8(ch))) & 0xff] ^ ((crc) >> 8));
+    return crc32Tab[(crc ^ ch) & 0xff] ^ (crc >> 8);
 }
 
 quint32 crc32buf(const QByteArray &data)
@@ -498,7 +456,9 @@ quint32 crc32buf(const QByteArray &data)
     return ~std::accumulate(data.begin(),
                             data.end(),
                             quint32(0xFFFFFFFF), // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-                            [](quint32 oldcrc32, char buf) { return updateCRC32(buf, oldcrc32); });
+                            [](quint32 oldcrc32, char buf) {
+        return updateCRC32(static_cast<unsigned char>(buf), oldcrc32);
+    });
 }
 
 bool StaticCompressedPrivate::compressGzip(const QString &inputPath,
@@ -522,7 +482,7 @@ bool StaticCompressedPrivate::compressGzip(const QString &inputPath,
         return false;
     }
 
-    QByteArray compressedData = qCompress(data, zlibCompressionLevel);
+    QByteArray compressedData = qCompress(data, zlib.compressionLevel);
     input.close();
 
     QFile output(outputPath);
@@ -553,24 +513,33 @@ bool StaticCompressedPrivate::compressGzip(const QString &inputPath,
     QDataStream headerStream(&header, QIODevice::WriteOnly);
     // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
     // prepend a generic 10-byte gzip header (see RFC 1952)
-    headerStream << quint16(0x1f8b) << quint16(0x0800)
-                 << quint32(origLastModified.toSecsSinceEpoch())
+    headerStream << quint8(0x1f) << quint8(0x8b) // ID1 and ID""
+                 << quint8(8)                    // CM / Compression Mode (8 = deflate)
+                 << quint8(0)                    // FLG / flags
+                 << static_cast<quint32>(origLastModified.toSecsSinceEpoch())
+                 << quint8(0) // XFL / extra flags
 #if defined Q_OS_UNIX
-                 << quint16(0x0003);
-#elif defined Q_OS_WIN
-                 << quint16(0x000b);
+                 << quint8(3);
 #elif defined Q_OS_MACOS
-                 << quint16(0x0007);
+                 << quint8(7);
+#elif defined Q_OS_WIN
+                 << quint8(11);
 #else
-                 << quint16(0x00ff);
+                 << quint8(255);
 #endif
     // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 
     // append a four-byte CRC-32 of the uncompressed data
     // append 4 bytes uncompressed input size modulo 2^32
+    auto crc    = crc32buf(data);
+    auto inSize = data.size();
     QByteArray footer;
     QDataStream footerStream(&footer, QIODevice::WriteOnly);
-    footerStream << crc32buf(data) << quint32(data.size());
+    footerStream << static_cast<quint8>(crc % 256) << static_cast<quint8>((crc >> 8) % 256)
+                 << static_cast<quint8>((crc >> 16) % 256) << static_cast<quint8>((crc >> 24) % 256)
+                 << static_cast<quint8>(inSize % 256) << static_cast<quint8>((inSize >> 8) % 256)
+                 << static_cast<quint8>((inSize >> 16) % 256)
+                 << static_cast<quint8>((inSize >> 24) % 256);
 
     if (Q_UNLIKELY(output.write(header + compressedData + footer) < 0)) {
         qCCritical(C_STATICCOMPRESSED).nospace()
@@ -601,7 +570,7 @@ bool StaticCompressedPrivate::compressDeflate(const QString &inputPath,
         return false;
     }
 
-    QByteArray compressedData = qCompress(data, zlibCompressionLevel);
+    QByteArray compressedData = qCompress(data, zlib.compressionLevel);
     input.close();
 
     QFile output(outputPath);
@@ -623,10 +592,8 @@ bool StaticCompressedPrivate::compressDeflate(const QString &inputPath,
         return false;
     }
 
-    // Strip the first six bytes (a 4-byte length put on by qCompress and a 2-byte zlib header)
-    // and the last four bytes (a zlib integrity check).
-    compressedData.remove(0, 6);
-    compressedData.chop(4);
+    // Strip the first four bytes (a 4-byte length header put on by qCompress)
+    compressedData.remove(0, 4);
 
     if (Q_UNLIKELY(output.write(compressedData) < 0)) {
         qCCritical(C_STATICCOMPRESSED).nospace() << "Failed to write compressed deflate file "

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed.cpp
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed.cpp
@@ -130,7 +130,7 @@ bool StaticCompressed::setup(Application *app)
 
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZOPFLI
     d->loadZopfliConfig(config);
-    qCInfo(C_STATICCOMPRESSED) << "Use Zopfli:" << d->zopfli.use;
+    qCInfo(C_STATICCOMPRESSED) << "Use Zopfli:" << d->useZopfli;
 #endif
 
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_BROTLI
@@ -299,24 +299,25 @@ bool StaticCompressedPrivate::locateCompressedFile(Context *c, const QString &re
 #endif
                             if (format == QLatin1String("gzip")) {
                             compressedPath = locateCacheFile(
-                                path, currentDateTime, zopfli.use ? ZopfliGzip : Gzip);
+                                path, currentDateTime, useZopfli ? ZopfliGzip : Gzip);
                             if (compressedPath.isEmpty()) {
                                 continue;
                             } else {
                                 qCDebug(C_STATICCOMPRESSED)
-                                    << "Serving" << (zopfli.use ? "zopfli" : "gzip")
-                                    << "compressed data from" << compressedPath;
+                                    << "Serving" << (useZopfli ? "zopfli" : "default")
+                                    << "compressed gzip data from" << compressedPath;
                                 contentEncoding = "gzip"_qba;
                                 break;
                             }
                         } else if (format == QLatin1String("deflate")) {
                             compressedPath = locateCacheFile(
-                                path, currentDateTime, zopfli.use ? ZopfliDeflate : Deflate);
+                                path, currentDateTime, useZopfli ? ZopfliDeflate : Deflate);
                             if (compressedPath.isEmpty()) {
                                 continue;
                             } else {
                                 qCDebug(C_STATICCOMPRESSED)
-                                    << "Serving deflate compressed data from" << compressedPath;
+                                    << "Serving" << (useZopfli ? "zopfli" : "default")
+                                    << "compressed deflate data from" << compressedPath;
                                 contentEncoding = "deflate"_qba;
                                 break;
                             }
@@ -672,9 +673,8 @@ bool StaticCompressedPrivate::compressDeflate(const QString &inputPath,
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZOPFLI
 void StaticCompressedPrivate::loadZopfliConfig(const QVariantMap &conf)
 {
-    zopfli.use =
-        conf.value(u"use_zopfli"_qs, defaultConfig.value(u"use_zopfli"_qs, false)).toBool();
-    if (zopfli.use) {
+    useZopfli = conf.value(u"use_zopfli"_qs, defaultConfig.value(u"use_zopfli"_qs, false)).toBool();
+    if (useZopfli) {
         ZopfliInitOptions(&zopfli.options);
         bool ok = false;
         zopfli.options.numiterations =

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed.cpp
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed.cpp
@@ -847,18 +847,6 @@ bool StaticCompressedPrivate::loadZstdConfig(const QVariantMap &conf)
         zstd.compressionLevel = zstd.compressionLevelDefault;
     }
 
-    zstd.compressionThreads = conf.value(u"zstd_compression_threads"_qs,
-                                         defaultConfig.value(u"zstd_compression_threads"_qs,
-                                                             zstd.compressionThreadsDefault))
-                                  .toInt(&ok);
-    if (!ok || zstd.compressionThreads < 0) {
-        qCWarning(C_STATICCOMPRESSED).nospace()
-            << "Invalid value for zstd_compression_threads. Has to be an integer value "
-               "greater than or equal to 0. Using default value "
-            << zstd.compressionThreadsDefault;
-        zstd.compressionThreads = zstd.compressionThreadsDefault;
-    }
-
     return true;
 }
 

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed.h
@@ -25,10 +25,10 @@ class StaticCompressedPrivate;
  * HREF="https://en.wikipedia.org/wiki/Brotli">Brotli</A> and <A
  * HREF="https://en.wikipedia.org/wiki/Zstd">Zstandard</A> (since %Cutelyst 4.4.0) compression
  * algorithms and to use <A HREF="https://en.wikipedia.org/wiki/Zopfli">Zopfli</A> for @a gzip
- * compression. Beside compressing the raw data on the fly and store the result in a cache
- * directory, it supports pre-compressed files distinguished by file extension in the static
- * source directories. The plugin uses the @a Accept-Encoding HTTP request header to determine
- * the compression methods supported by the user agent. If you do not need this, use the
+ * and @a deflate compression. Beside compressing the raw data on the fly and store the result in
+ * a cache directory, it supports pre-compressed files distinguished by file extension in the
+ * static source directories. The plugin uses the @a Accept-Encoding HTTP request header to
+ * determine the compression methods supported by the user agent. If you do not need this, use the
  * StaticSimple plugin to serve your static files.
  *
  * Beside serving the file content this will also set the respective HTTP header fields
@@ -50,12 +50,12 @@ class StaticCompressedPrivate;
  * <A HREF="https://github.com/facebook/zstd">libzstd</A> development and header files
  * available.
  *
- * To use <A HREF="https://en.wikipedia.org/wiki/Zopfli">Zopfli</A> for the @a gzip compression,
- * build with <TT>-DPLUGIN_STATICCOMPRESSED_ZOPFLI:BOOL=ON</TT> and have the <A
+ * To use <A HREF="https://en.wikipedia.org/wiki/Zopfli">Zopfli</A> for the @a gzip and @a deflate
+ * compression, build with <TT>-DPLUGIN_STATICCOMPRESSED_ZOPFLI:BOOL=ON</TT> and have the <A
  * HREF="https://github.com/google/zopfli">libzopfli</A> development and header files available.
  * Also set the configuration key @c use_zopfli to @c true. Be aware that @a Zopfli gives better
- * compression rate than default @a gzip but is also much slower. So @a Zopfli is disabled by
- * default even if it is enabled at compilation time.
+ * compression rate than default @a gzip and @a deflate but is also much slower. So @a Zopfli is
+ * disabled by default even if it is enabled at compilation time.
  *
  * <H3>On the fly compression</H3>
  *
@@ -64,10 +64,10 @@ class StaticCompressedPrivate;
  * agent. The compressed data is saved into files in the @c cache_diretory specified in the
  * configuration. The cache file name will be the MD5 hash sum of the original local file path
  * together with the file extension indicating the compression format (.br for Brotli, .gz for
- * gzip/Zopfli, .deflate for DEFLATE and .zst for Zstandard). If the modification time of the
- * original file is newer than the modification time of the cached compressed file, the file will
- * be compressed again. It is safe to clean the content of the cache directory - the files will
- * then be recompressed on the next request. On the fly compression can be disabled by setting
+ * gzip/Zopfli, .deflate for DEFLATE/Zopfli and .zst for Zstandard). If the modification time of
+ * the original file is newer than the modification time of the cached compressed file, the file
+ * will be compressed again. It is safe to clean the content of the cache directory - the files
+ * will then be recompressed on the next request. On the fly compression can be disabled by setting
  * @c on_the_fly_compression to @c false in the configuration file.
  *
  * <H3>Pre-compressed files</H3>
@@ -124,7 +124,8 @@ class StaticCompressedPrivate;
  *
  * @configblock{zlib_compression_level,integer,9}
  * Compression level for built in zlib based compression between 0 and 9, with 9 corresponding
- * to the best compression.
+ * to the best compression. Used for @a gzip and @a deflate compression format if @a use_zopfli
+ * is set to @c false.
  * @endconfigblock
  *
  * @configblock{brotli_quality_level,integer,11}
@@ -133,8 +134,8 @@ class StaticCompressedPrivate;
  * @endconfigblock
  *
  * @configblock{use_zopfli,bool,false}
- * Enables the optional use of @a Zopfli for the @a gzip compression. Note that @a Zopfli gives
- * much better compression results for the cost of a slower compression.
+ * Enables the optional use of @a Zopfli for the @a gzip and @ deflate compression format. Note
+ * that @a Zopfli gives much better compression results for the cost of a slower compression.
  * @endconfigblock
  *
  * @configblock{zopfli_iterations,integer,15}
@@ -244,7 +245,7 @@ public:
      *
      * If setServeDirsOnly() is set to @c false (the default), the plugin will still try to serve
      * files as static if they end with something that looks like a file extension, no matter if
-     * their request path starts with of of the @c dirs. Set setServeDirsOnly() to @c true to only
+     * their request path starts with one of the @c dirs. Set setServeDirsOnly() to @c true to only
      * serve files as static that start with paths defined here. If you would than request a file
      * like @c/some/where/else/script@c.js it would not be tried to be found in the included
      * directories and the dispatcher would try to find a fitting controller method for it.

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed.h
@@ -22,13 +22,14 @@ class StaticCompressedPrivate;
  * It has built in support for <A HREF="https://en.wikipedia.org/wiki/Gzip">gzip</A> and
  * <A HREF="https://en.wikipedia.org/wiki/DEFLATE">DEFLATE</A> compression format and can be
  * extended by external libraries to support the <A
- * HREF="https://en.wikipedia.org/wiki/Brotli">Brotli</A> compression algorithm and to use <A
- * HREF="https://en.wikipedia.org/wiki/Zopfli">Zopfli</A> for @a gzip compression. Beside
- * compressing the raw data on the fly and store the result in a cache directory, it supports
- * pre-compressed files distinguished by file extension in the static source directories. The
- * plugin uses the @a Accept-Encoding HTTP request header to determine the compression methods
- * supported by the user agent. If you do not need this, use the StaticSimple plugin to serve
- * your static files.
+ * HREF="https://en.wikipedia.org/wiki/Brotli">Brotli</A> and <A
+ * HREF="https://en.wikipedia.org/wiki/Zstd">Zstandard</A> (since %Cutelyst 4.4.0) compression
+ * algorithms and to use <A HREF="https://en.wikipedia.org/wiki/Zopfli">Zopfli</A> for @a gzip
+ * compression. Beside compressing the raw data on the fly and store the result in a cache
+ * directory, it supports pre-compressed files distinguished by file extension in the static
+ * source directories. The plugin uses the @a Accept-Encoding HTTP request header to determine
+ * the compression methods supported by the user agent. If you do not need this, use the
+ * StaticSimple plugin to serve your static files.
  *
  * Beside serving the file content this will also set the respective HTTP header fields
  * @c Content-Type, @c Content-Length, @c Last-Modified, @c Content-Encoding,
@@ -37,10 +38,16 @@ class StaticCompressedPrivate;
  * <H3>Compression formats</H3>
  *
  * Support for @a gzip and @a DEFLATE compression format is built in by using the
- * @link QByteArray::qCompress() qCompress()@endlink function. To enable suport for
- * <A HREF="https://en.wikipedia.org/wiki/Brotli">Brotli</A>, build
+ * @link QByteArray::qCompress() qCompress()@endlink function.
+ *
+ * To enable suport for <A HREF="https://en.wikipedia.org/wiki/Brotli">Brotli</A>, build
  * with <TT>-DPLUGIN_STATICCOMPRESSED_BROTLI:BOOL=ON</TT> and have the
  * <A HREF="https://github.com/google/brotli">libbrotlienc</A> development and header files
+ * available.
+ *
+ * To enable support for <A HREF="https://en.wikipedia.org/wiki/Zstd">Zstandard</A>, build
+ * with <TT>-DPLUGIN_STATICCOMPRESSED_ZSTD:BOOL=ON</TT> and have the
+ * <A HREF="https://github.com/facebook/zstd">libzstd</A> development and header files
  * available.
  *
  * To use <A HREF="https://en.wikipedia.org/wiki/Zopfli">Zopfli</A> for the @a gzip compression,
@@ -57,11 +64,11 @@ class StaticCompressedPrivate;
  * agent. The compressed data is saved into files in the @c cache_diretory specified in the
  * configuration. The cache file name will be the MD5 hash sum of the original local file path
  * together with the file extension indicating the compression format (.br for Brotli, .gz for
- * gzip/Zopfli and .deflate for DEFLATE). If the modification time of the original file is newer
- * than the modification time of the cached compressed file, the file will be compressed again.
- * It is safe to clean the content of the cache directory - the files will then be recompressed
- * on the next request. On the fly compression can be disabled by setting @c on_the_fly_compression
- * to @c false in the configuration file.
+ * gzip/Zopfli, .deflate for DEFLATE and .zst for Zstandard). If the modification time of the
+ * original file is newer than the modification time of the cached compressed file, the file will
+ * be compressed again. It is safe to clean the content of the cache directory - the files will
+ * then be recompressed on the next request. On the fly compression can be disabled by setting
+ * @c on_the_fly_compression to @c false in the configuration file.
  *
  * <H3>Pre-compressed files</H3>
  *
@@ -78,6 +85,7 @@ class StaticCompressedPrivate;
  * @li .br - Brotli compressed files
  * @li .gz - gzip/Zopfli compressed files
  * @li .deflate - DEFLATE compressed files
+ * @li .zst - Zstandard compressed files (since %Cutelyst 4.4.0)
  *
  * <H3>Only serve for specific request paths</H3>
  *
@@ -131,6 +139,12 @@ class StaticCompressedPrivate;
  *
  * @configblock{zopfli_iterations,integer,15}
  * Number of iterations used for @a Zopfli compression, more gives better compression but is slower.
+ * @endconfigblock
+ *
+ * @configblock{zstd_compression_level,integer,9}
+ * Compression level used for @a Zstandardd compression. Normally between 1 and 19, but can also
+ * use negative levels for faster compression or higher levels up to 22 for better/stronger
+ * compression.
  * @endconfigblock
  *
  * <H3>Usage example</H3>

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed.h
@@ -114,6 +114,11 @@ class StaticCompressedPrivate;
  * Comma separted list of file suffixes/extensions that should be compressed.
  * @endconfigblock
  *
+ * @configblock{compression_format_order,string,br\,zstd\,gzip\,deflate}
+ * Comma separated list of compression formats that will be used in order if supported
+ * by the user agent.
+ * @endconfigblock
+ *
  * @configblock{check_pre_compressed,bool,true}
  * Enables or disables the check for pre compressed files.
  * @endconfigblock

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed.h
@@ -142,7 +142,7 @@ class StaticCompressedPrivate;
  * @endconfigblock
  *
  * @configblock{zstd_compression_level,integer,9}
- * Compression level used for @a Zstandardd compression. Normally between 1 and 19, but can also
+ * Compression level used for @a Zstandard compression. Normally between 1 and 19, but can also
  * use negative levels for faster compression or higher levels up to 22 for better/stronger
  * compression.
  * @endconfigblock
@@ -176,10 +176,13 @@ class StaticCompressedPrivate;
  * @li @c -DPLUGIN_STATICCOMPRESSED_BROTLI@c:BOOL=ON - enables the @a Brotli support,
  * <A HREF="https://github.com/google/brotli">libbrotlienc</A> development and header files have to
  * be present (default: @c off)
+ * @li @c -DPLUGIN_STATICCOMPRESSED_ZSTD@c:BOOL=ON - enables the @a Zstandard support,
+ * <A HREF="https://github.com/facebook/zstd">libzstd</A development and header files have to be
+ * present (default: @c off) (since %Cutelyst 4.4.0)
  *
- * Since %Cutelyst 2.0.0 you can check if \c CUTELYST_STATICCOMPRESSED_WITH_ZOPFLI and/or
- * \c CUTELYST_STATICCOMPRESSED_WITH_BROTLI are defined if you need to know that the plugin supports
- * that compressions.
+ * Since %Cutelyst 2.0.0 you can check if \c CUTELYST_STATICCOMPRESSED_WITH_ZOPFLI,
+ * \c CUTELYST_STATICCOMPRESSED_WITH_BROTLI and/or \c CUTELYST_STATICCOMPRESSED_WITH_ZSTD are
+ * defined if you need to know that the plugin supports that compressions.
  *
  * @logcat{plugin.csrfprotection}
  *

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
@@ -60,7 +60,6 @@ public:
         constexpr static int iterationsDefault{15};
         constexpr static int iterationsMin{1};
         ZopfliOptions options;
-        bool use{false};
     } zopfli;
 #endif
 
@@ -97,6 +96,7 @@ public:
     QVariantMap defaultConfig;
     QRegularExpression re = QRegularExpression(QStringLiteral("\\.[^/]+$"));
     QDir cacheDir;
+    bool useZopfli{false};
     bool checkPreCompressed{true};
     bool onTheFlyCompression{true};
     bool serveDirsOnly{false};

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
@@ -36,8 +36,16 @@ public:
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZOPFLI
     [[nodiscard]] bool compressZopfli(const QString &inputPath, const QString &outputPath) const;
 #endif
+
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_BROTLI
+    void loadBrotliConfig(const QVariantMap &conf);
+
     [[nodiscard]] bool compressBrotli(const QString &inputPath, const QString &outputPath) const;
+
+    struct BrotliConfig {
+        constexpr static int qualityLevelDefault{11};
+        int qualityLevel{qualityLevelDefault};
+    } brotli;
 #endif
 
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZSTD
@@ -68,8 +76,6 @@ public:
     constexpr static int zopfliIterationsDefault{15};
     constexpr static int zopfliIterationsMin{1};
     int zopfliIterations{zopfliIterationsDefault};
-    constexpr static int brotliQualityLevelDefault{11};
-    int brotliQualityLevel{brotliQualityLevelDefault};
     bool useZopfli{false};
     bool checkPreCompressed{true};
     bool onTheFlyCompression{true};

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
@@ -11,6 +11,10 @@
 #include <QRegularExpression>
 #include <QVector>
 
+#ifdef CUTELYST_STATICCOMPRESSED_WITH_ZSTD
+#    include <zstd.h>
+#endif
+
 namespace Cutelyst {
 
 class Context;
@@ -37,11 +41,14 @@ public:
 #endif
 
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZSTD
-    void loadZstdConfig(const QVariantMap &conf);
+    [[nodiscard]] bool loadZstdConfig(const QVariantMap &conf);
 
     [[nodiscard]] bool compressZstd(const QString &inputPath, const QString &outputPath) const;
 
     struct ZstdConfig {
+        ~ZstdConfig() { ZSTD_freeCCtx(ctx); }
+
+        ZSTD_CCtx *ctx{nullptr};
         constexpr static int compressionLevelDefault{3};
         constexpr static int compressionLevelMin{1};
         constexpr static int compressionLevelMax{19};

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
@@ -26,7 +26,7 @@ class Context;
 class StaticCompressedPrivate
 {
 public:
-    enum Compression { Gzip, Zopfli, Brotli, Deflate, Zstd };
+    enum Compression { Gzip, ZopfliGzip, Brotli, Deflate, ZopfliDeflate, Zstd };
 
     void beforePrepareAction(Context *c, bool *skipMethod);
     bool locateCompressedFile(Context *c, const QString &relPath) const;
@@ -52,7 +52,9 @@ public:
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZOPFLI
     void loadZopfliConfig(const QVariantMap &conf);
 
-    [[nodiscard]] bool compressZopfli(const QString &inputPath, const QString &outputPath) const;
+    [[nodiscard]] bool compressZopfli(const QString &inputPath,
+                                      const QString &outputPath,
+                                      ZopfliFormat format) const;
 
     struct ZopfliConfig {
         constexpr static int iterationsDefault{15};

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
@@ -11,6 +11,10 @@
 #include <QRegularExpression>
 #include <QVector>
 
+#ifdef CUTELYST_STATICCOMPRESSED_WITH_ZOPFLI
+#    include <zopfli.h>
+#endif
+
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZSTD
 #    include <zstd.h>
 #endif
@@ -33,8 +37,18 @@ public:
                                     const QString &outputPath,
                                     const QDateTime &origLastModified) const;
     [[nodiscard]] bool compressDeflate(const QString &inputPath, const QString &outputPath) const;
+
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZOPFLI
+    void loadZopfliConfig(const QVariantMap &conf);
+
     [[nodiscard]] bool compressZopfli(const QString &inputPath, const QString &outputPath) const;
+
+    struct ZopfliConfig {
+        constexpr static int iterationsDefault{15};
+        constexpr static int iterationsMin{1};
+        ZopfliOptions options;
+        bool use{false};
+    } zopfli;
 #endif
 
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_BROTLI
@@ -73,10 +87,6 @@ public:
     constexpr static int zlibCompressionLevelMin{0};
     constexpr static int zlibCompressionLevelMax{9};
     int zlibCompressionLevel{zlibCompressionLevelDefault};
-    constexpr static int zopfliIterationsDefault{15};
-    constexpr static int zopfliIterationsMin{1};
-    int zopfliIterations{zopfliIterationsDefault};
-    bool useZopfli{false};
     bool checkPreCompressed{true};
     bool onTheFlyCompression{true};
     bool serveDirsOnly{false};

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
@@ -49,12 +49,10 @@ public:
         ~ZstdConfig() { ZSTD_freeCCtx(ctx); }
 
         ZSTD_CCtx *ctx{nullptr};
-        constexpr static int compressionLevelDefault{3};
+        constexpr static int compressionLevelDefault{9};
         constexpr static int compressionLevelMin{1};
         constexpr static int compressionLevelMax{19};
         int compressionLevel{compressionLevelDefault};
-        constexpr static int compressionThreadsDefault{1};
-        int compressionThreads{compressionThreadsDefault};
     } zstd;
 #endif
 

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
@@ -36,6 +36,19 @@ public:
     [[nodiscard]] bool compressBrotli(const QString &inputPath, const QString &outputPath) const;
 #endif
 
+#ifdef CUTELYST_STATICCOMPRESSED_WITH_ZSTD
+    void loadZstdConfig(const QVariantMap &conf);
+
+    struct ZstdConfig {
+        constexpr static int compressionLevelDefault{3};
+        constexpr static int compressionLevelMin{1};
+        constexpr static int compressionLevelMax{19};
+        int compressionLevel{compressionLevelDefault};
+        constexpr static int compressionThreadsDefault{1};
+        int compressionThreads{compressionThreadsDefault};
+    } zstd;
+#endif
+
     QVariantMap defaultConfig;
     QStringList dirs;
     QStringList mimeTypes;

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
@@ -18,7 +18,7 @@ class Context;
 class StaticCompressedPrivate
 {
 public:
-    enum Compression { Gzip, Zopfli, Brotli, Deflate };
+    enum Compression { Gzip, Zopfli, Brotli, Deflate, Zstd };
 
     void beforePrepareAction(Context *c, bool *skipMethod);
     bool locateCompressedFile(Context *c, const QString &relPath) const;
@@ -38,6 +38,8 @@ public:
 
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZSTD
     void loadZstdConfig(const QVariantMap &conf);
+
+    [[nodiscard]] bool compressZstd(const QString &inputPath, const QString &outputPath) const;
 
     struct ZstdConfig {
         constexpr static int compressionLevelDefault{3};

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
@@ -50,8 +50,6 @@ public:
 
         ZSTD_CCtx *ctx{nullptr};
         constexpr static int compressionLevelDefault{9};
-        constexpr static int compressionLevelMin{1};
-        constexpr static int compressionLevelMax{19};
         int compressionLevel{compressionLevelDefault};
     } zstd;
 #endif

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
@@ -89,11 +89,12 @@ public:
     } zstd;
 #endif
 
-    QVariantMap defaultConfig;
     QStringList dirs;
     QStringList mimeTypes;
     QStringList suffixes;
+    QStringList compressionFormatOrder;
     QVector<QDir> includePaths;
+    QVariantMap defaultConfig;
     QRegularExpression re = QRegularExpression(QStringLiteral("\\.[^/]+$"));
     QDir cacheDir;
     bool checkPreCompressed{true};

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed_p.h
@@ -33,10 +33,21 @@ public:
     [[nodiscard]] QString locateCacheFile(const QString &origPath,
                                           const QDateTime &origLastModified,
                                           Compression compression) const;
+
+    void loadZlibConfig(const QVariantMap &conf);
+
     [[nodiscard]] bool compressGzip(const QString &inputPath,
                                     const QString &outputPath,
                                     const QDateTime &origLastModified) const;
+
     [[nodiscard]] bool compressDeflate(const QString &inputPath, const QString &outputPath) const;
+
+    struct ZlibConfig {
+        constexpr static int compressionLevelDefault{9};
+        constexpr static int compressionLevelMin{0};
+        constexpr static int compressionLevelMax{9};
+        int compressionLevel{compressionLevelDefault};
+    } zlib;
 
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZOPFLI
     void loadZopfliConfig(const QVariantMap &conf);
@@ -83,10 +94,6 @@ public:
     QVector<QDir> includePaths;
     QRegularExpression re = QRegularExpression(QStringLiteral("\\.[^/]+$"));
     QDir cacheDir;
-    constexpr static int zlibCompressionLevelDefault{9};
-    constexpr static int zlibCompressionLevelMin{0};
-    constexpr static int zlibCompressionLevelMax{9};
-    int zlibCompressionLevel{zlibCompressionLevelDefault};
     bool checkPreCompressed{true};
     bool onTheFlyCompression{true};
     bool serveDirsOnly{false};

--- a/tests/teststaticcompressed.cpp
+++ b/tests/teststaticcompressed.cpp
@@ -88,7 +88,13 @@ TestEngine *TestStaticCompressed::getEngine(bool serveDirsOnly)
     auto app    = new TestApplication;
     auto engine = new TestEngine(app, {});
 
-    auto plug = new StaticCompressed(app);
+    const QVariantMap defaultConfig{{u"zlib_compression_level"_qs, 1},
+                                    {u"brotli_quality_level"_qs, 0},
+                                    {u"use_zopfli"_qs, true},
+                                    {u"zopfli_iterations"_qs, 5},
+                                    {u"zstd_compression_level"_qs, 1}};
+
+    auto plug = new StaticCompressed(app, defaultConfig);
     plug->setIncludePaths({m_dataDir.path()});
     plug->setDirs({u"forced"_qs});
     plug->setServeDirsOnly(serveDirsOnly);

--- a/tests/teststaticcompressed.cpp
+++ b/tests/teststaticcompressed.cpp
@@ -65,6 +65,9 @@ const QStringList TestStaticCompressed::types{u"js"_qs,
                                               u"min.css.map"_qs};
 
 const QByteArrayList TestStaticCompressed::encoding{
+#ifdef CUTELYST_STATICCOMPRESSED_WITH_ZSTD
+    "zstd",
+#endif
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_BROTLI
     "br",
 #endif
@@ -98,16 +101,18 @@ TestEngine *TestStaticCompressed::getEngine(bool serveDirsOnly)
 
 TestEngine::TestResponse TestStaticCompressed::getFile(const QString &path, const Headers &headers)
 {
-    const Headers hdrs =
-        headers.data().empty() ? Headers({{"Accept-Encoding", "gzip, defalte, br"}}) : headers;
+    const Headers hdrs = headers.data().empty()
+                             ? Headers({{"Accept-Encoding", "gzip, deflate, br, zstd"}})
+                             : headers;
     return m_engine->createRequest("GET", path, {}, headers, nullptr);
 }
 
 TestEngine::TestResponse TestStaticCompressed::getForcedFile(const QString &path,
                                                              const Headers &headers)
 {
-    const Headers hdrs =
-        headers.data().empty() ? Headers({{"Accept-Encoding", "gzip, defalte, br"}}) : headers;
+    const Headers hdrs = headers.data().empty()
+                             ? Headers({{"Accept-Encoding", "gzip, deflate, br, zstd"}})
+                             : headers;
     return m_engineDirsOnly->createRequest("GET", path, {}, headers, nullptr);
 }
 
@@ -201,7 +206,9 @@ void TestStaticCompressed::testPreCompressed()
 
     QVERIFY(writeTestFile(fileName));
     QString encodedFileName = fileName;
-    if (encoding == "br") {
+    if (encoding == "zstd") {
+        encodedFileName += u".zst"_qs;
+    } else if (encoding == "br") {
         encodedFileName += u".br"_qs;
     } else if (encoding == "gzip") {
         encodedFileName += u".gz"_qs;


### PR DESCRIPTION
This adds support for Zstandard compression if enabled via CMake `-DPLUGIN_STATICCOMPRESSED_ZSTD:BOOL=ON`. For this the header and development files of libzstd >= 1.4.0 are required.

Also improves and fixes the internal _gzip_ and _deflate_ compression created by qCompress().

Adds a new configuration file option `compression_format_order` to select the order of the available compression formats.