### PR TITLE
Fix deprecated string literal operators

### DIFF
--- a/Cutelyst/Actions/REST/actionrest.cpp
+++ b/Cutelyst/Actions/REST/actionrest.cpp
@@ -99,10 +99,10 @@ bool ActionRESTPrivate::dispatchRestMethod(Context *c, const QByteArray &httpMet
         ret = returnOptions(c, q->name());
     } else if (httpMethod.compare("HEAD") == 0) {
         // redispatch to GET
-        ret = dispatchRestMethod(c, "GET"_qba);
+        ret = dispatchRestMethod(c, "GET"_ba);
     } else if (httpMethod.compare("not_implemented") != 0) {
         // try dispatching to foo_not_implemented
-        ret = dispatchRestMethod(c, "not_implemented"_qba);
+        ret = dispatchRestMethod(c, "not_implemented"_ba);
     } else {
         // not_implemented
         ret = returnNotImplemented(c, q->name());
@@ -114,9 +114,9 @@ bool ActionRESTPrivate::dispatchRestMethod(Context *c, const QByteArray &httpMet
 bool ActionRESTPrivate::returnOptions(Context *c, const QString &methodName) const
 {
     Response *response = c->response();
-    response->setContentType("text/plain"_qba);
+    response->setContentType("text/plain"_ba);
     response->setStatus(Response::OK); // 200
-    response->setHeader("Allow"_qba, getAllowedMethods(c->controller(), methodName));
+    response->setHeader("Allow"_ba, getAllowedMethods(c->controller(), methodName));
     response->body().clear();
     return true;
 }
@@ -125,7 +125,7 @@ bool ActionRESTPrivate::returnNotImplemented(Context *c, const QString &methodNa
 {
     Response *response = c->response();
     response->setStatus(Response::MethodNotAllowed); // 405
-    response->setHeader("Allow"_qba, getAllowedMethods(c->controller(), methodName));
+    response->setHeader("Allow"_ba, getAllowedMethods(c->controller(), methodName));
 
     const QByteArray body = "Method " + c->req()->method() + " not implemented for " +
                             c->request()->uri().toString(QUrl::FullyEncoded).toLatin1();

--- a/Cutelyst/Actions/RenderView/renderview.cpp
+++ b/Cutelyst/Actions/RenderView/renderview.cpp
@@ -14,6 +14,7 @@
 Q_LOGGING_CATEGORY(CUTELYST_RENDERVIEW, "cutelyst.renderview", QtWarningMsg)
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 /**
  * \ingroup core-actions
@@ -65,8 +66,8 @@ bool RenderView::init(Cutelyst::Application *application, const QVariantHash &ar
 {
     Q_D(RenderView);
 
-    const auto attributes = args.value(u"attributes"_qs).value<ParamsMultiMap>();
-    d->view               = application->view(attributes.value(u"View"_qs));
+    const auto attributes = args.value(u"attributes"_s).value<ParamsMultiMap>();
+    d->view               = application->view(attributes.value(u"View"_s));
 
     return Action::init(application, args);
 }
@@ -81,7 +82,7 @@ bool RenderView::doExecute(Cutelyst::Context *c)
 
     Response *res = c->res();
     if (res->contentType().isEmpty()) {
-        res->setContentType("text/html; charset=utf-8"_qba);
+        res->setContentType("text/html; charset=utf-8"_ba);
     }
 
     if (c->req()->isHead()) {

--- a/Cutelyst/Plugins/Authentication/credentialhttp.cpp
+++ b/Cutelyst/Plugins/Authentication/credentialhttp.cpp
@@ -13,6 +13,7 @@
 #include <QUrl>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Q_LOGGING_CATEGORY(C_CREDENTIALHTTP, "cutelyst.plugin.credentialhttp", QtWarningMsg)
 
@@ -182,10 +183,10 @@ AuthenticationUser CredentialHttpPrivate::authenticationFailed(Context *c,
     Q_UNUSED(authinfo);
     Response *res = c->response();
     res->setStatus(Response::Unauthorized); // 401
-    res->setContentType("text/plain; charset=UTF-8"_qba);
+    res->setContentType("text/plain; charset=UTF-8"_ba);
 
     if (authorizationRequiredMessage.isEmpty()) {
-        res->setBody("Authorization required."_qba);
+        res->setBody("Authorization required."_ba);
     } else {
         res->setBody(authorizationRequiredMessage);
     }
@@ -206,7 +207,7 @@ bool CredentialHttpPrivate::isAuthTypeBasic() const
 void CredentialHttpPrivate::createBasicAuthResponse(Context *c, AuthenticationRealm *realm)
 {
     c->res()->headers().setWwwAuthenticate(
-        joinAuthHeaderParts("Basic"_qba, buildAuthHeaderCommon(realm)));
+        joinAuthHeaderParts("Basic"_ba, buildAuthHeaderCommon(realm)));
 }
 
 QByteArrayList CredentialHttpPrivate::buildAuthHeaderCommon(AuthenticationRealm *realm) const

--- a/Cutelyst/Plugins/CSRFProtection/csrfprotection_p.h
+++ b/Cutelyst/Plugins/CSRFProtection/csrfprotection_p.h
@@ -56,7 +56,7 @@ public:
     QString defaultDetachTo;
     QString errorMsgStashKey;
     QString genericErrorMessage;
-    QByteArray genericContentType{"text/plain; charset=utf8"_qba};
+    QByteArray genericContentType{QByteArrayLiteral("text/plain; charset=utf8")};
     std::chrono::seconds cookieExpiration{0};
     QNetworkCookie::SameSite cookieSameSite = QNetworkCookie::SameSite::Strict;
     bool cookieHttpOnly{false};

--- a/Cutelyst/Plugins/Memcached/memcached.cpp
+++ b/Cutelyst/Plugins/Memcached/memcached.cpp
@@ -15,6 +15,7 @@
 Q_LOGGING_CATEGORY(C_MEMCACHED, "cutelyst.plugin.memcached", QtWarningMsg)
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static thread_local Memcached *mcd = nullptr;
@@ -46,51 +47,51 @@ bool Memcached::setup(Application *app)
 {
     Q_D(Memcached);
 
-    d->loadedConfig = app->engine()->config(u"Cutelyst_Memcached_Plugin"_qs);
+    d->loadedConfig = app->engine()->config(u"Cutelyst_Memcached_Plugin"_s);
     QStringList memcConfig;
 
-    const QStringList serverList = d->config(u"servers"_qs).toString().split(u';');
+    const QStringList serverList = d->config(u"servers"_s).toString().split(u';');
 
     if (serverList.empty()) {
-        memcConfig.push_back(u"--SERVER=localhost"_qs);
+        memcConfig.push_back(u"--SERVER=localhost"_s);
     }
 
-    for (const QString &flag : {u"verify_key"_qs,
-                                u"remove_failed_servers"_qs,
-                                u"binary_protocol"_qs,
-                                u"buffer_requests"_qs,
-                                u"hash_with_namespace"_qs,
-                                u"noreply"_qs,
-                                u"randomize_replica_read"_qs,
-                                u"sort_hosts"_qs,
-                                u"support_cas"_qs,
-                                u"use_udp"_qs,
-                                u"tcp_nodelay"_qs,
-                                u"tcp_keepalive"_qs}) {
+    for (const QString &flag : {u"verify_key"_s,
+                                u"remove_failed_servers"_s,
+                                u"binary_protocol"_s,
+                                u"buffer_requests"_s,
+                                u"hash_with_namespace"_s,
+                                u"noreply"_s,
+                                u"randomize_replica_read"_s,
+                                u"sort_hosts"_s,
+                                u"support_cas"_s,
+                                u"use_udp"_s,
+                                u"tcp_nodelay"_s,
+                                u"tcp_keepalive"_s}) {
         if (d->config(flag, false).toBool()) {
             const QString flagStr = u"--" + flag.toUpper().replace(u'_', u'-');
             memcConfig.push_back(flagStr);
         }
     }
 
-    const bool useUDP = d->config(u"use_udp"_qs, false).toBool();
+    const bool useUDP = d->config(u"use_udp"_s, false).toBool();
 
     for (const QString &opt : {
-             u"connect_timeout"_qs,
-             u"distribution"_qs,
-             u"hash"_qs,
-             u"number_of_replicas"_qs,
-             u"namespace"_qs,
-             u"retry_timeout"_qs,
-             u"server_failure_limit"_qs,
-             u"snd_timeout"_qs,
-             u"socket_recv_size"_qs,
-             u"socket_send_size"_qs,
-             u"poll_timeout"_qs,
-             u"io_bytes_watermark"_qs,
-             u"io_key_prefetch"_qs,
-             u"io_msg_watermark"_qs,
-             u"rcv_timeout"_qs,
+             u"connect_timeout"_s,
+             u"distribution"_s,
+             u"hash"_s,
+             u"number_of_replicas"_s,
+             u"namespace"_s,
+             u"retry_timeout"_s,
+             u"server_failure_limit"_s,
+             u"snd_timeout"_s,
+             u"socket_recv_size"_s,
+             u"socket_send_size"_s,
+             u"poll_timeout"_s,
+             u"io_bytes_watermark"_s,
+             u"io_key_prefetch"_s,
+             u"io_msg_watermark"_s,
+             u"rcv_timeout"_s,
          }) {
         const QString _val = d->config(opt).toString();
         if (!_val.isEmpty()) {
@@ -193,10 +194,10 @@ bool Memcached::setup(Application *app)
             }
         }
 
-        d->compression      = d->config(u"compression"_qs, false).toBool();
-        d->compressionLevel = d->config(u"compression_level"_qs, -1).toInt();
+        d->compression      = d->config(u"compression"_s, false).toBool();
+        d->compressionLevel = d->config(u"compression_level"_s, -1).toInt();
         d->compressionThreshold =
-            d->config(u"compression_threshold"_qs, MemcachedPrivate::defaultCompressionThreshold)
+            d->config(u"compression_threshold"_s, MemcachedPrivate::defaultCompressionThreshold)
                 .toInt();
         if (d->compression) {
             qCInfo(C_MEMCACHED).nospace()
@@ -206,7 +207,7 @@ bool Memcached::setup(Application *app)
             qCInfo(C_MEMCACHED) << "Compression: disabled";
         }
 
-        const QString encKey = d->config(u"encryption_key"_qs).toString();
+        const QString encKey = d->config(u"encryption_key"_s).toString();
         if (!encKey.isEmpty()) {
             const QByteArray encKeyBa = encKey.toUtf8();
             const memcached_return_t rt =
@@ -223,8 +224,8 @@ bool Memcached::setup(Application *app)
 
 #ifdef LIBMEMCACHED_WITH_SASL_SUPPORT
 #    if LIBMEMCACHED_WITH_SASL_SUPPORT == 1
-        const QString saslUser = d->config(u"sasl_user"_qs).toString();
-        const QString saslPass = d->config(u"sasl_password"_qs).toString();
+        const QString saslUser = d->config(u"sasl_user"_s).toString();
+        const QString saslPass = d->config(u"sasl_password"_s).toString();
         if (!saslUser.isEmpty() && !saslPass.isEmpty()) {
             const memcached_return_t rt = memcached_set_sasl_auth_data(
                 new_memc, saslUser.toUtf8().constData(), saslPass.toUtf8().constData());
@@ -250,7 +251,7 @@ bool Memcached::setup(Application *app)
 
     if (ok) {
         connect(app, &Application::postForked, this, [this] { mcd = this; });
-        app->loadTranslations(u"plugin_memcached"_qs);
+        app->loadTranslations(u"plugin_memcached"_s);
     } else {
         qCCritical(C_MEMCACHED) << "Failed to configure the connection to the memcached server(s)";
     }

--- a/Cutelyst/Plugins/MemcachedSessionStore/memcachedsessionstore.cpp
+++ b/Cutelyst/Plugins/MemcachedSessionStore/memcachedsessionstore.cpp
@@ -14,11 +14,12 @@
 #include <QLoggingCategory>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Q_LOGGING_CATEGORY(C_MEMCACHEDSESSIONSTORE, "cutelyst.plugin.sessionmemcached", QtWarningMsg)
 
-const QString MemcachedSessionStorePrivate::stashKeyMemcdSave{u"_c_session_store_memcd_save"_qs};
-const QString MemcachedSessionStorePrivate::stashKeyMemcdData{u"_c_session_store_memcd_data"_qs};
+const QString MemcachedSessionStorePrivate::stashKeyMemcdSave{u"_c_session_store_memcd_save"_s};
+const QString MemcachedSessionStorePrivate::stashKeyMemcdData{u"_c_session_store_memcd_data"_s};
 
 static QVariantHash
     loadMemcSessionData(Context *c, const QByteArray &sid, const QByteArray &groupKey);
@@ -31,8 +32,8 @@ MemcachedSessionStore::MemcachedSessionStore(Cutelyst::Application *app, QObject
     Q_ASSERT_X(app,
                "construct MemachedSessionStore",
                "you have to specifiy a pointer to the Application object");
-    const QVariantMap map = app->engine()->config(u"Cutelyst_MemcachedSessionStore_Plugin"_qs);
-    d->groupKey           = map.value(u"group_key"_qs).toString().toLatin1();
+    const QVariantMap map = app->engine()->config(u"Cutelyst_MemcachedSessionStore_Plugin"_s);
+    d->groupKey           = map.value(u"group_key"_s).toString().toLatin1();
 }
 
 MemcachedSessionStore::~MemcachedSessionStore() = default;
@@ -122,7 +123,7 @@ QVariantHash loadMemcSessionData(Context *c, const QByteArray &sid, const QByteA
             }
         } else {
             bool ok            = false;
-            const auto expires = data.value(u"expires"_qs).value<time_t>();
+            const auto expires = data.value(u"expires"_s).value<time_t>();
             if (groupKey.isEmpty()) {
                 ok = Memcached::set(sessionKey, data, expires);
             } else {

--- a/Cutelyst/Plugins/Session/session.cpp
+++ b/Cutelyst/Plugins/Session/session.cpp
@@ -17,6 +17,7 @@
 #include <QUuid>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Q_LOGGING_CATEGORY(C_SESSION, "cutelyst.plugin.session", QtWarningMsg)
 
@@ -55,17 +56,17 @@ bool Session::setup(Application *app)
     Q_D(Session);
     d->sessionName = QCoreApplication::applicationName().toLatin1() + "_session";
 
-    d->loadedConfig   = app->engine()->config(u"Cutelyst_Session_Plugin"_qs);
+    d->loadedConfig   = app->engine()->config(u"Cutelyst_Session_Plugin"_s);
     d->sessionExpires = std::chrono::duration_cast<std::chrono::seconds>(
-                            Utils::durationFromString(d->config(u"expires"_qs, 7200).toString()))
+                            Utils::durationFromString(d->config(u"expires"_s, 7200).toString()))
                             .count();
-    d->expiryThreshold = d->config(u"expiry_threshold"_qs, 0).toLongLong();
-    d->verifyAddress   = d->config(u"verify_address"_qs, false).toBool();
-    d->verifyUserAgent = d->config(u"verify_user_agent"_qs, false).toBool();
-    d->cookieHttpOnly  = d->config(u"cookie_http_only"_qs, true).toBool();
-    d->cookieSecure    = d->config(u"cookie_secure"_qs, false).toBool();
+    d->expiryThreshold = d->config(u"expiry_threshold"_s, 0).toLongLong();
+    d->verifyAddress   = d->config(u"verify_address"_s, false).toBool();
+    d->verifyUserAgent = d->config(u"verify_user_agent"_s, false).toBool();
+    d->cookieHttpOnly  = d->config(u"cookie_http_only"_s, true).toBool();
+    d->cookieSecure    = d->config(u"cookie_secure"_s, false).toBool();
 
-    const QString _sameSite = d->config(u"cookie_same_site"_qs, u"strict"_qs).toString();
+    const QString _sameSite = d->config(u"cookie_same_site"_s, u"strict"_s).toString();
     if (_sameSite.compare(u"default", Qt::CaseInsensitive) == 0) {
         d->cookieSameSite = QNetworkCookie::SameSite::Default;
     } else if (_sameSite.compare(u"none", Qt::CaseInsensitive) == 0) {
@@ -148,7 +149,7 @@ void Session::changeExpires(Context *c, quint64 expires)
         return;
     }
 
-    m_instance->d_ptr->store->storeSessionData(c, sid, u"expires"_qs, timeExp);
+    m_instance->d_ptr->store->storeSessionData(c, sid, u"expires"_s, timeExp);
 }
 
 void Session::deleteSession(Context *c, const QString &reason)
@@ -413,7 +414,7 @@ QVariant SessionPrivate::loadSession(Context *c)
             c->setStash(SESSION_VALUES, sessionData);
 
             if (m_instance->d_ptr->verifyAddress) {
-                auto it = sessionData.constFind(u"__address"_qs);
+                auto it = sessionData.constFind(u"__address"_s);
                 if (it != sessionData.constEnd() &&
                     it->toString() != c->request()->address().toString()) {
                     qCWarning(C_SESSION)
@@ -425,7 +426,7 @@ QVariant SessionPrivate::loadSession(Context *c)
             }
 
             if (m_instance->d_ptr->verifyUserAgent) {
-                auto it = sessionData.constFind(u"__user_agent"_qs);
+                auto it = sessionData.constFind(u"__user_agent"_s);
                 if (it != sessionData.constEnd() &&
                     it->toByteArray() != c->request()->userAgent()) {
                     qCWarning(C_SESSION)
@@ -600,7 +601,7 @@ QNetworkCookie SessionPrivate::makeSessionCookie(Session *session,
 {
     Q_UNUSED(c)
     QNetworkCookie cookie(session->d_ptr->sessionName, sid);
-    cookie.setPath(u"/"_qs);
+    cookie.setPath(u"/"_s);
     cookie.setExpirationDate(expires);
     cookie.setHttpOnly(session->d_ptr->cookieHttpOnly);
     cookie.setSecure(session->d_ptr->cookieSecure);

--- a/Cutelyst/Plugins/StaticCompressed/staticcompressed.cpp
+++ b/Cutelyst/Plugins/StaticCompressed/staticcompressed.cpp
@@ -28,6 +28,7 @@
 #endif
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Q_LOGGING_CATEGORY(C_STATICCOMPRESSED, "cutelyst.plugin.staticcompressed", QtWarningMsg)
 
@@ -36,7 +37,7 @@ StaticCompressed::StaticCompressed(Application *parent)
     , d_ptr(new StaticCompressedPrivate)
 {
     Q_D(StaticCompressed);
-    d->includePaths.append(parent->config(u"root"_qs).toString());
+    d->includePaths.append(parent->config(u"root"_s).toString());
 }
 
 StaticCompressed::StaticCompressed(Application *parent, const QVariantMap &defaultConfig)
@@ -44,7 +45,7 @@ StaticCompressed::StaticCompressed(Application *parent, const QVariantMap &defau
     , d_ptr(new StaticCompressedPrivate)
 {
     Q_D(StaticCompressed);
-    d->includePaths.append(parent->config(u"root"_qs).toString());
+    d->includePaths.append(parent->config(u"root"_s).toString());
     d->defaultConfig = defaultConfig;
 }
 
@@ -75,13 +76,13 @@ bool StaticCompressed::setup(Application *app)
 {
     Q_D(StaticCompressed);
 
-    const QVariantMap config = app->engine()->config(u"Cutelyst_StaticCompressed_Plugin"_qs);
+    const QVariantMap config = app->engine()->config(u"Cutelyst_StaticCompressed_Plugin"_s);
     const QString _defaultCacheDir =
         QStandardPaths::writableLocation(QStandardPaths::CacheLocation) +
         QLatin1String("/compressed-static");
     d->cacheDir.setPath(config
-                            .value(u"cache_directory"_qs,
-                                   d->defaultConfig.value(u"cache_directory"_qs, _defaultCacheDir))
+                            .value(u"cache_directory"_s,
+                                   d->defaultConfig.value(u"cache_directory"_s, _defaultCacheDir))
                             .toString());
 
     if (Q_UNLIKELY(!d->cacheDir.exists())) {
@@ -97,9 +98,9 @@ bool StaticCompressed::setup(Application *app)
 
     const QString _mimeTypes =
         config
-            .value(u"mime_types"_qs,
-                   d->defaultConfig.value(u"mime_types"_qs,
-                                          u"text/css,application/javascript,text/javascript"_qs))
+            .value(u"mime_types"_s,
+                   d->defaultConfig.value(u"mime_types"_s,
+                                          u"text/css,application/javascript,text/javascript"_s))
             .toString();
     qCInfo(C_STATICCOMPRESSED) << "MIME Types:" << _mimeTypes;
     d->mimeTypes = _mimeTypes.split(u',', Qt::SkipEmptyParts);
@@ -107,25 +108,25 @@ bool StaticCompressed::setup(Application *app)
     const QString _suffixes =
         config
             .value(
-                u"suffixes"_qs,
-                d->defaultConfig.value(u"suffixes"_qs, u"js.map,css.map,min.js.map,min.css.map"_qs))
+                u"suffixes"_s,
+                d->defaultConfig.value(u"suffixes"_s, u"js.map,css.map,min.js.map,min.css.map"_s))
             .toString();
     qCInfo(C_STATICCOMPRESSED) << "Suffixes:" << _suffixes;
     d->suffixes = _suffixes.split(u',', Qt::SkipEmptyParts);
 
     d->checkPreCompressed = config
-                                .value(u"check_pre_compressed"_qs,
-                                       d->defaultConfig.value(u"check_pre_compressed"_qs, true))
+                                .value(u"check_pre_compressed"_s,
+                                       d->defaultConfig.value(u"check_pre_compressed"_s, true))
                                 .toBool();
     qCInfo(C_STATICCOMPRESSED) << "Check for pre-compressed files:" << d->checkPreCompressed;
 
     d->onTheFlyCompression = config
-                                 .value(u"on_the_fly_compression"_qs,
-                                        d->defaultConfig.value(u"on_the_fly_compression"_qs, true))
+                                 .value(u"on_the_fly_compression"_s,
+                                        d->defaultConfig.value(u"on_the_fly_compression"_s, true))
                                  .toBool();
     qCInfo(C_STATICCOMPRESSED) << "Compress static files on the fly:" << d->onTheFlyCompression;
 
-    QStringList supportedCompressions{u"deflate"_qs, u"gzip"_qs};
+    QStringList supportedCompressions{u"deflate"_s, u"gzip"_s};
     d->loadZlibConfig(config);
 
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZOPFLI
@@ -135,30 +136,30 @@ bool StaticCompressed::setup(Application *app)
 
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_BROTLI
     d->loadBrotliConfig(config);
-    supportedCompressions << u"br"_qs;
+    supportedCompressions << u"br"_s;
 #endif
 
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZSTD
     if (Q_UNLIKELY(!d->loadZstdConfig(config))) {
         return false;
     }
-    supportedCompressions << u"zstd"_qs;
+    supportedCompressions << u"zstd"_s;
 #endif
 
     const QStringList defaultCompressionFormatOrder{
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_BROTLI
-        u"br"_qs,
+        u"br"_s,
 #endif
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZSTD
-        u"zstd"_qs,
+        u"zstd"_s,
 #endif
-        u"gzip"_qs,
-        u"deflate"_qs};
+        u"gzip"_s,
+        u"deflate"_s};
 
     QStringList _compressionFormatOrder =
         config
-            .value(u"compression_format_order"_qs,
-                   d->defaultConfig.value(u"compression_format_order"_qs,
+            .value(u"compression_format_order"_s,
+                   d->defaultConfig.value(u"compression_format_order"_s,
                                           defaultCompressionFormatOrder.join(u',')))
             .toString()
             .split(u',', Qt::SkipEmptyParts);
@@ -209,8 +210,8 @@ void StaticCompressedPrivate::beforePrepareAction(Context *c, bool *skipMethod)
             if (!locateCompressedFile(c, path)) {
                 Response *res = c->response();
                 res->setStatus(Response::NotFound);
-                res->setContentType("text/html"_qba);
-                res->setBody(u"File not found: "_qs + path);
+                res->setContentType("text/html"_ba);
+                res->setBody(u"File not found: "_s + path);
             }
 
             *skipMethod = true;
@@ -258,7 +259,7 @@ bool StaticCompressedPrivate::locateCompressedFile(Context *c, const QString &re
                 if (mimeType.isDefault()) {
                     if (path.endsWith(u"css.map", Qt::CaseInsensitive) ||
                         path.endsWith(u"js.map", Qt::CaseInsensitive)) {
-                        _mimeTypeName = "application/json"_qba;
+                        _mimeTypeName = "application/json"_ba;
                     }
                 }
 
@@ -279,7 +280,7 @@ bool StaticCompressedPrivate::locateCompressedFile(Context *c, const QString &re
                             } else {
                                 qCDebug(C_STATICCOMPRESSED)
                                     << "Serving brotli compressed data from" << compressedPath;
-                                contentEncoding = "br"_qba;
+                                contentEncoding = "br"_ba;
                                 break;
                             }
                         } else
@@ -292,7 +293,7 @@ bool StaticCompressedPrivate::locateCompressedFile(Context *c, const QString &re
                             } else {
                                 qCDebug(C_STATICCOMPRESSED)
                                     << "Serving zstd compressed data from" << compressedPath;
-                                contentEncoding = "zstd"_qba;
+                                contentEncoding = "zstd"_ba;
                                 break;
                             }
                         } else
@@ -306,7 +307,7 @@ bool StaticCompressedPrivate::locateCompressedFile(Context *c, const QString &re
                                 qCDebug(C_STATICCOMPRESSED)
                                     << "Serving" << (useZopfli ? "zopfli" : "default")
                                     << "compressed gzip data from" << compressedPath;
-                                contentEncoding = "gzip"_qba;
+                                contentEncoding = "gzip"_ba;
                                 break;
                             }
                         } else if (format == QLatin1String("deflate")) {
@@ -318,7 +319,7 @@ bool StaticCompressedPrivate::locateCompressedFile(Context *c, const QString &re
                                 qCDebug(C_STATICCOMPRESSED)
                                     << "Serving" << (useZopfli ? "zopfli" : "default")
                                     << "compressed deflate data from" << compressedPath;
-                                contentEncoding = "deflate"_qba;
+                                contentEncoding = "deflate"_ba;
                                 break;
                             }
                         }
@@ -347,7 +348,7 @@ bool StaticCompressedPrivate::locateCompressedFile(Context *c, const QString &re
 
                 headers.setLastModified(currentDateTime);
                 // Tell Firefox & friends its OK to cache, even over SSL
-                headers.setCacheControl("public"_qba);
+                headers.setCacheControl("public"_ba);
 
                 if (!contentEncoding.isEmpty()) {
                     // serve correct encoding type
@@ -358,7 +359,7 @@ bool StaticCompressedPrivate::locateCompressedFile(Context *c, const QString &re
                         << "Original Size:" << fileInfo.size();
 
                     // force proxies to cache compressed and non-compressed files separately
-                    headers.pushHeader("Vary"_qba, "Accept-Encoding"_qba);
+                    headers.pushHeader("Vary"_ba, "Accept-Encoding"_ba);
                 }
 
                 return true;
@@ -385,21 +386,21 @@ QString StaticCompressedPrivate::locateCacheFile(const QString &origPath,
     switch (compression) {
     case ZopfliGzip:
     case Gzip:
-        suffix = u".gz"_qs;
+        suffix = u".gz"_s;
         break;
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZSTD
     case Zstd:
-        suffix = u".zst"_qs;
+        suffix = u".zst"_s;
         break;
 #endif
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_BROTLI
     case Brotli:
-        suffix = u".br"_qs;
+        suffix = u".br"_s;
         break;
 #endif
     case ZopfliDeflate:
     case Deflate:
-        suffix = u".deflate"_qs;
+        suffix = u".deflate"_s;
         break;
     default:
         Q_ASSERT_X(false, "locate cache file", "invalid compression type");
@@ -481,8 +482,8 @@ void StaticCompressedPrivate::loadZlibConfig(const QVariantMap &conf)
 {
     bool ok = false;
     zlib.compressionLevel =
-        conf.value(u"zlib_compression_level"_qs,
-                   defaultConfig.value(u"zlib_compression_level"_qs, zlib.compressionLevelDefault))
+        conf.value(u"zlib_compression_level"_s,
+                   defaultConfig.value(u"zlib_compression_level"_s, zlib.compressionLevelDefault))
             .toInt(&ok);
 
     if (!ok || zlib.compressionLevel < zlib.compressionLevelMin ||
@@ -673,13 +674,13 @@ bool StaticCompressedPrivate::compressDeflate(const QString &inputPath,
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZOPFLI
 void StaticCompressedPrivate::loadZopfliConfig(const QVariantMap &conf)
 {
-    useZopfli = conf.value(u"use_zopfli"_qs, defaultConfig.value(u"use_zopfli"_qs, false)).toBool();
+    useZopfli = conf.value(u"use_zopfli"_s, defaultConfig.value(u"use_zopfli"_s, false)).toBool();
     if (useZopfli) {
         ZopfliInitOptions(&zopfli.options);
         bool ok = false;
         zopfli.options.numiterations =
-            conf.value(u"zopfli_iterations"_qs,
-                       defaultConfig.value(u"zopfli_iterations"_qs, zopfli.iterationsDefault))
+            conf.value(u"zopfli_iterations"_s,
+                       defaultConfig.value(u"zopfli_iterations"_s, zopfli.iterationsDefault))
                 .toInt(&ok);
         if (!ok || zopfli.options.numiterations < zopfli.iterationsMin) {
             qCWarning(C_STATICCOMPRESSED).nospace()
@@ -762,8 +763,8 @@ void StaticCompressedPrivate::loadBrotliConfig(const QVariantMap &conf)
 {
     bool ok = false;
     brotli.qualityLevel =
-        conf.value(u"brotli_quality_level"_qs,
-                   defaultConfig.value(u"brotli_quality_level"_qs, brotli.qualityLevelDefault))
+        conf.value(u"brotli_quality_level"_s,
+                   defaultConfig.value(u"brotli_quality_level"_s, brotli.qualityLevelDefault))
             .toInt(&ok);
 
     if (!ok || brotli.qualityLevel < BROTLI_MIN_QUALITY ||
@@ -858,8 +859,8 @@ bool StaticCompressedPrivate::loadZstdConfig(const QVariantMap &conf)
     bool ok = false;
 
     zstd.compressionLevel =
-        conf.value(u"zstd_compression_level"_qs,
-                   defaultConfig.value(u"zstd_compression_level"_qs, zstd.compressionLevelDefault))
+        conf.value(u"zstd_compression_level"_s,
+                   defaultConfig.value(u"zstd_compression_level"_s, zstd.compressionLevelDefault))
             .toInt(&ok);
     if (!ok || zstd.compressionLevel < ZSTD_minCLevel() ||
         zstd.compressionLevel > ZSTD_maxCLevel()) {

--- a/Cutelyst/Plugins/StaticSimple/staticsimple.cpp
+++ b/Cutelyst/Plugins/StaticSimple/staticsimple.cpp
@@ -15,6 +15,7 @@
 #include <QMimeDatabase>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Q_LOGGING_CATEGORY(C_STATICSIMPLE, "cutelyst.plugin.staticsimple", QtWarningMsg)
 
@@ -75,7 +76,7 @@ void StaticSimple::beforePrepareAction(Context *c, bool *skipMethod)
             if (!locateStaticFile(c, path)) {
                 Response *res = c->response();
                 res->setStatus(Response::NotFound);
-                res->setContentType("text/html"_qba);
+                res->setContentType("text/html"_ba);
                 res->setBody("File not found: " + path.toUtf8());
             }
 
@@ -128,7 +129,7 @@ bool StaticSimple::locateStaticFile(Context *c, const QString &relPath)
 
                 headers.setLastModified(currentDateTime);
                 // Tell Firefox & friends its OK to cache, even over SSL
-                headers.setHeader("Cache-Control"_qba, "public"_qba);
+                headers.setHeader("Cache-Control"_ba, "public"_ba);
 
                 return true;
             }

--- a/Cutelyst/Plugins/Utils/LangSelect/langselect.cpp
+++ b/Cutelyst/Plugins/Utils/LangSelect/langselect.cpp
@@ -23,11 +23,12 @@
 Q_LOGGING_CATEGORY(C_LANGSELECT, "cutelyst.plugin.langselect", QtWarningMsg)
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static thread_local LangSelect *lsp = nullptr;
 
-const QString LangSelectPrivate::stashKeySelectionTried{u"_c_langselect_tried"_qs};
+const QString LangSelectPrivate::stashKeySelectionTried{u"_c_langselect_tried"_s};
 
 LangSelect::LangSelect(Application *parent, Cutelyst::LangSelect::Source source)
     : Plugin(parent)
@@ -53,11 +54,11 @@ bool LangSelect::setup(Application *app)
 {
     Q_D(LangSelect);
 
-    const QVariantMap config = app->engine()->config(u"Cutelyst_LangSelect_Plugin"_qs);
+    const QVariantMap config = app->engine()->config(u"Cutelyst_LangSelect_Plugin"_s);
 
     bool cookieExpirationOk = false;
     const QString cookieExpireStr =
-        config.value(u"cookie_expiration"_qs, static_cast<qint64>(d->cookieExpiration.count()))
+        config.value(u"cookie_expiration"_s, static_cast<qint64>(d->cookieExpiration.count()))
             .toString();
     d->cookieExpiration = std::chrono::duration_cast<std::chrono::seconds>(
         Utils::durationFromString(cookieExpireStr, &cookieExpirationOk));
@@ -72,9 +73,9 @@ bool LangSelect::setup(Application *app)
         d->cookieExpiration = LangSelectPrivate::cookieDefaultExpiration;
     }
 
-    d->cookieDomain = config.value(u"cookie_domain"_qs).toString();
+    d->cookieDomain = config.value(u"cookie_domain"_s).toString();
 
-    const QString _sameSite = config.value(u"cookie_same_site"_qs, u"lax"_qs).toString();
+    const QString _sameSite = config.value(u"cookie_same_site"_s, u"lax"_s).toString();
     if (_sameSite.compare(u"default", Qt::CaseInsensitive) == 0) {
         d->cookieSameSite = QNetworkCookie::SameSite::Default;
     } else if (_sameSite.compare(u"none", Qt::CaseInsensitive) == 0) {
@@ -90,7 +91,7 @@ bool LangSelect::setup(Application *app)
         d->cookieSameSite = QNetworkCookie::SameSite::Lax;
     }
 
-    d->cookieSecure = config.value(u"cookie_secure"_qs).toBool();
+    d->cookieSecure = config.value(u"cookie_secure"_s).toBool();
 
     if ((d->cookieSameSite == QNetworkCookie::SameSite::None) && !d->cookieSecure) {
         qCWarning(C_LANGSELECT) << "cookie_same_site has been set to None but cookie_secure is "
@@ -201,8 +202,8 @@ void LangSelect::setLocalesFromDir(const QString &path,
     if (Q_LIKELY(!path.isEmpty() && !name.isEmpty())) {
         const QDir dir(path);
         if (Q_LIKELY(dir.exists())) {
-            const auto _pref     = prefix.isEmpty() ? u"."_qs : prefix;
-            const auto _suff     = suffix.isEmpty() ? u".qm"_qs : suffix;
+            const auto _pref     = prefix.isEmpty() ? u"."_s : prefix;
+            const auto _suff     = suffix.isEmpty() ? u".qm"_s : suffix;
             const QString filter = name + _pref + u'*' + _suff;
             const auto files     = dir.entryInfoList({name}, QDir::Files);
             if (Q_LIKELY(!files.empty())) {
@@ -793,11 +794,11 @@ void LangSelectPrivate::setFallback(Context *c) const
 void LangSelectPrivate::setContentLanguage(Context *c) const
 {
     if (addContentLanguageHeader) {
-        c->res()->setHeader("Content-Language"_qba, c->locale().bcp47Name().toLatin1());
+        c->res()->setHeader("Content-Language"_ba, c->locale().bcp47Name().toLatin1());
     }
     c->stash(
         {{langStashKey, c->locale().bcp47Name()},
-         {dirStashKey, (c->locale().textDirection() == Qt::LeftToRight ? u"ltr"_qs : u"rtl"_qs)}});
+         {dirStashKey, (c->locale().textDirection() == Qt::LeftToRight ? u"ltr"_s : u"rtl"_s)}});
 }
 
 void LangSelectPrivate::beforePrepareAction(Context *c, bool *skipMethod) const

--- a/Cutelyst/Plugins/Utils/LangSelect/langselect_p.h
+++ b/Cutelyst/Plugins/Utils/LangSelect/langselect_p.h
@@ -26,7 +26,8 @@ public:
     bool getFromSession(Context *c, const QString &key) const;
     bool getFromSubdomain(Context *c, const QMap<QString, QLocale> &map) const;
     bool getFromDomain(Context *c, const QMap<QString, QLocale> &map) const;
-    bool getFromHeader(Context *c, const QByteArray &name = "Accept-Language"_qba) const;
+    bool getFromHeader(Context *c,
+                       const QByteArray &name = QByteArrayLiteral("Accept-Language")) const;
     void setToQuery(Context *c, const QString &key) const;
     void setToCookie(Context *c, const QByteArray &name) const;
     void setToSession(Context *c, const QString &key) const;

--- a/Cutelyst/Plugins/Utils/Validator/validator.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validator.cpp
@@ -12,6 +12,7 @@
 #include <QLoggingCategory>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Q_LOGGING_CATEGORY(C_VALIDATOR, "cutelyst.utils.validator", QtWarningMsg)
 
@@ -102,13 +103,13 @@ ValidatorResult
     }
 
     if (!result && flags.testFlag(FillStashOnError)) {
-        c->setStash(u"validationErrorStrings"_qs, result.errorStrings());
-        c->setStash(u"validationErrors"_qs, QVariant::fromValue(result.errors()));
+        c->setStash(u"validationErrorStrings"_s, result.errorStrings());
+        c->setStash(u"validationErrors"_s, QVariant::fromValue(result.errors()));
 
         if (!params.isEmpty()) {
             auto i = params.constBegin();
             while (i != params.constEnd()) {
-                if (!i.key().contains(u"password"_qs, Qt::CaseInsensitive)) {
+                if (!i.key().contains(u"password"_s, Qt::CaseInsensitive)) {
                     c->setStash(i.key(), i.value());
                 }
                 ++i;
@@ -128,5 +129,5 @@ void Validator::addValidator(ValidatorRule *v)
 
 void Validator::loadTranslations(Application *app)
 {
-    app->loadTranslations(u"plugin_utils_validator"_qs);
+    app->loadTranslations(u"plugin_utils_validator"_s);
 }

--- a/Cutelyst/Plugins/Utils/Validator/validatoraccepted.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoraccepted.cpp
@@ -8,8 +8,9 @@
 #include <QStringList>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
-const QStringList ValidatorAcceptedPrivate::trueVals{u"yes"_qs, u"on"_qs, u"1"_qs, u"true"_qs};
+const QStringList ValidatorAcceptedPrivate::trueVals{u"yes"_s, u"on"_s, u"1"_s, u"true"_s};
 
 ValidatorAccepted::ValidatorAccepted(const QString &field,
                                      const Cutelyst::ValidatorMessages &messages)

--- a/Cutelyst/Plugins/Utils/Validator/validatoralpha.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralpha.cpp
@@ -6,8 +6,9 @@
 #include "validatoralpha_p.h"
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
-const QRegularExpression ValidatorAlphaPrivate::regex{u"^[\\pL\\pM]+$"_qs};
+const QRegularExpression ValidatorAlphaPrivate::regex{u"^[\\pL\\pM]+$"_s};
 
 ValidatorAlpha::ValidatorAlpha(const QString &field,
                                bool asciiOnly,

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphadash.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphadash.cpp
@@ -6,8 +6,9 @@
 #include "validatoralphadash_p.h"
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
-const QRegularExpression ValidatorAlphaDashPrivate::regex{u"^[\\pL\\pM\\pN_-]+$"_qs};
+const QRegularExpression ValidatorAlphaDashPrivate::regex{u"^[\\pL\\pM\\pN_-]+$"_s};
 
 ValidatorAlphaDash::ValidatorAlphaDash(const QString &field,
                                        bool asciiOnly,

--- a/Cutelyst/Plugins/Utils/Validator/validatoralphanum.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoralphanum.cpp
@@ -6,8 +6,9 @@
 #include "validatoralphanum_p.h"
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
-const QRegularExpression ValidatorAlphaNumPrivate::regex{u"^[\\pL\\pM\\pN]+$"_qs};
+const QRegularExpression ValidatorAlphaNumPrivate::regex{u"^[\\pL\\pM\\pN]+$"_s};
 
 ValidatorAlphaNum::ValidatorAlphaNum(const QString &field,
                                      bool asciiOnly,

--- a/Cutelyst/Plugins/Utils/Validator/validatorboolean.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorboolean.cpp
@@ -8,9 +8,10 @@
 #include <QStringList>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
-const QStringList ValidatorBooleanPrivate::trueVals{u"1"_qs, u"true"_qs, u"on"_qs};
-const QStringList ValidatorBooleanPrivate::falseVals{u"0"_qs, u"false"_qs, u"off"_qs};
+const QStringList ValidatorBooleanPrivate::trueVals{u"1"_s, u"true"_s, u"on"_s};
+const QStringList ValidatorBooleanPrivate::falseVals{u"0"_s, u"false"_s, u"off"_s};
 
 ValidatorBoolean::ValidatorBoolean(const QString &field,
                                    const ValidatorMessages &messages,

--- a/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatoremail.cpp
@@ -14,12 +14,13 @@
 #include <QUrl>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 const QRegularExpression ValidatorEmailPrivate::ipv4Regex{
     u"\\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25["
-    "0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"_qs};
-const QRegularExpression ValidatorEmailPrivate::ipv6PartRegex{u"^[0-9A-Fa-f]{0,4}$"_qs};
-const QString ValidatorEmailPrivate::stringSpecials{u"()<>[]:;@\\,.\""_qs};
+    "0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"_s};
+const QRegularExpression ValidatorEmailPrivate::ipv6PartRegex{u"^[0-9A-Fa-f]{0,4}$"_s};
+const QString ValidatorEmailPrivate::stringSpecials{u"()<>[]:;@\\,.\""_s};
 
 ValidatorEmail::ValidatorEmail(const QString &field,
                                Category threshold,

--- a/Cutelyst/Plugins/Utils/Validator/validatorip.cpp
+++ b/Cutelyst/Plugins/Utils/Validator/validatorip.cpp
@@ -10,9 +10,10 @@
 #include <QHostAddress>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 const QRegularExpression ValidatorIpPrivate::regex{
-    u"^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"_qs};
+    u"^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"_s};
 
 ValidatorIp::ValidatorIp(const QString &field,
                          Constraints constraints,

--- a/Cutelyst/Plugins/View/JSON/viewjson.cpp
+++ b/Cutelyst/Plugins/View/JSON/viewjson.cpp
@@ -11,6 +11,7 @@
 #include <QtCore/QJsonObject>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 ViewJson::ViewJson(QObject *parent, const QString &name)
     : View(new ViewJsonPrivate, parent, name)
@@ -136,10 +137,10 @@ QByteArray ViewJson::render(Context *c) const
 
     Response *res = c->response();
     if (d->xJsonHeader && c->request()->headers().contains("X-Prototype-Version")) {
-        res->setHeader("X-Json"_qba, "eval(\"(\"+this.transport.responseText+\")\")"_qba);
+        res->setHeader("X-Json"_ba, "eval(\"(\"+this.transport.responseText+\")\")"_ba);
     }
 
-    res->setContentType("application/json"_qba);
+    res->setContentType("application/json"_ba);
 
     return QJsonDocument(obj).toJson(d->format);
 }

--- a/Cutelyst/Server/localserver.cpp
+++ b/Cutelyst/Server/localserver.cpp
@@ -24,6 +24,7 @@ static inline int cutelyst_safe_accept(int s, struct sockaddr *addr, uint *addrl
 #endif
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 LocalServer::LocalServer(Server *wsgi, QObject *parent)
     : QLocalServer(parent)
@@ -103,7 +104,7 @@ void LocalServer::incomingConnection(quintptr handle)
     if (Q_LIKELY(sock->setSocketDescriptor(qintptr(handle)))) {
         sock->proto = m_protocol;
 
-        sock->serverAddress = "localhost"_qba;
+        sock->serverAddress = "localhost"_ba;
         if (++m_processing) {
             m_engine->startSocketTimeout();
         }

--- a/Cutelyst/Server/protocolfastcgi.cpp
+++ b/Cutelyst/Server/protocolfastcgi.cpp
@@ -155,7 +155,7 @@ quint16 ProtocolFastCGI::addHeader(ProtoRequestFastCGI *request,
         if (!request->headerHost && memcmp(key + 5, "HOST", 4) == 0) {
             request->serverAddress = value;
             request->headerHost    = true;
-            request->headers.pushHeader("Host"_qba, value);
+            request->headers.pushHeader(QByteArrayLiteral("Host"), value);
         } else {
             const auto keyStr = QByteArray(key + 5, keylen - 5).replace('_', '-');
             request->headers.pushHeader(keyStr, value);

--- a/Cutelyst/Server/protocolhttp.cpp
+++ b/Cutelyst/Server/protocolhttp.cpp
@@ -23,6 +23,7 @@
 #include <QVariant>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 QByteArray http11StatusMessage(quint16 status);
 
@@ -522,16 +523,16 @@ bool ProtoRequestHttp::webSocketHandshakeDo(const QByteArray &key,
     Cutelyst::Headers &headers             = response->headers();
 
     response->setStatus(Cutelyst::Response::SwitchingProtocols);
-    headers.setHeader("Upgrade"_qba, "WebSocket"_qba);
-    headers.setHeader("Connection"_qba, "Upgrade"_qba);
+    headers.setHeader("Upgrade"_ba, "WebSocket"_ba);
+    headers.setHeader("Connection"_ba, "Upgrade"_ba);
     const auto localOrigin = origin.isEmpty() ? requestHeaders.header("Origin") : origin;
-    headers.setHeader("Sec-Websocket-Origin"_qba, localOrigin.isEmpty() ? "*"_qba : localOrigin);
+    headers.setHeader("Sec-Websocket-Origin"_ba, localOrigin.isEmpty() ? "*"_ba : localOrigin);
 
     if (!protocol.isEmpty()) {
-        headers.setHeader("Sec-Websocket-Protocol"_qba, protocol);
+        headers.setHeader("Sec-Websocket-Protocol"_ba, protocol);
     } else if (const auto wsProtocol = requestHeaders.header("Sec-Websocket-Protocol");
                !wsProtocol.isEmpty()) {
-        headers.setHeader("Sec-Websocket-Protocol"_qba, wsProtocol);
+        headers.setHeader("Sec-Websocket-Protocol"_ba, wsProtocol);
     }
 
     const QByteArray localKey = key.isEmpty() ? requestHeaders.header("Sec-Websocket-Key") : key;
@@ -543,7 +544,7 @@ bool ProtoRequestHttp::webSocketHandshakeDo(const QByteArray &key,
 
     const QByteArray wsAccept =
         QCryptographicHash::hash(wsKey, QCryptographicHash::Sha1).toBase64();
-    headers.setHeader("Sec-Websocket-Accept"_qba, wsAccept);
+    headers.setHeader("Sec-Websocket-Accept"_ba, wsAccept);
 
     headerConnection  = ProtoRequestHttp::HeaderConnection::Upgrade;
     websocketUpgraded = true;

--- a/Cutelyst/Server/protocolhttp2.cpp
+++ b/Cutelyst/Server/protocolhttp2.cpp
@@ -12,6 +12,7 @@
 #include <QLoggingCategory>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Q_LOGGING_CATEGORY(C_SERVER_H2, "cutelyst.server.http2", QtWarningMsg)
 
@@ -849,7 +850,7 @@ H2Stream::H2Stream(quint32 _streamId, qint32 _initialWindowSize, ProtoRequestHtt
     , streamId(_streamId)
     , windowSize(_initialWindowSize)
 {
-    protocol      = "HTTP/2"_qba;
+    protocol      = "HTTP/2"_ba;
     serverAddress = protoRequestH2->sock->serverAddress;
     remoteAddress = protoRequestH2->sock->remoteAddress;
     remotePort    = protoRequestH2->sock->remotePort;

--- a/Cutelyst/Server/server.cpp
+++ b/Cutelyst/Server/server.cpp
@@ -40,6 +40,7 @@
 Q_LOGGING_CATEGORY(CUTELYST_SERVER, "cutelyst.server", QtWarningMsg)
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Server::Server(QObject *parent)
     : QObject(parent)
@@ -50,9 +51,9 @@ Server::Server(QObject *parent)
     if (!qEnvironmentVariableIsSet("QT_MESSAGE_PATTERN")) {
         if (qEnvironmentVariableIsSet("JOURNAL_STREAM")) {
             // systemd journal already logs PID, check if it logs threadid as well
-            qSetMessagePattern(u"%{category}[%{type}] %{message}"_qs);
+            qSetMessagePattern(u"%{category}[%{type}] %{message}"_s);
         } else {
-            qSetMessagePattern(u"%{pid}:%{threadid} %{category}[%{type}] %{message}"_qs);
+            qSetMessagePattern(u"%{pid}:%{threadid} %{category}[%{type}] %{message}"_s);
         }
     }
 
@@ -1933,7 +1934,7 @@ void ServerPrivate::loadConfig()
         ++loadedIt;
     }
 
-    QVariantMap sessionConfig = loadedConfig.value(u"server"_qs).toMap();
+    QVariantMap sessionConfig = loadedConfig.value(u"server"_s).toMap();
 
     applyConfig(sessionConfig);
 

--- a/Cutelyst/Server/staticmap.cpp
+++ b/Cutelyst/Server/staticmap.cpp
@@ -17,6 +17,7 @@
 Q_LOGGING_CATEGORY(C_SERVER_SM, "cutelyst.server.staticmap", QtWarningMsg)
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 StaticMap::StaticMap(Cutelyst::Application *parent)
     : Plugin(parent)
@@ -108,7 +109,7 @@ bool StaticMap::serveFile(Cutelyst::Context *c, const QString &filename)
 
         headers.setLastModified(currentDateTime);
         // Tell Firefox & friends its OK to cache, even over SSL
-        headers.setHeader("Cache-Control"_qba, "public"_qba);
+        headers.setHeader("Cache-Control"_ba, "public"_ba);
 
         return true;
     }

--- a/Cutelyst/action.cpp
+++ b/Cutelyst/action.cpp
@@ -8,6 +8,7 @@
 #include "controller.h"
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Action::Action(QObject *parent)
     : Component(new ActionPrivate, parent)
@@ -49,17 +50,17 @@ void Action::setupAction(const QVariantHash &args, Application *app)
 
     init(app, args);
 
-    d->ns = args.value(u"namespace"_qs).toString();
+    d->ns = args.value(u"namespace"_s).toString();
 
-    const auto attributes = args.value(u"attributes"_qs).value<ParamsMultiMap>();
+    const auto attributes = args.value(u"attributes"_s).value<ParamsMultiMap>();
     d->attributes         = attributes;
 
-    const QString argsAttr = attributes.value(u"Args"_qs);
+    const QString argsAttr = attributes.value(u"Args"_s);
     if (!argsAttr.isEmpty()) {
         d->numberOfArgs = qint8(argsAttr.toInt());
     }
 
-    const QString capturesAttr = attributes.value(u"CaptureArgs"_qs);
+    const QString capturesAttr = attributes.value(u"CaptureArgs"_s);
     if (!capturesAttr.isEmpty()) {
         d->numberOfCaptures = qint8(capturesAttr.toInt());
     }

--- a/Cutelyst/application.cpp
+++ b/Cutelyst/application.cpp
@@ -43,6 +43,7 @@ Q_LOGGING_CATEGORY(CUTELYST_STATS, "cutelyst.stats", QtWarningMsg)
 Q_LOGGING_CATEGORY(CUTELYST_COMPONENT, "cutelyst.component", QtWarningMsg)
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Application::Application(QObject *parent)
     : QObject(parent)
@@ -87,7 +88,7 @@ Headers &Application::defaultHeaders() noexcept
 void Application::addXCutelystVersionHeader()
 {
     Q_D(Application);
-    d->headers.setHeader("X-Cutelyst"_qba, QByteArrayLiteral(CUTELYST_VERSION));
+    d->headers.setHeader("X-Cutelyst"_ba, QByteArrayLiteral(CUTELYST_VERSION));
 }
 
 bool Application::registerPlugin(Plugin *plugin)
@@ -214,13 +215,13 @@ QVariantMap Application::config() const noexcept
 
 QString Application::pathTo(const QString &path) const
 {
-    QDir home = config(u"home"_qs).toString();
+    QDir home = config(u"home"_s).toString();
     return home.absoluteFilePath(path);
 }
 
 QString Cutelyst::Application::pathTo(const QStringList &path) const
 {
-    QDir home = config(u"home"_qs).toString();
+    QDir home = config(u"home"_s).toString();
     return home.absoluteFilePath(path.join(u'/'));
 }
 
@@ -283,9 +284,9 @@ bool Application::setup(Engine *engine)
 
         if (zeroCore) {
             QVector<QStringList> tableDataHandlers;
-            tableDataHandlers.append({u"application/x-www-form-urlencoded"_qs});
-            tableDataHandlers.append({u"application/json"_qs});
-            tableDataHandlers.append({u"multipart/form-data"_qs});
+            tableDataHandlers.append({u"application/x-www-form-urlencoded"_s});
+            tableDataHandlers.append({u"application/json"_s});
+            tableDataHandlers.append({u"multipart/form-data"_s});
             qCDebug(CUTELYST_CORE)
                 << Utils::buildTable(tableDataHandlers,
                                      QStringList(),
@@ -298,7 +299,7 @@ bool Application::setup(Engine *engine)
                 << "Using engine" << QString::fromLatin1(d->engine->metaObject()->className());
         }
 
-        QString home = d->config.value(u"home"_qs).toString();
+        QString home = d->config.value(u"home"_s).toString();
         if (home.isEmpty()) {
             if (zeroCore) {
                 qCDebug(CUTELYST_CORE) << "Couldn't find home";

--- a/Cutelyst/context.cpp
+++ b/Cutelyst/context.cpp
@@ -20,6 +20,7 @@
 #include <QUrlQuery>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Context::Context(ContextPrivate *priv)
     : d_ptr(priv)
@@ -503,9 +504,9 @@ void Context::finalize()
         qCDebug(CUTELYST_STATS,
                 "Response Code: %d; Content-Type: %s; Content-Length: %s",
                 d->response->status(),
-                d->response->headers().header("Content-Type"_qba, "unknown"_qba).constData(),
+                d->response->headers().header("Content-Type"_ba, "unknown"_ba).constData(),
                 d->response->headers()
-                    .header("Content-Length"_qba, QByteArray::number(d->response->size()))
+                    .header("Content-Length"_ba, QByteArray::number(d->response->size()))
                     .constData());
 
         const std::chrono::duration<double> duration =

--- a/Cutelyst/controller.cpp
+++ b/Cutelyst/controller.cpp
@@ -13,6 +13,7 @@
 #include <QRegularExpression>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 /**
  * \ingroup core
@@ -590,7 +591,7 @@ ParamsMultiMap ControllerPrivate::parseAttributes(const QMetaMethod &method,
         ++pos;
     }
 
-    const static auto digitRE = QRegularExpression(u"\\D"_qs);
+    const static auto digitRE = QRegularExpression(u"\\D"_s);
 
     // Add the attributes to the map in the reverse order so
     // that values() return them in the right order
@@ -715,7 +716,7 @@ QObject *ControllerPrivate::instantiateClass(const QString &name, const QByteArr
 {
     QString instanceName = name;
     if (!instanceName.isEmpty()) {
-        const static QRegularExpression nonWordsRE(u"\\W"_qs);
+        const static QRegularExpression nonWordsRE(u"\\W"_s);
         instanceName.remove(nonWordsRE);
 
         QMetaType id = QMetaType::fromName(instanceName.toLatin1().data());

--- a/Cutelyst/dispatcher.cpp
+++ b/Cutelyst/dispatcher.cpp
@@ -19,6 +19,7 @@
 #include <QUrl>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Dispatcher::Dispatcher(QObject *parent)
     : QObject(parent)
@@ -285,13 +286,13 @@ QString Dispatcher::uriForAction(Action *action, const QStringList &captures) co
     QString ret;
     if (Q_UNLIKELY(action == nullptr)) {
         qCCritical(CUTELYST_DISPATCHER) << "Dispatcher::uriForAction called with null action";
-        ret = u"/"_qs;
+        ret = u"/"_s;
     } else {
         for (DispatchType *dispatch : d->dispatchers) {
             ret = dispatch->uriForAction(action, captures);
             if (!ret.isNull()) {
                 if (ret.isEmpty()) {
-                    ret = u"/"_qs;
+                    ret = u"/"_s;
                 }
                 break;
             }

--- a/Cutelyst/dispatchtypechained.cpp
+++ b/Cutelyst/dispatchtypechained.cpp
@@ -11,6 +11,7 @@
 #include <QtCore/QUrl>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 DispatchTypeChained::DispatchTypeChained(QObject *parent)
     : DispatchType(parent)
@@ -164,7 +165,7 @@ DispatchType::MatchType
     // TODO avoid toString()
     // TODO remove mid(1)
     const BestActionMatch ret =
-        d->recurseMatch(args.size(), u"/"_qs, path.mid(1).toString().split(QLatin1Char('/')));
+        d->recurseMatch(args.size(), u"/"_s, path.mid(1).toString().split(QLatin1Char('/')));
     const ActionList chain = ret.actions;
     if (ret.isNull || chain.isEmpty()) {
         return NoMatch;

--- a/Cutelyst/dispatchtypepath.cpp
+++ b/Cutelyst/dispatchtypepath.cpp
@@ -12,6 +12,7 @@
 #include <QRegularExpression>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 DispatchTypePath::DispatchTypePath(QObject *parent)
     : DispatchType(parent)
@@ -28,7 +29,7 @@ QByteArray DispatchTypePath::list() const
 {
     Q_D(const DispatchTypePath);
 
-    const static QRegularExpression multipleSlashes(u"/{1,}"_qs);
+    const static QRegularExpression multipleSlashes(u"/{1,}"_s);
 
     QVector<QStringList> table;
 
@@ -41,14 +42,14 @@ QByteArray DispatchTypePath::list() const
         const auto paths = d->paths.value(path);
         for (Action *action : paths.actions) {
             QString _path = u'/' + path;
-            if (action->attribute(u"Args"_qs).isEmpty()) {
+            if (action->attribute(u"Args"_s).isEmpty()) {
                 _path.append(u"/...");
             } else {
                 for (int i = 0; i < action->numberOfArgs(); ++i) {
                     _path.append(u"/*");
                 }
             }
-            _path.replace(multipleSlashes, u"/"_qs);
+            _path.replace(multipleSlashes, u"/"_s);
 
             QString privateName = action->reverse();
             if (!privateName.startsWith(u'/')) {
@@ -59,7 +60,7 @@ QByteArray DispatchTypePath::list() const
         }
     }
 
-    return Utils::buildTable(table, {u"Path"_qs, u"Private"_qs}, u"Loaded Path actions:"_qs);
+    return Utils::buildTable(table, {u"Path"_s, u"Private"_s}, u"Loaded Path actions:"_s);
 }
 
 Cutelyst::DispatchType::MatchType
@@ -103,7 +104,7 @@ bool DispatchTypePath::registerAction(Action *action)
 
     bool ret              = false;
     const auto attributes = action->attributes();
-    const auto range      = attributes.equal_range(u"Path"_qs);
+    const auto range      = attributes.equal_range(u"Path"_s);
     for (auto i = range.first; i != range.second; ++i) {
         if (d->registerPath(*i, action)) {
             ret = true;
@@ -125,11 +126,11 @@ QString DispatchTypePath::uriForAction(Cutelyst::Action *action, const QStringLi
     QString ret;
     if (captures.isEmpty()) {
         const auto attributes = action->attributes();
-        auto it               = attributes.constFind(u"Path"_qs);
+        auto it               = attributes.constFind(u"Path"_s);
         if (it != attributes.constEnd()) {
             const QString &path = it.value();
             if (path.isEmpty()) {
-                ret = u"/"_qs;
+                ret = u"/"_s;
             } else if (!path.startsWith(u'/')) {
                 ret = u'/' + path;
             } else {
@@ -145,7 +146,7 @@ bool DispatchTypePathPrivate::registerPath(const QString &path, Action *action)
     QString _path = path;
     // TODO see if we can make controllers fix this
     if (_path.isEmpty()) {
-        _path = u"/"_qs;
+        _path = u"/"_s;
     } else if (!_path.startsWith(u'/')) {
         _path.prepend(u'/');
     }

--- a/Cutelyst/enginerequest.cpp
+++ b/Cutelyst/enginerequest.cpp
@@ -13,6 +13,7 @@
 Q_LOGGING_CATEGORY(CUTELYST_ENGINEREQUEST, "cutelyst.engine_request", QtWarningMsg)
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 EngineRequest::EngineRequest()
 {
@@ -60,7 +61,7 @@ void EngineRequest::finalizeError()
 {
     Response *res = context->response();
 
-    res->setContentType("text/html; charset=utf-8"_qba);
+    res->setContentType("text/html; charset=utf-8"_ba);
 
     QByteArray body;
 
@@ -96,7 +97,7 @@ void EngineRequest::finalizeCookies()
     Headers &headers   = res->headers();
     const auto cookies = res->cookies();
     for (const QNetworkCookie &cookie : cookies) {
-        headers.pushHeader("Set-Cookie"_qba, cookie.toRawForm());
+        headers.pushHeader("Set-Cookie"_ba, cookie.toRawForm());
     }
 }
 
@@ -201,7 +202,7 @@ bool EngineRequest::webSocketHandshakeDo(const QByteArray &key,
 void EngineRequest::setPath(char *rawPath, const int len)
 {
     if (len == 0) {
-        path = u"/"_qs;
+        path = u"/"_s;
         return;
     }
 

--- a/Cutelyst/headers.cpp
+++ b/Cutelyst/headers.cpp
@@ -10,6 +10,7 @@
 #include <QStringList>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 inline QByteArray decodeBasicAuth(const QByteArray &auth);
 inline Headers::Authorization decodeBasicAuthPair(const QByteArray &auth);
@@ -37,12 +38,12 @@ QByteArray Headers::contentDisposition() const noexcept
 
 void Headers::setCacheControl(const QByteArray &value)
 {
-    setHeader("Cache-Control"_qba, value);
+    setHeader("Cache-Control"_ba, value);
 }
 
 void Headers::setContentDisposition(const QByteArray &contentDisposition)
 {
-    setHeader("Content-Disposition"_qba, contentDisposition);
+    setHeader("Content-Disposition"_ba, contentDisposition);
 }
 
 void Headers::setContentDispositionAttachment(const QByteArray &filename)
@@ -61,7 +62,7 @@ QByteArray Headers::contentEncoding() const noexcept
 
 void Headers::setContentEncoding(const QByteArray &encoding)
 {
-    setHeader("Content-Encoding"_qba, encoding);
+    setHeader("Content-Encoding"_ba, encoding);
 }
 
 QByteArray Headers::contentType() const
@@ -75,7 +76,7 @@ QByteArray Headers::contentType() const
 
 void Headers::setContentType(const QByteArray &contentType)
 {
-    setHeader("Content-Type"_qba, contentType);
+    setHeader("Content-Type"_ba, contentType);
 }
 
 QByteArray Headers::contentTypeCharset() const
@@ -171,7 +172,7 @@ qint64 Headers::contentLength() const
 
 void Headers::setContentLength(qint64 value)
 {
-    setHeader("Content-Length"_qba, QByteArray::number(value));
+    setHeader("Content-Length"_ba, QByteArray::number(value));
 }
 
 QByteArray Headers::setDateWithDateTime(const QDateTime &date)
@@ -180,7 +181,7 @@ QByteArray Headers::setDateWithDateTime(const QDateTime &date)
     // and follow RFC 822
     QByteArray dt =
         QLocale::c().toString(date.toUTC(), u"ddd, dd MMM yyyy hh:mm:ss 'GMT").toLatin1();
-    setHeader("Date"_qba, dt);
+    setHeader("Date"_ba, dt);
     return dt;
 }
 
@@ -260,7 +261,7 @@ bool Headers::ifNoneMatch(const QByteArray &etag) const
 
 void Headers::setETag(const QByteArray &etag)
 {
-    setHeader("ETag"_qba, '"' + etag + '"');
+    setHeader("ETag"_ba, '"' + etag + '"');
 }
 
 QByteArray Headers::lastModified() const noexcept
@@ -270,7 +271,7 @@ QByteArray Headers::lastModified() const noexcept
 
 void Headers::setLastModified(const QByteArray &value)
 {
-    setHeader("Last-Modified"_qba, value);
+    setHeader("Last-Modified"_ba, value);
 }
 
 QString Headers::setLastModified(const QDateTime &lastModified)
@@ -289,7 +290,7 @@ QByteArray Headers::server() const noexcept
 
 void Headers::setServer(const QByteArray &value)
 {
-    setHeader("Server"_qba, value);
+    setHeader("Server"_ba, value);
 }
 
 QByteArray Headers::connection() const noexcept
@@ -317,20 +318,20 @@ void Headers::setReferer(const QByteArray &uri)
     int fragmentPos = uri.indexOf('#');
     if (fragmentPos != -1) {
         // Strip fragment per RFC 2616, section 14.36.
-        setHeader("Referer"_qba, uri.mid(0, fragmentPos));
+        setHeader("Referer"_ba, uri.mid(0, fragmentPos));
     } else {
-        setHeader("Referer"_qba, uri);
+        setHeader("Referer"_ba, uri);
     }
 }
 
 void Headers::setWwwAuthenticate(const QByteArray &value)
 {
-    setHeader("Www-Authenticate"_qba, value);
+    setHeader("Www-Authenticate"_ba, value);
 }
 
 void Headers::setProxyAuthenticate(const QByteArray &value)
 {
-    setHeader("Proxy-Authenticate"_qba, value);
+    setHeader("Proxy-Authenticate"_ba, value);
 }
 
 QByteArray Headers::authorization() const noexcept
@@ -370,7 +371,7 @@ QByteArray Headers::setAuthorizationBasic(const QString &username, const QString
 
     const QString result = username + u':' + password;
     ret                  = "Basic " + result.toLatin1().toBase64();
-    setHeader("Authorization"_qba, ret);
+    setHeader("Authorization"_ba, ret);
     return ret;
 }
 

--- a/Cutelyst/request.cpp
+++ b/Cutelyst/request.cpp
@@ -15,6 +15,7 @@
 #include <QJsonObject>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Request::Request(Cutelyst::EngineRequest *engineRequest)
     : d_ptr(new RequestPrivate)
@@ -497,7 +498,7 @@ void RequestPrivate::parseBody() const
         const Uploads ups = MultiPartFormDataParser::parse(body, contentType);
         for (Upload *upload : ups) {
             if (upload->filename().isEmpty() &&
-                upload->headers().header("Content-Type"_qba).isEmpty()) {
+                upload->headers().header("Content-Type"_ba).isEmpty()) {
                 bodyParam.insert(upload->name(), QString::fromUtf8(upload->readAll()));
                 upload->seek(0);
             }
@@ -595,7 +596,7 @@ static Request::Cookie nextField(QByteArrayView text, int &position)
 
 void RequestPrivate::parseCookies() const
 {
-    const QByteArray cookieString = engineRequest->headers.header("Cookie"_qba);
+    const QByteArray cookieString = engineRequest->headers.header("Cookie"_ba);
     int position                  = 0;
     const int length              = cookieString.length();
     while (position < length) {

--- a/Cutelyst/response.cpp
+++ b/Cutelyst/response.cpp
@@ -15,6 +15,7 @@
 #include <QtCore/QJsonDocument>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 Response::Response(const Headers &defaultHeaders, EngineRequest *engineRequest)
     : d_ptr(new ResponsePrivate(defaultHeaders, engineRequest))
@@ -39,12 +40,12 @@ qint64 Response::writeData(const char *data, qint64 len)
 
     // Finalize headers if someone manually writes output
     if (!(d->engineRequest->status & EngineRequest::FinalizedHeaders)) {
-        if (d->headers.header("Transfer-Encoding"_qba).compare("chunked") == 0) {
+        if (d->headers.header("Transfer-Encoding"_ba).compare("chunked") == 0) {
             d->engineRequest->status |= EngineRequest::IOWrite | EngineRequest::Chunked;
         } else {
             // When chunked encoding is not set the client can only know
             // that data is finished if we close the connection
-            d->headers.setHeader("Connection"_qba, "Close"_qba);
+            d->headers.setHeader("Connection"_ba, "Close"_ba);
             d->engineRequest->status |= EngineRequest::IOWrite;
         }
         delete d->bodyIODevice;
@@ -126,7 +127,7 @@ void Response::setCborBody(const QByteArray &cbor)
 {
     Q_D(Response);
     d->setBodyData(cbor);
-    d->headers.setContentType("application/cbor"_qba);
+    d->headers.setContentType("application/cbor"_ba);
 }
 
 void Response::setCborValueBody(const QCborValue &value)
@@ -138,7 +139,7 @@ void Response::setJsonBody(const QByteArray &json)
 {
     Q_D(Response);
     d->setBodyData(json);
-    d->headers.setContentType("application/json"_qba);
+    d->headers.setContentType("application/json"_ba);
 }
 
 void Response::setJsonObjectBody(const QJsonObject &obj)
@@ -239,8 +240,8 @@ void Response::redirect(const QUrl &url, quint16 status)
         const auto location = url.toEncoded(QUrl::FullyEncoded);
         qCDebug(CUTELYST_RESPONSE) << "Redirecting to" << location << status;
 
-        d->headers.setHeader("Location"_qba, location);
-        d->headers.setContentType("text/html; charset=utf-8"_qba);
+        d->headers.setHeader("Location"_ba, location);
+        d->headers.setContentType("text/html; charset=utf-8"_ba);
 
         const QByteArray buf = R"V0G0N(<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -255,7 +256,7 @@ void Response::redirect(const QUrl &url, quint16 status)
 )V0G0N";
         setBody(buf);
     } else {
-        d->headers.removeHeader("Location"_qba);
+        d->headers.removeHeader("Location"_ba);
         qCDebug(CUTELYST_RESPONSE) << "Invalid redirect removing header" << url << status;
     }
 }

--- a/Cutelyst/testengine.cpp
+++ b/Cutelyst/testengine.cpp
@@ -5,6 +5,7 @@
 #include <QBuffer>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 TestEngine::TestEngine(Application *app, const QVariantMap &opts)
     : Engine{app, 0, opts}
@@ -23,7 +24,7 @@ TestEngine::TestResponse TestEngine::createRequest(const QByteArray &method,
                                                    QByteArray *body)
 {
     QIODevice *bodyDevice = nullptr;
-    if (headers.header("Sequential"_qba).isEmpty()) {
+    if (headers.header("Sequential"_ba).isEmpty()) {
         bodyDevice = new QBuffer(body);
     } else {
         bodyDevice = new SequentialBuffer(body);
@@ -40,10 +41,10 @@ TestEngine::TestResponse TestEngine::createRequest(const QByteArray &method,
     QByteArray _path = path;
     req.setPath(_path);
     req.query          = query;
-    req.protocol       = "HTTP/1.1"_qba;
+    req.protocol       = "HTTP/1.1"_ba;
     req.isSecure       = false;
-    req.serverAddress  = "127.0.0.1"_qba;
-    req.remoteAddress  = QHostAddress(u"127.0.0.1"_qs);
+    req.serverAddress  = "127.0.0.1"_ba;
+    req.remoteAddress  = QHostAddress(u"127.0.0.1"_s);
     req.remotePort     = 3000;
     req.remoteUser     = QString{};
     req.headers        = headersCL;

--- a/Cutelyst/utils.cpp
+++ b/Cutelyst/utils.cpp
@@ -121,7 +121,7 @@ QString Utils::decodePercentEncoding(QString *s)
     char *data           = ba.data();
     const char *inputPtr = data;
 
-    const int len = ba.count();
+    const int len = ba.length();
     bool skipUtf8 = true;
     int outlen    = 0;
     for (int i = 0; i < len; ++i, ++outlen) {
@@ -249,7 +249,7 @@ QString Utils::decodePercentEncoding(QByteArray *ba)
     char *data           = ba->data();
     const char *inputPtr = data;
 
-    int len       = ba->count();
+    int len       = ba->length();
     bool skipUtf8 = true;
     int outlen    = 0;
     for (int i = 0; i < len; ++i, ++outlen) {

--- a/Cutelyst/view.cpp
+++ b/Cutelyst/view.cpp
@@ -49,7 +49,7 @@ bool View::doExecute(Context *c)
         }
     }
     const QByteArray acceptEncoding = c->req()->header("Accept-Encoding");
-    if (d->minimalSizeToDeflate >= 0 && output.count() > d->minimalSizeToDeflate &&
+    if (d->minimalSizeToDeflate >= 0 && output.length() > d->minimalSizeToDeflate &&
         acceptEncoding.toLower().contains("deflate")) {
         QByteArray compressedData = qCompress(output); // Use  zlib's default compression
         compressedData.remove(0, 6);                   // Remove qCompress and zlib headers

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -25,6 +25,8 @@
 #define OUT_EXISTS "  exists "
 #define OUT_CREATED " created "
 
+using namespace Qt::Literals::StringLiterals;
+
 bool buildControllerHeader(const QString &filename, const QString &controllerName, bool helpers);
 bool buildControllerImplementation(const QString &filename,
                                    const QString &controllerName,
@@ -32,8 +34,8 @@ bool buildControllerImplementation(const QString &filename,
 
 bool createController(const QString &controllerName)
 {
-    const static QRegularExpression nonWordRE(u"\\W"_qs);
-    const static QRegularExpression nonDigitRE(u"^\\d"_qs);
+    const static QRegularExpression nonWordRE(u"\\W"_s);
+    const static QRegularExpression nonDigitRE(u"^\\d"_s);
     if (controllerName.contains(nonWordRE) || controllerName.contains(nonDigitRE)) {
         //% "Error: invalid Controller name."
         std::cerr << qUtf8Printable(qtTrId("cutelystcmd-err-inv-cont-name")) << std::endl;
@@ -377,8 +379,8 @@ bool createApplication(const QString &name)
     QString nameWithUnderscore = name;
     nameWithUnderscore.replace(u'-', u'_');
 
-    const static QRegularExpression nonWordRE(u"\\W"_qs);
-    const static QRegularExpression nonDigitRE(u"^\\d"_qs);
+    const static QRegularExpression nonWordRE(u"\\W"_s);
+    const static QRegularExpression nonDigitRE(u"^\\d"_s);
 
     if (nameWithUnderscore.contains(nonWordRE) || nameWithUnderscore.contains(nonDigitRE)) {
         //% "Error: invalid application name."
@@ -520,7 +522,7 @@ int main(int argc, char *argv[])
                                   //: CLI option value name
                                   //% "port"
                                   qtTrId("cutelystcmd-opt-server-port-value"),
-                                  u"3000"_qs);
+                                  u"3000"_s);
     parser.addOption(serverPort);
 
     QCommandLineOption restartOpt(

--- a/tests/coverageobject.h
+++ b/tests/coverageobject.h
@@ -13,6 +13,7 @@
 #include <QObject>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 class CoverageObject : public QObject
 {
@@ -63,7 +64,7 @@ public:
     void default404(Context *c)
     {
         c->response()->setStatus(Response::NotFound);
-        c->response()->setBody("404 - Not Found."_qba);
+        c->response()->setBody("404 - Not Found."_ba);
     }
 
 private:
@@ -73,9 +74,9 @@ private:
     C_ATTR(Auto,)
     bool Auto(Context *c)
     {
-        if (!c->req()->queryParam(u"autoFalse"_qs).isEmpty()) {
+        if (!c->req()->queryParam(u"autoFalse"_s).isEmpty()) {
             c->response()->setStatus(Response::InternalServerError);
-            c->response()->setBody("autoFalse"_qba);
+            c->response()->setBody("autoFalse"_ba);
             return false;
         }
         return true;
@@ -260,7 +261,7 @@ public:
     {
         defaultHeaders() = Headers();
         // load the core translations from the build directory
-        loadTranslations(u"cutelystcore"_qs, QStringLiteral(CUTELYST_BUILD_DIR) + u"/Cutelyst"_qs);
+        loadTranslations(u"cutelystcore"_s, QStringLiteral(CUTELYST_BUILD_DIR) + u"/Cutelyst"_s);
     }
     virtual bool init()
     {

--- a/tests/testactionrenderview.cpp
+++ b/tests/testactionrenderview.cpp
@@ -12,6 +12,7 @@
 #include <QtTest/QTest>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 class TestView : public View
 {
@@ -53,7 +54,7 @@ public:
     C_ATTR(test3, :Local :ActionClass(RenderView))
     void test3(Context *c)
     {
-        c->response()->setContentType("plain/text"_qba);
+        c->response()->setContentType("plain/text"_ba);
         c->setStash(QStringLiteral("data"), QByteArrayLiteral("test3"));
     }
 
@@ -189,8 +190,8 @@ void TestActionRenderView::testController_data()
     QTest::addColumn<QByteArray>("output");
     QTest::addColumn<QString>("contentType");
 
-    const auto get  = "GET"_qba;
-    const auto head = "HEAD"_qba;
+    const auto get  = "GET"_ba;
+    const auto head = "HEAD"_ba;
 
     QTest::newRow("renderview-test-00")
         << get << QStringLiteral("/action/render/view/test0") << 200 << QByteArrayLiteral("test0")

--- a/tests/testactionrest.cpp
+++ b/tests/testactionrest.cpp
@@ -11,6 +11,7 @@
 #include <QtTest/QTest>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 class ActionREST : public Controller
 {
@@ -150,11 +151,11 @@ void TestActionREST::testController_data()
     QTest::addColumn<QByteArray>("output");
     QTest::addColumn<QString>("allow");
 
-    const auto head         = "HEAD"_qba;
-    const auto get          = "GET"_qba;
-    const auto put          = "PUT"_qba;
-    const auto options      = "OPTIONS"_qba;
-    const auto methodDELETE = "DELETE"_qba;
+    const auto head         = "HEAD"_ba;
+    const auto get          = "GET"_ba;
+    const auto put          = "PUT"_ba;
+    const auto options      = "OPTIONS"_ba;
+    const auto methodDELETE = "DELETE"_ba;
 
     QTest::newRow("rest-test1-00") << get << QStringLiteral("/action/rest/test1/") << 200
                                    << QByteArrayLiteral("test1.test1 GET.") << QString();

--- a/tests/testactionroleacl.cpp
+++ b/tests/testactionroleacl.cpp
@@ -188,7 +188,7 @@ TestEngine *TestActionRoleACL::getEngine()
     new DeniedRoleACL(app);
     new ActionRoleACL(app);
 
-    auto clearStore = std::make_shared<StoreMinimal>(u"id"_qs);
+    auto clearStore = std::make_shared<StoreMinimal>(QStringLiteral(u"id"));
 
     AuthenticationUser fooUser(QStringLiteral("foo"));
     fooUser.insert(QStringLiteral("roles"), QStringList{QStringLiteral("admin")});

--- a/tests/testauthentication.cpp
+++ b/tests/testauthentication.cpp
@@ -179,8 +179,8 @@ TestEngine *TestAuthentication::getEngine()
     clearPassword->setPasswordType(CredentialPassword::Clear);
     auth->addRealm(std::make_shared<AuthenticationRealm>(clearStore, clearPassword));
 
-    const auto preSalt  = u"preSalt"_qs;
-    const auto postSalt = u"postSalt"_qs;
+    const auto preSalt  = QStringLiteral(u"preSalt");
+    const auto postSalt = QStringLiteral(u"postSalt");
 
     auto hashedStore = std::make_shared<StoreMinimal>(QStringLiteral("id"));
     {

--- a/tests/testcsrfprotection.cpp
+++ b/tests/testcsrfprotection.cpp
@@ -9,6 +9,7 @@
 #include <QTest>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 class TestCsrfProtection : public CoverageObject
 {
@@ -130,7 +131,7 @@ void TestCsrfProtection::initTestCase()
     QVERIFY(m_engine);
     if (m_cookie.value().isEmpty()) {
         const auto result = m_engine->createRequest(
-            "GET", u"/csrfprotection/test/testCsrf"_qs, QByteArray(), Headers(), nullptr);
+            "GET", u"/csrfprotection/test/testCsrf"_s, QByteArray(), Headers(), nullptr);
         const QList<QNetworkCookie> cookies =
             QNetworkCookie::parseCookies(result.headers.header("Set-Cookie"));
         QVERIFY(!cookies.empty());
@@ -178,7 +179,7 @@ void TestCsrfProtection::initTest()
     m_fieldValue =
         m_engine
             ->createRequest(
-                "GET", u"/csrfprotection/test/testCsrf"_qs, QByteArray(), headers, nullptr)
+                "GET", u"/csrfprotection/test/testCsrf"_s, QByteArray(), headers, nullptr)
             .body;
 }
 
@@ -217,7 +218,7 @@ void TestCsrfProtection::doTest()
     QFETCH(QByteArray, output);
 
     const auto result = m_engine->createRequest(
-        method, u"/csrfprotection/test/testCsrf"_qs, QByteArray(), headers, &body);
+        method, u"/csrfprotection/test/testCsrf"_s, QByteArray(), headers, &body);
 
     QCOMPARE(result.statusCode, status);
     QCOMPARE(result.body, output);
@@ -334,7 +335,7 @@ void TestCsrfProtection::doTest_data()
 void TestCsrfProtection::detachToOnArgument()
 {
     const auto result = m_engine->createRequest(
-        "POST", u"/csrfprotection/test/testCsrfDetachTo"_qs, QByteArray(), Headers(), nullptr);
+        "POST", u"/csrfprotection/test/testCsrfDetachTo"_s, QByteArray(), Headers(), nullptr);
     QCOMPARE(result.statusCode, 403);
     QCOMPARE(result.body, QByteArrayLiteral("detachdenied"));
 }
@@ -342,7 +343,7 @@ void TestCsrfProtection::detachToOnArgument()
 void TestCsrfProtection::csrfIgnorArgument()
 {
     const auto result = m_engine->createRequest(
-        "POST", u"/csrfprotection/test/testCsrfIgnore"_qs, QByteArray(), Headers(), nullptr);
+        "POST", u"/csrfprotection/test/testCsrfIgnore"_s, QByteArray(), Headers(), nullptr);
     QCOMPARE(result.statusCode, 200);
     QCOMPARE(result.body, QByteArrayLiteral("allowed"));
 }
@@ -350,7 +351,7 @@ void TestCsrfProtection::csrfIgnorArgument()
 void TestCsrfProtection::ignoreNamespace()
 {
     const auto result =
-        m_engine->createRequest("POST", u"/testns/testCsrf"_qs, QByteArray(), Headers(), nullptr);
+        m_engine->createRequest("POST", u"/testns/testCsrf"_s, QByteArray(), Headers(), nullptr);
     QCOMPARE(result.statusCode, 200);
     QCOMPARE(result.body, QByteArrayLiteral("allowed"));
 }
@@ -358,7 +359,7 @@ void TestCsrfProtection::ignoreNamespace()
 void TestCsrfProtection::ignoreNamespaceRequired()
 {
     const auto result = m_engine->createRequest(
-        "POST", u"/testns/testCsrfRequired"_qs, QByteArray(), Headers(), nullptr);
+        "POST", u"/testns/testCsrfRequired"_s, QByteArray(), Headers(), nullptr);
     QCOMPARE(result.statusCode, 403);
     QCOMPARE(result.body, QByteArrayLiteral("denied"));
 }
@@ -366,7 +367,7 @@ void TestCsrfProtection::ignoreNamespaceRequired()
 void TestCsrfProtection::csrfRedirect()
 {
     const auto result = m_engine->createRequest(
-        "POST", u"/csrfprotection/test/testCsrfRedirect"_qs, QByteArray(), Headers(), nullptr);
+        "POST", u"/csrfprotection/test/testCsrfRedirect"_s, QByteArray(), Headers(), nullptr);
     QCOMPARE(result.statusCode, 403);
     QCOMPARE(result.body, QByteArrayLiteral("denied"));
 }

--- a/tests/testheaders.cpp
+++ b/tests/testheaders.cpp
@@ -8,6 +8,7 @@
 #include <QtTest/QTest>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 class TestHeaders : public CoverageObject
 {
@@ -21,13 +22,13 @@ void TestHeaders::testCombining()
     Headers headers;
 
     // insensitive
-    headers.setHeader("x-test"_qba, "test1"_qba);
-    QCOMPARE(headers.header("x-test"_qba), "test1"_qba);
+    headers.setHeader("x-test"_ba, "test1"_ba);
+    QCOMPARE(headers.header("x-test"_ba), "test1"_ba);
 
-    headers.setHeader("x-TEST"_qba, "test2"_qba);
+    headers.setHeader("x-TEST"_ba, "test2"_ba);
     QCOMPARE(headers.header("x-test"), "test2");
 
-    headers.setHeader("x-TEST"_qba, "test3");
+    headers.setHeader("x-TEST"_ba, "test3");
     QCOMPARE(headers.header("x-test"), "test3");
 
     // header helpers
@@ -100,19 +101,19 @@ void TestHeaders::testCombining()
     QCOMPARE(headers.date(), dt);
     QCOMPARE(headers.date(), dt.toUTC());
 
-    headers.setAuthorizationBasic(u"user"_qs, u"pass"_qs);
+    headers.setAuthorizationBasic(u"user"_s, u"pass"_s);
     QCOMPARE(headers.authorization(), "Basic dXNlcjpwYXNz");
     QCOMPARE(headers.authorizationBasic(), "user:pass");
     QCOMPARE(headers.authorizationBasic(), "user:pass");
-    QCOMPARE(headers.authorizationBasicObject().user, u"user"_qs);
+    QCOMPARE(headers.authorizationBasicObject().user, u"user"_s);
 
-    const auto authorizationHeader = "Basic dXNlcjpwYXNz, Bearer xyz"_qba;
-    headers.setHeader("Authorization"_qba, authorizationHeader);
+    const auto authorizationHeader = "Basic dXNlcjpwYXNz, Bearer xyz"_ba;
+    headers.setHeader("Authorization"_ba, authorizationHeader);
     QCOMPARE(headers.authorization(), authorizationHeader);
-    QCOMPARE(headers.authorizationBearer(), "xyz"_qba);
+    QCOMPARE(headers.authorizationBearer(), "xyz"_ba);
     QCOMPARE(headers.authorizationBasic(), "user:pass");
     QCOMPARE(headers.authorizationBasic(), "user:pass");
-    QCOMPARE(headers.authorizationBasicObject().user, u"user"_qs);
+    QCOMPARE(headers.authorizationBasicObject().user, u"user"_s);
 
     Headers copy = headers;
     QCOMPARE(copy, headers);

--- a/tests/testrequest.cpp
+++ b/tests/testrequest.cpp
@@ -19,6 +19,7 @@
 #include <QUuid>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 class TestRequest : public CoverageObject
 {
@@ -427,11 +428,11 @@ void TestRequest::testController_data()
     QTest::addColumn<QByteArray>("body");
     QTest::addColumn<QByteArray>("output");
 
-    const auto get  = "GET"_qba;
-    const auto GeT  = "GeT"_qba;
-    const auto post = "POST"_qba;
-    const auto head = "HEAD"_qba;
-    const auto PoSt = "PoSt"_qba;
+    const auto get  = "GET"_ba;
+    const auto GeT  = "GeT"_ba;
+    const auto post = "POST"_ba;
+    const auto head = "HEAD"_ba;
+    const auto PoSt = "PoSt"_ba;
 
     QUrlQuery query;
     Headers headers;
@@ -1093,7 +1094,7 @@ void TestRequest::testUploads_data()
     QTest::addColumn<QByteArray>("body");
     QTest::addColumn<QByteArray>("output");
 
-    const auto post = "POST"_qba;
+    const auto post = "POST"_ba;
 
     QUrlQuery query;
     Headers headers;

--- a/tests/testresponse.cpp
+++ b/tests/testresponse.cpp
@@ -21,6 +21,7 @@
 #include <QUuid>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 class TestResponse : public CoverageObject
 {
@@ -85,7 +86,7 @@ public:
     C_ATTR(contentLengthIODevice, :Local :AutoArgs)
     void contentLengthIODevice(Context *c)
     {
-        c->response()->setBody("something_to_test_for_updated_content_type"_qba);
+        c->response()->setBody("something_to_test_for_updated_content_type"_ba);
 
         auto buffer = new QBuffer;
         buffer->open(QBuffer::ReadWrite);
@@ -103,7 +104,7 @@ public:
     C_ATTR(contentTypeCharset, :Local :AutoArgs)
     void contentTypeCharset(Context *c)
     {
-        c->response()->setContentType(c->request()->queryParam(u"data"_qs).toLatin1());
+        c->response()->setContentType(c->request()->queryParam(u"data"_s).toLatin1());
         c->response()->setBody(c->response()->contentTypeCharset());
     }
 
@@ -218,9 +219,9 @@ public:
     C_ATTR(sendJson, :Local :AutoArgs)
     void sendJson(Context *c)
     {
-        c->response()->setJsonBody("{}"_qba);
+        c->response()->setJsonBody("{}"_ba);
 
-        c->response()->setJsonBody(u"{}"_qs);
+        c->response()->setJsonBody(u"{}"_s);
 
         QJsonObject obj;
         c->response()->setJsonObjectBody(obj);
@@ -287,8 +288,8 @@ void TestResponse::testController_data()
     QTest::addColumn<Headers>("responseHeaders");
     QTest::addColumn<QByteArray>("output");
 
-    const auto get  = "GET"_qba;
-    const auto post = "POST"_qba;
+    const auto get  = "GET"_ba;
+    const auto post = "POST"_ba;
 
     QUrlQuery query;
     Headers headers;

--- a/tests/testserver.cpp
+++ b/tests/testserver.cpp
@@ -13,6 +13,7 @@
 #include <QTest>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 class TestServer : public CoverageObject
 {
@@ -73,177 +74,173 @@ void TestServer::initTestCase()
     QVERIFY(m_tmpDir.isValid());
 
     // load this from the server/ini value in file1.ini
-    const QString file3Ini = m_tmpDir.filePath(u"file3.ini"_qs);
+    const QString file3Ini = m_tmpDir.filePath(u"file3.ini"_s);
     writeIniFile(file3Ini,
-                 {{u"Testsection1"_qs, {{u"john"_qs, u"doe"_qs}}},
-                  {u"Testsection3"_qs, {{u"hello"_qs, u"world"_qs}}}});
+                 {{u"Testsection1"_s, {{u"john"_s, u"doe"_s}}},
+                  {u"Testsection3"_s, {{u"hello"_s, u"world"_s}}}});
 
-    const QString file1Ini = m_tmpDir.filePath(u"file1.ini"_qs);
+    const QString file1Ini = m_tmpDir.filePath(u"file1.ini"_s);
     writeIniFile(file1Ini,
-                 {{u"Cutelyst"_qs, {{u"hello"_qs, u"world1"_qs}, {u"onlyin1"_qs, u"hello"_qs}}},
-                  {u"Testsection1"_qs, {{u"foo"_qs, u"bar"_qs}, {u"hello"_qs, u"world"_qs}}},
-                  {u"server"_qs, {{u"ini"_qs, file3Ini}}}});
+                 {{u"Cutelyst"_s, {{u"hello"_s, u"world1"_s}, {u"onlyin1"_s, u"hello"_s}}},
+                  {u"Testsection1"_s, {{u"foo"_s, u"bar"_s}, {u"hello"_s, u"world"_s}}},
+                  {u"server"_s, {{u"ini"_s, file3Ini}}}});
 
-    const QString file2Ini = m_tmpDir.filePath(u"file2.ini"_qs);
+    const QString file2Ini = m_tmpDir.filePath(u"file2.ini"_s);
     writeIniFile(file2Ini,
-                 {{u"Cutelyst"_qs, {{u"hello"_qs, u"world2"_qs}, {u"onlyin2"_qs, u"world"_qs}}},
-                  {u"Testsection2"_qs, {{u"fu"_qs, u"baz"_qs}, {u"hello"_qs, u"world"_qs}}}});
+                 {{u"Cutelyst"_s, {{u"hello"_s, u"world2"_s}, {u"onlyin2"_s, u"world"_s}}},
+                  {u"Testsection2"_s, {{u"fu"_s, u"baz"_s}, {u"hello"_s, u"world"_s}}}});
 
     m_expectedIniConfig = {
-        {u"Cutelyst"_qs,
-         QVariantMap{{u"hello"_qs, u"world2"_qs},
-                     {u"onlyin1"_qs, u"hello"_qs},
-                     {u"onlyin2"_qs, u"world"_qs}}},
-        {u"Testsection1"_qs,
-         QVariantMap{{u"foo"_qs, u"bar"_qs}, {u"hello"_qs, u"world"_qs}, {u"john"_qs, u"doe"_qs}}},
-        {u"Testsection2"_qs, QVariantMap{{u"fu"_qs, u"baz"_qs}, {u"hello"_qs, u"world"_qs}}},
-        {u"Testsection3"_qs, QVariantMap{{u"hello"_qs, u"world"_qs}}},
-        {u"server"_qs, QVariantMap{{u"ini"_qs, file3Ini}}}};
+        {u"Cutelyst"_s,
+         QVariantMap{
+             {u"hello"_s, u"world2"_s}, {u"onlyin1"_s, u"hello"_s}, {u"onlyin2"_s, u"world"_s}}},
+        {u"Testsection1"_s,
+         QVariantMap{{u"foo"_s, u"bar"_s}, {u"hello"_s, u"world"_s}, {u"john"_s, u"doe"_s}}},
+        {u"Testsection2"_s, QVariantMap{{u"fu"_s, u"baz"_s}, {u"hello"_s, u"world"_s}}},
+        {u"Testsection3"_s, QVariantMap{{u"hello"_s, u"world"_s}}},
+        {u"server"_s, QVariantMap{{u"ini"_s, file3Ini}}}};
 
     // load this from the server/json value in file1.json
-    const QString file3Json = m_tmpDir.filePath(u"file3.json"_qs);
+    const QString file3Json = m_tmpDir.filePath(u"file3.json"_s);
     writeJsonFile(file3Json,
-                  QJsonObject{{u"Testsection1"_qs, QJsonObject{{u"john"_qs, u"doe"_qs}}},
-                              {u"Testsection3"_qs, QJsonObject{{u"hello"_qs, u"world"_qs}}}});
+                  QJsonObject{{u"Testsection1"_s, QJsonObject{{u"john"_s, u"doe"_s}}},
+                              {u"Testsection3"_s, QJsonObject{{u"hello"_s, u"world"_s}}}});
 
-    const QString file1Json = m_tmpDir.filePath(u"file1.json"_qs);
+    const QString file1Json = m_tmpDir.filePath(u"file1.json"_s);
     writeJsonFile(
         file1Json,
         QJsonObject{
-            {{u"Cutelyst"_qs,
-              QJsonObject{{u"hello"_qs, u"world1"_qs}, {u"onlyin1"_qs, u"hello"_qs}}},
-             {u"Testsection1"_qs, QJsonObject{{u"foo"_qs, u"bar"_qs}, {u"hello"_qs, u"world"_qs}}},
-             {u"server"_qs, QJsonObject{{u"json"_qs, file3Json}}}}});
+            {{u"Cutelyst"_s, QJsonObject{{u"hello"_s, u"world1"_s}, {u"onlyin1"_s, u"hello"_s}}},
+             {u"Testsection1"_s, QJsonObject{{u"foo"_s, u"bar"_s}, {u"hello"_s, u"world"_s}}},
+             {u"server"_s, QJsonObject{{u"json"_s, file3Json}}}}});
 
-    const QString file2Json = m_tmpDir.filePath(u"file2.json"_qs);
+    const QString file2Json = m_tmpDir.filePath(u"file2.json"_s);
     writeJsonFile(
         file2Json,
-        QJsonObject{{{u"Cutelyst"_qs,
-                      QJsonObject{{u"hello"_qs, u"world2"_qs}, {u"onlyin2"_qs, u"world"_qs}}},
-                     {u"Testsection2"_qs,
-                      QJsonObject{{u"fu"_qs, u"baz"_qs}, {u"hello"_qs, u"world"_qs}}}}});
+        QJsonObject{
+            {{u"Cutelyst"_s, QJsonObject{{u"hello"_s, u"world2"_s}, {u"onlyin2"_s, u"world"_s}}},
+             {u"Testsection2"_s, QJsonObject{{u"fu"_s, u"baz"_s}, {u"hello"_s, u"world"_s}}}}});
 
     m_expectedJsonConfig = {
-        {u"Cutelyst"_qs,
-         QVariantMap{{u"hello"_qs, u"world2"_qs},
-                     {u"onlyin1"_qs, u"hello"_qs},
-                     {u"onlyin2"_qs, u"world"_qs}}},
-        {u"Testsection1"_qs,
-         QVariantMap{{u"foo"_qs, u"bar"_qs}, {u"hello"_qs, u"world"_qs}, {u"john"_qs, u"doe"_qs}}},
-        {u"Testsection2"_qs, QVariantMap{{u"fu"_qs, u"baz"_qs}, {u"hello"_qs, u"world"_qs}}},
-        {u"Testsection3"_qs, QVariantMap{{u"hello"_qs, u"world"_qs}}},
-        {u"server"_qs, QVariantMap{{u"json"_qs, file3Json}}}};
+        {u"Cutelyst"_s,
+         QVariantMap{
+             {u"hello"_s, u"world2"_s}, {u"onlyin1"_s, u"hello"_s}, {u"onlyin2"_s, u"world"_s}}},
+        {u"Testsection1"_s,
+         QVariantMap{{u"foo"_s, u"bar"_s}, {u"hello"_s, u"world"_s}, {u"john"_s, u"doe"_s}}},
+        {u"Testsection2"_s, QVariantMap{{u"fu"_s, u"baz"_s}, {u"hello"_s, u"world"_s}}},
+        {u"Testsection3"_s, QVariantMap{{u"hello"_s, u"world"_s}}},
+        {u"server"_s, QVariantMap{{u"json"_s, file3Json}}}};
 
-    const QString serverConfig1Ini = m_tmpDir.filePath(u"serverConfig1.ini"_qs);
+    const QString serverConfig1Ini = m_tmpDir.filePath(u"serverConfig1.ini"_s);
     writeIniFile(serverConfig1Ini,
-                 {{u"Testsection1"_qs, {{u"hello"_qs, u"world"_qs}}},
-                  {u"server"_qs,
-                   {{u"threads"_qs, 2},
-                    {u"processes"_qs, 3},
-                    {u"chdir"_qs, u"/path/to/chdir"_qs},
-                    {u"http_socket"_qs, u"localhost:3000"_qs},
-                    {u"http2_socket"_qs, u"localhost:3001"_qs},
-                    {u"http2_header_table_size"_qs, 123},
-                    {u"upgrade_h2c"_qs, true},
-                    {u"https_h2"_qs, true},
-                    {u"https_socket"_qs, u"localhost:3002"_qs},
-                    {u"fastcgi_socket"_qs, u"/path/to/socket"_qs},
-                    {u"socket_access"_qs, u"ug"_qs},
-                    {u"socket_timeout"_qs, 4321},
-                    {u"chdir2"_qs, u"/path/to/chdir2"_qs},
-                    {u"listen"_qs, 111},
-                    {u"socket_sndbuf"_qs, 123},
-                    {u"socket_rcvbuf"_qs, 456}}}});
+                 {{u"Testsection1"_s, {{u"hello"_s, u"world"_s}}},
+                  {u"server"_s,
+                   {{u"threads"_s, 2},
+                    {u"processes"_s, 3},
+                    {u"chdir"_s, u"/path/to/chdir"_s},
+                    {u"http_socket"_s, u"localhost:3000"_s},
+                    {u"http2_socket"_s, u"localhost:3001"_s},
+                    {u"http2_header_table_size"_s, 123},
+                    {u"upgrade_h2c"_s, true},
+                    {u"https_h2"_s, true},
+                    {u"https_socket"_s, u"localhost:3002"_s},
+                    {u"fastcgi_socket"_s, u"/path/to/socket"_s},
+                    {u"socket_access"_s, u"ug"_s},
+                    {u"socket_timeout"_s, 4321},
+                    {u"chdir2"_s, u"/path/to/chdir2"_s},
+                    {u"listen"_s, 111},
+                    {u"socket_sndbuf"_s, 123},
+                    {u"socket_rcvbuf"_s, 456}}}});
 
-    const QString serverConfig2Ini = m_tmpDir.filePath(u"serverConfig2.ini"_qs);
+    const QString serverConfig2Ini = m_tmpDir.filePath(u"serverConfig2.ini"_s);
     writeIniFile(serverConfig2Ini,
-                 {{u"Testsection2"_qs, {{u"foo"_qs, u"bar"_qs}}},
-                  {u"server"_qs,
-                   {{u"ini"_qs, serverConfig1Ini},
-                    {u"static_map"_qs, u"/mountpoint1=/path/to/static1"_qs},
-                    {u"static_map2"_qs, u"/mountpoint2=/path/to/static2"_qs},
-                    {u"master"_qs, true},
-                    {u"auto_reload"_qs, true},
-                    {u"touch_reload"_qs, u"/path/to/file"_qs},
-                    {u"buffer_size"_qs, 5432},
-                    {u"post_buffering"_qs, 456},
-                    {u"post_buffering_bufsize"_qs, 5000},
-                    {u"tcp_nodelay"_qs, true},
-                    {u"so_keepalive"_qs, true},
-                    {u"websocket_max_size"_qs, 2048}}}});
+                 {{u"Testsection2"_s, {{u"foo"_s, u"bar"_s}}},
+                  {u"server"_s,
+                   {{u"ini"_s, serverConfig1Ini},
+                    {u"static_map"_s, u"/mountpoint1=/path/to/static1"_s},
+                    {u"static_map2"_s, u"/mountpoint2=/path/to/static2"_s},
+                    {u"master"_s, true},
+                    {u"auto_reload"_s, true},
+                    {u"touch_reload"_s, u"/path/to/file"_s},
+                    {u"buffer_size"_s, 5432},
+                    {u"post_buffering"_s, 456},
+                    {u"post_buffering_bufsize"_s, 5000},
+                    {u"tcp_nodelay"_s, true},
+                    {u"so_keepalive"_s, true},
+                    {u"websocket_max_size"_s, 2048}}}});
 
-    const QString serverConfig3Ini = m_tmpDir.filePath(u"serverConfig3.ini"_qs);
+    const QString serverConfig3Ini = m_tmpDir.filePath(u"serverConfig3.ini"_s);
     writeIniFile(serverConfig3Ini,
-                 {{u"Testsection3"_qs, {{u"fu"_qs, u"baz"_qs}}},
-                  {u"server"_qs,
-                   {{u"pidfile"_qs, u"/path/to/pidfile1"_qs},
-                    {u"pidfile2"_qs, u"/path/to/pidfile2"_qs},
-                    {u"uid"_qs, u"user"_qs},
-                    {u"gid"_qs, u"group"_qs},
-                    {u"no_initgroups"_qs, true},
-                    {u"chown_socket"_qs, u"user:group"_qs},
-                    {u"umask"_qs, u"0077"_qs},
-                    {u"cpu_affinity"_qs, 1},
-                    {u"reuse_port"_qs, true},
-                    {u"lazy"_qs, true},
-                    {u"using_frontend_proxy"_qs, true}}}});
+                 {{u"Testsection3"_s, {{u"fu"_s, u"baz"_s}}},
+                  {u"server"_s,
+                   {{u"pidfile"_s, u"/path/to/pidfile1"_s},
+                    {u"pidfile2"_s, u"/path/to/pidfile2"_s},
+                    {u"uid"_s, u"user"_s},
+                    {u"gid"_s, u"group"_s},
+                    {u"no_initgroups"_s, true},
+                    {u"chown_socket"_s, u"user:group"_s},
+                    {u"umask"_s, u"0077"_s},
+                    {u"cpu_affinity"_s, 1},
+                    {u"reuse_port"_s, true},
+                    {u"lazy"_s, true},
+                    {u"using_frontend_proxy"_s, true}}}});
 
-    m_expectedServerConfig = {{u"Testsection1"_qs, QVariantMap{{u"hello"_qs, u"world"_qs}}},
-                              {u"Testsection2"_qs, QVariantMap{{u"foo"_qs, u"bar"_qs}}},
-                              {u"Testsection3"_qs, QVariantMap{{u"fu"_qs, u"baz"_qs}}},
-                              {u"server"_qs,
-                               QVariantMap{{u"threads"_qs, 2},
-                                           {u"processes"_qs, 3},
-                                           {u"chdir"_qs, u"/path/to/chdir"_qs},
-                                           {u"http_socket"_qs, u"localhost:3000"_qs},
-                                           {u"http2_socket"_qs, u"localhost:3001"_qs},
-                                           {u"http2_header_table_size"_qs, 123},
-                                           {u"upgrade_h2c"_qs, true},
-                                           {u"https_h2"_qs, true},
-                                           {u"https_socket"_qs, u"localhost:3002"_qs},
-                                           {u"fastcgi_socket"_qs, u"/path/to/socket"_qs},
-                                           {u"socket_access"_qs, u"ug"_qs},
-                                           {u"socket_timeout"_qs, 4321},
-                                           {u"chdir2"_qs, u"/path/to/chdir2"_qs},
-                                           {u"ini"_qs, serverConfig1Ini},
-                                           {u"static_map"_qs, u"/mountpoint1=/path/to/static1"_qs},
-                                           {u"static_map2"_qs, u"/mountpoint2=/path/to/static2"_qs},
-                                           {u"master"_qs, true},
-                                           {u"auto_reload"_qs, true},
-                                           {u"touch_reload"_qs, u"/path/to/file"_qs},
-                                           {u"listen"_qs, 111},
-                                           {u"buffer_size"_qs, 5432},
-                                           {u"post_buffering"_qs, 456},
-                                           {u"post_buffering_bufsize"_qs, 5000},
-                                           {u"tcp_nodelay"_qs, true},
-                                           {u"so_keepalive"_qs, true},
-                                           {u"socket_sndbuf"_qs, 123},
-                                           {u"socket_rcvbuf"_qs, 456},
-                                           {u"websocket_max_size"_qs, 2048},
-                                           {u"pidfile"_qs, u"/path/to/pidfile1"_qs},
-                                           {u"pidfile2"_qs, u"/path/to/pidfile2"_qs},
-                                           {u"uid"_qs, u"user"_qs},
-                                           {u"gid"_qs, u"group"_qs},
-                                           {u"no_initgroups"_qs, true},
-                                           {u"chown_socket"_qs, u"user:group"_qs},
-                                           {u"umask"_qs, u"0077"_qs},
-                                           {u"cpu_affinity"_qs, 1},
-                                           {u"reuse_port"_qs, true},
-                                           {u"lazy"_qs, true},
-                                           {u"using_frontend_proxy"_qs, true}}}};
+    m_expectedServerConfig = {{u"Testsection1"_s, QVariantMap{{u"hello"_s, u"world"_s}}},
+                              {u"Testsection2"_s, QVariantMap{{u"foo"_s, u"bar"_s}}},
+                              {u"Testsection3"_s, QVariantMap{{u"fu"_s, u"baz"_s}}},
+                              {u"server"_s,
+                               QVariantMap{{u"threads"_s, 2},
+                                           {u"processes"_s, 3},
+                                           {u"chdir"_s, u"/path/to/chdir"_s},
+                                           {u"http_socket"_s, u"localhost:3000"_s},
+                                           {u"http2_socket"_s, u"localhost:3001"_s},
+                                           {u"http2_header_table_size"_s, 123},
+                                           {u"upgrade_h2c"_s, true},
+                                           {u"https_h2"_s, true},
+                                           {u"https_socket"_s, u"localhost:3002"_s},
+                                           {u"fastcgi_socket"_s, u"/path/to/socket"_s},
+                                           {u"socket_access"_s, u"ug"_s},
+                                           {u"socket_timeout"_s, 4321},
+                                           {u"chdir2"_s, u"/path/to/chdir2"_s},
+                                           {u"ini"_s, serverConfig1Ini},
+                                           {u"static_map"_s, u"/mountpoint1=/path/to/static1"_s},
+                                           {u"static_map2"_s, u"/mountpoint2=/path/to/static2"_s},
+                                           {u"master"_s, true},
+                                           {u"auto_reload"_s, true},
+                                           {u"touch_reload"_s, u"/path/to/file"_s},
+                                           {u"listen"_s, 111},
+                                           {u"buffer_size"_s, 5432},
+                                           {u"post_buffering"_s, 456},
+                                           {u"post_buffering_bufsize"_s, 5000},
+                                           {u"tcp_nodelay"_s, true},
+                                           {u"so_keepalive"_s, true},
+                                           {u"socket_sndbuf"_s, 123},
+                                           {u"socket_rcvbuf"_s, 456},
+                                           {u"websocket_max_size"_s, 2048},
+                                           {u"pidfile"_s, u"/path/to/pidfile1"_s},
+                                           {u"pidfile2"_s, u"/path/to/pidfile2"_s},
+                                           {u"uid"_s, u"user"_s},
+                                           {u"gid"_s, u"group"_s},
+                                           {u"no_initgroups"_s, true},
+                                           {u"chown_socket"_s, u"user:group"_s},
+                                           {u"umask"_s, u"0077"_s},
+                                           {u"cpu_affinity"_s, 1},
+                                           {u"reuse_port"_s, true},
+                                           {u"lazy"_s, true},
+                                           {u"using_frontend_proxy"_s, true}}}};
 }
 
 void TestServer::testSetIni()
 {
     Server server;
-    server.setIni({m_tmpDir.filePath(u"file1.ini"_qs), m_tmpDir.filePath(u"file2.ini"_qs)});
+    server.setIni({m_tmpDir.filePath(u"file1.ini"_s), m_tmpDir.filePath(u"file2.ini"_s)});
     QCOMPARE(server.config(), m_expectedIniConfig);
 }
 
 void TestServer::testSetJson()
 {
     Server server;
-    server.setJson({m_tmpDir.filePath(u"file1.json"_qs), m_tmpDir.filePath(u"file2.json"_qs)});
+    server.setJson({m_tmpDir.filePath(u"file1.json"_s), m_tmpDir.filePath(u"file2.json"_s)});
     QCOMPARE(server.config(), m_expectedJsonConfig);
 }
 
@@ -251,28 +248,28 @@ void TestServer::testSetServerConfigFromFile()
 {
     Server server;
     server.setIni(
-        {m_tmpDir.filePath(u"serverConfig2.ini"_qs), m_tmpDir.filePath(u"serverConfig3.ini"_qs)});
+        {m_tmpDir.filePath(u"serverConfig2.ini"_s), m_tmpDir.filePath(u"serverConfig3.ini"_s)});
     QCOMPARE(server.config(), m_expectedServerConfig);
-    QCOMPARE(server.threads(), u"2"_qs);
+    QCOMPARE(server.threads(), u"2"_s);
 #ifdef Q_OS_UNIX
-    QCOMPARE(server.processes(), u"3"_qs);
+    QCOMPARE(server.processes(), u"3"_s);
 #endif
-    QCOMPARE(server.chdir(), u"/path/to/chdir"_qs);
-    QCOMPARE(server.httpSocket(), QStringList(u"localhost:3000"_qs));
-    QCOMPARE(server.http2Socket(), QStringList(u"localhost:3001"_qs));
+    QCOMPARE(server.chdir(), u"/path/to/chdir"_s);
+    QCOMPARE(server.httpSocket(), QStringList(u"localhost:3000"_s));
+    QCOMPARE(server.http2Socket(), QStringList(u"localhost:3001"_s));
     QCOMPARE(server.http2HeaderTableSize(), 123);
     QCOMPARE(server.upgradeH2c(), true);
     QCOMPARE(server.httpsH2(), true);
-    QCOMPARE(server.httpsSocket(), QStringList(u"localhost:3002"_qs));
-    QCOMPARE(server.fastcgiSocket(), QStringList(u"/path/to/socket"_qs));
-    QCOMPARE(server.socketAccess(), u"ug"_qs);
+    QCOMPARE(server.httpsSocket(), QStringList(u"localhost:3002"_s));
+    QCOMPARE(server.fastcgiSocket(), QStringList(u"/path/to/socket"_s));
+    QCOMPARE(server.socketAccess(), u"ug"_s);
     QCOMPARE(server.socketTimeout(), 4321);
-    QCOMPARE(server.chdir2(), u"/path/to/chdir2"_qs);
-    QCOMPARE(server.staticMap(), QStringList(u"/mountpoint1=/path/to/static1"_qs));
-    QCOMPARE(server.staticMap2(), QStringList(u"/mountpoint2=/path/to/static2"_qs));
+    QCOMPARE(server.chdir2(), u"/path/to/chdir2"_s);
+    QCOMPARE(server.staticMap(), QStringList(u"/mountpoint1=/path/to/static1"_s));
+    QCOMPARE(server.staticMap2(), QStringList(u"/mountpoint2=/path/to/static2"_s));
     QCOMPARE(server.master(), true);
     QCOMPARE(server.autoReload(), true);
-    QCOMPARE(server.touchReload(), QStringList(u"/path/to/file"_qs));
+    QCOMPARE(server.touchReload(), QStringList(u"/path/to/file"_s));
     QCOMPARE(server.listenQueue(), 111);
     QCOMPARE(server.bufferSize(), 5432);
     QCOMPARE(server.postBuffering(), 456);
@@ -282,14 +279,14 @@ void TestServer::testSetServerConfigFromFile()
     QCOMPARE(server.socketSndbuf(), 123);
     QCOMPARE(server.socketRcvbuf(), 456);
     QCOMPARE(server.websocketMaxSize(), 2048);
-    QCOMPARE(server.pidfile(), u"/path/to/pidfile1"_qs);
-    QCOMPARE(server.pidfile2(), u"/path/to/pidfile2"_qs);
+    QCOMPARE(server.pidfile(), u"/path/to/pidfile1"_s);
+    QCOMPARE(server.pidfile2(), u"/path/to/pidfile2"_s);
 #ifdef Q_OS_UNIX
-    QCOMPARE(server.uid(), u"user"_qs);
-    QCOMPARE(server.gid(), u"group"_qs);
+    QCOMPARE(server.uid(), u"user"_s);
+    QCOMPARE(server.gid(), u"group"_s);
     QCOMPARE(server.noInitgroups(), true);
-    QCOMPARE(server.chownSocket(), u"user:group"_qs);
-    QCOMPARE(server.umask(), u"0077"_qs);
+    QCOMPARE(server.chownSocket(), u"user:group"_s);
+    QCOMPARE(server.umask(), u"0077"_s);
     QCOMPARE(server.cpuAffinity(), 1);
 #endif
 #ifdef Q_OS_LINUX

--- a/tests/teststaticcompressed.cpp
+++ b/tests/teststaticcompressed.cpp
@@ -13,6 +13,7 @@
 #include <QTextStream>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 // NOLINTBEGIN(cppcoreguidelines-avoid-do-while)
 class TestStaticCompressed : public CoverageObject
 {
@@ -55,14 +56,14 @@ private:
     bool writeTestFile(const QString &name);
 };
 
-const QStringList TestStaticCompressed::types{u"js"_qs,
-                                              u"css"_qs,
-                                              u"min.js"_qs,
-                                              u"min.css"_qs,
-                                              u"js.map"_qs,
-                                              u"css.map"_qs,
-                                              u"min.js.map"_qs,
-                                              u"min.css.map"_qs};
+const QStringList TestStaticCompressed::types{u"js"_s,
+                                              u"css"_s,
+                                              u"min.js"_s,
+                                              u"min.css"_s,
+                                              u"js.map"_s,
+                                              u"css.map"_s,
+                                              u"min.js.map"_s,
+                                              u"min.css.map"_s};
 
 const QByteArrayList TestStaticCompressed::encoding{
 #ifdef CUTELYST_STATICCOMPRESSED_WITH_ZSTD
@@ -88,15 +89,15 @@ TestEngine *TestStaticCompressed::getEngine(bool serveDirsOnly)
     auto app    = new TestApplication;
     auto engine = new TestEngine(app, {});
 
-    const QVariantMap defaultConfig{{u"zlib_compression_level"_qs, 1},
-                                    {u"brotli_quality_level"_qs, 0},
-                                    {u"use_zopfli"_qs, true},
-                                    {u"zopfli_iterations"_qs, 5},
-                                    {u"zstd_compression_level"_qs, 1}};
+    const QVariantMap defaultConfig{{u"zlib_compression_level"_s, 1},
+                                    {u"brotli_quality_level"_s, 0},
+                                    {u"use_zopfli"_s, true},
+                                    {u"zopfli_iterations"_s, 5},
+                                    {u"zstd_compression_level"_s, 1}};
 
     auto plug = new StaticCompressed(app, defaultConfig);
     plug->setIncludePaths({m_dataDir.path()});
-    plug->setDirs({u"forced"_qs});
+    plug->setDirs({u"forced"_s});
     plug->setServeDirsOnly(serveDirsOnly);
 
     if (!engine->init()) {
@@ -162,7 +163,7 @@ void TestStaticCompressed::cleanupTestCase()
  */
 void TestStaticCompressed::testFileNotFound()
 {
-    const auto resp = getFile(u"/filenotavailable.js"_qs);
+    const auto resp = getFile(u"/filenotavailable.js"_s);
     QVERIFY(resp.statusCode >= Response::BadRequest);
 }
 
@@ -195,7 +196,7 @@ void TestStaticCompressed::testOnTheFlyCompression_data()
     for (const QString &type : TestStaticCompressed::types) {
         for (const QByteArray &enc : TestStaticCompressed::encoding) {
             const QByteArray testName = type.toLatin1() + "-" + enc;
-            const QString fileName    = u"onTheFly-"_qs + QString::fromLatin1(enc) + u"."_qs + type;
+            const QString fileName    = u"onTheFly-"_s + QString::fromLatin1(enc) + u"."_s + type;
             QTest::newRow(testName.data()) << fileName << enc;
         }
     }
@@ -213,13 +214,13 @@ void TestStaticCompressed::testPreCompressed()
     QVERIFY(writeTestFile(fileName));
     QString encodedFileName = fileName;
     if (encoding == "zstd") {
-        encodedFileName += u".zst"_qs;
+        encodedFileName += u".zst"_s;
     } else if (encoding == "br") {
-        encodedFileName += u".br"_qs;
+        encodedFileName += u".br"_s;
     } else if (encoding == "gzip") {
-        encodedFileName += u".gz"_qs;
+        encodedFileName += u".gz"_s;
     } else if (encoding == "deflate") {
-        encodedFileName += u".deflate"_qs;
+        encodedFileName += u".deflate"_s;
     } else {
         QVERIFY2(false, "invalid encoding");
     }
@@ -243,8 +244,7 @@ void TestStaticCompressed::testPreCompressed_data()
     for (const QString &type : TestStaticCompressed::types) {
         for (const QByteArray &enc : TestStaticCompressed::encoding) {
             const QByteArray testName = type.toLatin1() + "-" + enc;
-            const QString fileName =
-                u"preCompressed-"_qs + QString::fromLatin1(enc) + u"."_qs + type;
+            const QString fileName = u"preCompressed-"_s + QString::fromLatin1(enc) + u"."_s + type;
             QTest::newRow(testName.data()) << fileName << enc;
         }
     }
@@ -256,13 +256,13 @@ void TestStaticCompressed::testPreCompressed_data()
  */
 void TestStaticCompressed::testLastModifiedSince()
 {
-    QVERIFY(writeTestFile(u"lastmodified.js"_qs));
-    QFileInfo fi(m_dataDir.filePath(u"lastmodified.js"_qs));
+    QVERIFY(writeTestFile(u"lastmodified.js"_s));
+    QFileInfo fi(m_dataDir.filePath(u"lastmodified.js"_s));
     Headers hdrs{
         {"Accept-Encoding", "br"},
         {"If-Modified-Since",
          fi.lastModified().toUTC().toString(u"ddd, dd MMM yyyy hh:mm:ss 'GMT'").toLatin1()}};
-    const auto resp = getFile(u"/lastmodified.js"_qs, hdrs);
+    const auto resp = getFile(u"/lastmodified.js"_s, hdrs);
 
     QCOMPARE(resp.statusCode, Response::NotModified);
 }
@@ -274,11 +274,11 @@ void TestStaticCompressed::testLastModifiedSince()
 void TestStaticCompressed::testGetFileFromSubdirs()
 {
     QDir dataDir(m_dataDir.path());
-    QVERIFY(dataDir.mkpath(u"static/css"_qs));
-    QVERIFY(writeTestFile(u"static/css/mytestfile.css"_qs));
-    const auto resp = getFile(u"/static/css/mytestfile.css"_qs, {{"Accept-Encoding", "gzip"}});
+    QVERIFY(dataDir.mkpath(u"static/css"_s));
+    QVERIFY(writeTestFile(u"static/css/mytestfile.css"_s));
+    const auto resp = getFile(u"/static/css/mytestfile.css"_s, {{"Accept-Encoding", "gzip"}});
     QCOMPARE(resp.statusCode, Response::OK);
-    QCOMPARE(resp.headers.header("Content-Encoding"), "gzip"_qba);
+    QCOMPARE(resp.headers.header("Content-Encoding"), "gzip"_ba);
 }
 
 /**
@@ -289,8 +289,8 @@ void TestStaticCompressed::testGetFileFromSubdirs()
 void TestStaticCompressed::testFileNotFoundFromForcedDirs()
 {
     QDir dataDir(m_dataDir.path());
-    QVERIFY(dataDir.mkpath(u"forced/css"_qs));
-    const auto resp = getFile(u"/forced/css/notavailable.css"_qs);
+    QVERIFY(dataDir.mkpath(u"forced/css"_s));
+    const auto resp = getFile(u"/forced/css/notavailable.css"_s);
     QCOMPARE(resp.statusCode, Response::NotFound);
 }
 
@@ -302,11 +302,11 @@ void TestStaticCompressed::testFileNotFoundFromForcedDirs()
 void TestStaticCompressed::testGetFileFromForcedDirs()
 {
     QDir dataDir(m_dataDir.path());
-    QVERIFY(dataDir.mkpath(u"forced/css"_qs));
-    QVERIFY(writeTestFile(u"forced/css/mytestfile.css"_qs));
-    const auto resp = getFile(u"/forced/css/mytestfile.css"_qs, {{"Accept-Encoding", "gzip"}});
+    QVERIFY(dataDir.mkpath(u"forced/css"_s));
+    QVERIFY(writeTestFile(u"forced/css/mytestfile.css"_s));
+    const auto resp = getFile(u"/forced/css/mytestfile.css"_s, {{"Accept-Encoding", "gzip"}});
     QCOMPARE(resp.statusCode, Response::OK);
-    QCOMPARE(resp.headers.header("Content-Encoding"), "gzip"_qba);
+    QCOMPARE(resp.headers.header("Content-Encoding"), "gzip"_ba);
 }
 
 /**
@@ -317,12 +317,12 @@ void TestStaticCompressed::testGetFileFromForcedDirs()
 void TestStaticCompressed::testGetFileFromForcedDirsOnly()
 {
     QDir dataDir(m_dataDir.path());
-    QVERIFY(dataDir.mkpath(u"forced/css"_qs));
-    QVERIFY(writeTestFile(u"forced/css/myforcedtestfile.css"_qs));
+    QVERIFY(dataDir.mkpath(u"forced/css"_s));
+    QVERIFY(writeTestFile(u"forced/css/myforcedtestfile.css"_s));
     const auto resp =
-        getForcedFile(u"/forced/css/myforcedtestfile.css"_qs, {{"Accept-Encoding", "gzip"}});
+        getForcedFile(u"/forced/css/myforcedtestfile.css"_s, {{"Accept-Encoding", "gzip"}});
     QCOMPARE(resp.statusCode, Response::OK);
-    QCOMPARE(resp.headers.header("Content-Encoding"), "gzip"_qba);
+    QCOMPARE(resp.headers.header("Content-Encoding"), "gzip"_ba);
 }
 
 /**
@@ -333,8 +333,8 @@ void TestStaticCompressed::testGetFileFromForcedDirsOnly()
 void TestStaticCompressed::testFileNotFoundFromForcedDirsOnly()
 {
     QDir dataDir(m_dataDir.path());
-    QVERIFY(dataDir.mkpath(u"forced"_qs));
-    const auto resp = getForcedFile(u"/forced/notavailable.js"_qs);
+    QVERIFY(dataDir.mkpath(u"forced"_s));
+    const auto resp = getForcedFile(u"/forced/notavailable.js"_s);
     QCOMPARE(resp.statusCode, Response::NotFound);
 }
 
@@ -346,8 +346,8 @@ void TestStaticCompressed::testFileNotFoundFromForcedDirsOnly()
 void TestStaticCompressed::testFileNotInForcedDirsOnly()
 {
     QDir dataDir(m_dataDir.path());
-    QVERIFY(dataDir.mkpath(u"forced"_qs));
-    const auto resp = getForcedFile(u"/notinforced.js"_qs);
+    QVERIFY(dataDir.mkpath(u"forced"_s));
+    const auto resp = getForcedFile(u"/notinforced.js"_s);
     QVERIFY(resp.statusCode >= Response::BadRequest);
 }
 
@@ -357,7 +357,7 @@ void TestStaticCompressed::testFileNotInForcedDirsOnly()
  */
 void TestStaticCompressed::testControllerPath()
 {
-    const auto resp = getFile(u"/test/controller/hello"_qs);
+    const auto resp = getFile(u"/test/controller/hello"_s);
     QCOMPARE(resp.statusCode, Response::OK);
 }
 

--- a/tests/teststaticsimple.cpp
+++ b/tests/teststaticsimple.cpp
@@ -13,6 +13,7 @@
 #include <QTextStream>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 // NOLINTBEGIN(cppcoreguidelines-avoid-do-while)
 class TestStaticSimple : public CoverageObject
 {
@@ -66,7 +67,7 @@ TestEngine *TestStaticSimple::getEngine(bool serveDirsOnly)
 
     auto plug = new StaticSimple(app);
     plug->setIncludePaths({m_dataDir.path()});
-    plug->setDirs({u"forced"_qs});
+    plug->setDirs({u"forced"_s});
     plug->setServeDirsOnly(serveDirsOnly);
 
     if (!engine->init()) {
@@ -120,49 +121,49 @@ void TestStaticSimple::cleanupTestCase()
 
 void TestStaticSimple::testFileNotFound()
 {
-    const auto resp = getFile(u"/filenotavailable.js"_qs);
+    const auto resp = getFile(u"/filenotavailable.js"_s);
     QVERIFY(resp.statusCode >= Response::BadRequest);
 }
 
 void TestStaticSimple::testGetFileFromRoot()
 {
-    QVERIFY(writeTestFile(u"mytestfile.css"_qs));
-    const auto resp = getFile(u"/mytestfile.css"_qs);
+    QVERIFY(writeTestFile(u"mytestfile.css"_s));
+    const auto resp = getFile(u"/mytestfile.css"_s);
     QCOMPARE(resp.statusCode, Response::OK);
 }
 
 void TestStaticSimple::testGetFileFromSubdirs()
 {
     QDir dataDir(m_dataDir.path());
-    QVERIFY(dataDir.mkpath(u"static/css"_qs));
-    QVERIFY(writeTestFile(u"static/css/mytestfile.css"_qs));
-    const auto resp = getFile(u"/static/css/mytestfile.css"_qs);
+    QVERIFY(dataDir.mkpath(u"static/css"_s));
+    QVERIFY(writeTestFile(u"static/css/mytestfile.css"_s));
+    const auto resp = getFile(u"/static/css/mytestfile.css"_s);
     QCOMPARE(resp.statusCode, Response::OK);
 }
 
 void TestStaticSimple::testFileNotFoundFomForcedDirs()
 {
     QDir dataDir(m_dataDir.path());
-    QVERIFY(dataDir.mkpath(u"forced/css"_qs));
-    const auto resp = getFile(u"/forced/css/notavailable.css"_qs);
+    QVERIFY(dataDir.mkpath(u"forced/css"_s));
+    const auto resp = getFile(u"/forced/css/notavailable.css"_s);
     QCOMPARE(resp.statusCode, Response::NotFound);
 }
 
 void TestStaticSimple::testGetFileFromForcedDirs()
 {
     QDir dataDir(m_dataDir.path());
-    QVERIFY(dataDir.mkpath(u"forced/css"_qs));
-    QVERIFY(writeTestFile(u"forced/css/mytestfile.css"_qs));
-    const auto resp = getFile(u"/forced/css/mytestfile.css"_qs);
+    QVERIFY(dataDir.mkpath(u"forced/css"_s));
+    QVERIFY(writeTestFile(u"forced/css/mytestfile.css"_s));
+    const auto resp = getFile(u"/forced/css/mytestfile.css"_s);
     QCOMPARE(resp.statusCode, Response::OK);
 }
 
 void TestStaticSimple::testLastModifiedSince()
 {
-    QVERIFY(writeTestFile(u"lastmodified.js"_qs));
-    QFileInfo fi(m_dataDir.filePath(u"lastmodified.js"_qs));
+    QVERIFY(writeTestFile(u"lastmodified.js"_s));
+    QFileInfo fi(m_dataDir.filePath(u"lastmodified.js"_s));
     const auto resp = getFile(
-        u"/lastmodified.js"_qs,
+        u"/lastmodified.js"_s,
         {{"If-Modified-Since",
           fi.lastModified().toUTC().toString(u"ddd, dd MMM yyyy hh:mm:ss 'GMT'").toLatin1()}});
     QCOMPARE(resp.statusCode, Response::NotModified);
@@ -176,9 +177,9 @@ void TestStaticSimple::testLastModifiedSince()
 void TestStaticSimple::testGetFileFromForcedDirsOnly()
 {
     QDir dataDir(m_dataDir.path());
-    QVERIFY(dataDir.mkpath(u"forced/css"_qs));
-    QVERIFY(writeTestFile(u"forced/css/myforcedtestfile.css"_qs));
-    const auto resp = getForcedFile(u"/forced/css/myforcedtestfile.css"_qs);
+    QVERIFY(dataDir.mkpath(u"forced/css"_s));
+    QVERIFY(writeTestFile(u"forced/css/myforcedtestfile.css"_s));
+    const auto resp = getForcedFile(u"/forced/css/myforcedtestfile.css"_s);
     QCOMPARE(resp.statusCode, Response::OK);
 }
 
@@ -190,8 +191,8 @@ void TestStaticSimple::testGetFileFromForcedDirsOnly()
 void TestStaticSimple::testFileNotFoundFromForcedDirsOnly()
 {
     QDir dataDir(m_dataDir.path());
-    QVERIFY(dataDir.mkpath(u"forced"_qs));
-    const auto resp = getForcedFile(u"/forced/notavailable.js"_qs);
+    QVERIFY(dataDir.mkpath(u"forced"_s));
+    const auto resp = getForcedFile(u"/forced/notavailable.js"_s);
     QCOMPARE(resp.statusCode, Response::NotFound);
 }
 
@@ -203,8 +204,8 @@ void TestStaticSimple::testFileNotFoundFromForcedDirsOnly()
 void TestStaticSimple::testFileNotInForcedDirsOnly()
 {
     QDir dataDir(m_dataDir.path());
-    QVERIFY(dataDir.mkpath(u"forced"_qs));
-    const auto resp = getForcedFile(u"/notinforced.js"_qs);
+    QVERIFY(dataDir.mkpath(u"forced"_s));
+    const auto resp = getForcedFile(u"/notinforced.js"_s);
     QVERIFY(resp.statusCode >= Response::BadRequest);
 }
 
@@ -214,7 +215,7 @@ void TestStaticSimple::testFileNotInForcedDirsOnly()
  */
 void TestStaticSimple::testControllerPath()
 {
-    const auto resp = getFile(u"/test/controller/hello"_qs);
+    const auto resp = getFile(u"/test/controller/hello"_s);
     QCOMPARE(resp.statusCode, Response::OK);
 }
 

--- a/tests/teststatusmessage.cpp
+++ b/tests/teststatusmessage.cpp
@@ -186,7 +186,7 @@ void TestStatusMessage::doTest()
     auto result = m_engine->createRequest(
         "GET", urlAux.path(), urlAux.query(QUrl::FullyEncoded).toLatin1(), Headers(), nullptr);
     Headers headers = result.headers;
-    headers.setHeader("Cookie"_qba, headers.header("Set-Cookie"));
+    headers.setHeader(QByteArrayLiteral("Cookie"), headers.header("Set-Cookie"));
 
     QUrl urlAux2(url + QLatin1String("Test/") + m_sm->statusMsgStashKey() + QLatin1Char('/') +
                  m_sm->errorMgStashKey());

--- a/tests/testutils.cpp
+++ b/tests/testutils.cpp
@@ -7,6 +7,7 @@
 #include <QTest>
 
 using namespace std::chrono_literals;
+using namespace Qt::Literals::StringLiterals;
 
 class UtilsTest : public QObject
 {
@@ -39,54 +40,53 @@ void UtilsTest::testDurationFromString_data()
     QTest::addColumn<std::chrono::microseconds>("us");
     QTest::addColumn<bool>("ok");
 
-    QTest::newRow("valid-us-01") << u"123456us"_qs << 123456us << true;
-    QTest::newRow("valid-us-02") << u"123456  usec"_qs << 123456us << true;
+    QTest::newRow("valid-us-01") << u"123456us"_s << 123456us << true;
+    QTest::newRow("valid-us-02") << u"123456  usec"_s << 123456us << true;
 
-    QTest::newRow("valid-ms-01") << u"123ms"_qs << 123000us << true;
-    QTest::newRow("valid-ms-02") << u"123456  msec"_qs << 123456000us << true;
+    QTest::newRow("valid-ms-01") << u"123ms"_s << 123000us << true;
+    QTest::newRow("valid-ms-02") << u"123456  msec"_s << 123456000us << true;
 
-    QTest::newRow("valid-sec-01") << u"12seconds"_qs << 12000000us << true;
-    QTest::newRow("valid-sec-02") << u"12 second"_qs << 12000000us << true;
-    QTest::newRow("valid-sec-03") << u"12    sec"_qs << 12000000us << true;
-    QTest::newRow("valid-sec-04") << u"  12    s"_qs << 12000000us << true;
-    QTest::newRow("valid-sec-05") << u"    12   "_qs << 12000000us << true;
+    QTest::newRow("valid-sec-01") << u"12seconds"_s << 12000000us << true;
+    QTest::newRow("valid-sec-02") << u"12 second"_s << 12000000us << true;
+    QTest::newRow("valid-sec-03") << u"12    sec"_s << 12000000us << true;
+    QTest::newRow("valid-sec-04") << u"  12    s"_s << 12000000us << true;
+    QTest::newRow("valid-sec-05") << u"    12   "_s << 12000000us << true;
 
-    QTest::newRow("valid-min-01") << u"12minutes"_qs << 720000000us << true;
-    QTest::newRow("valid-min-02") << u"12 minute"_qs << 720000000us << true;
-    QTest::newRow("valid-min-03") << u"12    min"_qs << 720000000us << true;
-    QTest::newRow("valid-min-04") << u"   12  m "_qs << 720000000us << true;
+    QTest::newRow("valid-min-01") << u"12minutes"_s << 720000000us << true;
+    QTest::newRow("valid-min-02") << u"12 minute"_s << 720000000us << true;
+    QTest::newRow("valid-min-03") << u"12    min"_s << 720000000us << true;
+    QTest::newRow("valid-min-04") << u"   12  m "_s << 720000000us << true;
 
-    QTest::newRow("valid-hr-01") << u"1hours"_qs << 3600000000us << true;
-    QTest::newRow("valid-hr-02") << u"1 hour"_qs << 3600000000us << true;
-    QTest::newRow("valid-hr-03") << u"1   hr"_qs << 3600000000us << true;
-    QTest::newRow("valid-hr-04") << u" 1  h "_qs << 3600000000us << true;
+    QTest::newRow("valid-hr-01") << u"1hours"_s << 3600000000us << true;
+    QTest::newRow("valid-hr-02") << u"1 hour"_s << 3600000000us << true;
+    QTest::newRow("valid-hr-03") << u"1   hr"_s << 3600000000us << true;
+    QTest::newRow("valid-hr-04") << u" 1  h "_s << 3600000000us << true;
 
-    QTest::newRow("valid-day-01") << u"1days"_qs << 86400000000us << true;
-    QTest::newRow("valid-day-02") << u"1 day"_qs << 86400000000us << true;
-    QTest::newRow("valid-day-03") << u" 1 d "_qs << 86400000000us << true;
+    QTest::newRow("valid-day-01") << u"1days"_s << 86400000000us << true;
+    QTest::newRow("valid-day-02") << u"1 day"_s << 86400000000us << true;
+    QTest::newRow("valid-day-03") << u" 1 d "_s << 86400000000us << true;
 
-    QTest::newRow("valid-week-01") << u"1weeks"_qs << 604800000000us << true;
-    QTest::newRow("valid-week-02") << u"1 week"_qs << 604800000000us << true;
-    QTest::newRow("valid-week-03") << u" 1  w "_qs << 604800000000us << true;
+    QTest::newRow("valid-week-01") << u"1weeks"_s << 604800000000us << true;
+    QTest::newRow("valid-week-02") << u"1 week"_s << 604800000000us << true;
+    QTest::newRow("valid-week-03") << u" 1  w "_s << 604800000000us << true;
 
-    QTest::newRow("valid-month-01") << u"1months"_qs << 2629746000000us << true;
-    QTest::newRow("valid-month-02") << u"1 month"_qs << 2629746000000us << true;
-    QTest::newRow("valid-month-03") << u"  1  M "_qs << 2629746000000us << true;
+    QTest::newRow("valid-month-01") << u"1months"_s << 2629746000000us << true;
+    QTest::newRow("valid-month-02") << u"1 month"_s << 2629746000000us << true;
+    QTest::newRow("valid-month-03") << u"  1  M "_s << 2629746000000us << true;
 
-    QTest::newRow("valid-year-01") << u"1years"_qs << 31556952000000us << true;
-    QTest::newRow("valid-year-02") << u"1 year"_qs << 31556952000000us << true;
-    QTest::newRow("valid-year-03") << u" 1  y "_qs << 31556952000000us << true;
+    QTest::newRow("valid-year-01") << u"1years"_s << 31556952000000us << true;
+    QTest::newRow("valid-year-02") << u"1 year"_s << 31556952000000us << true;
+    QTest::newRow("valid-year-03") << u" 1  y "_s << 31556952000000us << true;
 
-    QTest::newRow("combined-valid-01") << u"1hour 12 minutes"_qs << 4320000000us << true;
-    QTest::newRow("combined-valid-02") << u" 12 min   1hr  "_qs << 4320000000us << true;
-    QTest::newRow("combined-valid-03") << u"1 sec 1"_qs << 2000000us << true;
+    QTest::newRow("combined-valid-01") << u"1hour 12 minutes"_s << 4320000000us << true;
+    QTest::newRow("combined-valid-02") << u" 12 min   1hr  "_s << 4320000000us << true;
+    QTest::newRow("combined-valid-03") << u"1 sec 1"_s << 2000000us << true;
 
     QTest::newRow("invalid-digit-too-long")
-        << u"184467440737095516152934759234234"_qs << std::chrono::microseconds::zero() << false;
-    QTest::newRow("invalid-no-digit")
-        << u"seconds"_qs << std::chrono::microseconds::zero() << false;
-    QTest::newRow("invalid-unit") << u"1 Stunde"_qs << std::chrono::microseconds::zero() << false;
-    QTest::newRow("invalid-empty") << u"  "_qs << std::chrono::microseconds::zero() << false;
+        << u"184467440737095516152934759234234"_s << std::chrono::microseconds::zero() << false;
+    QTest::newRow("invalid-no-digit") << u"seconds"_s << std::chrono::microseconds::zero() << false;
+    QTest::newRow("invalid-unit") << u"1 Stunde"_s << std::chrono::microseconds::zero() << false;
+    QTest::newRow("invalid-empty") << u"  "_s << std::chrono::microseconds::zero() << false;
 }
 
 QTEST_MAIN(UtilsTest)

--- a/tests/testvalidator.cpp
+++ b/tests/testvalidator.cpp
@@ -28,6 +28,7 @@
 #include <QUuid>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 class TestValidator : public CoverageObject
 {
@@ -206,7 +207,7 @@ public:
     C_ATTR(bodyParamsOnly, :Local :AutoArgs)
     void bodyParamsOnly(Context *c)
     {
-        Validator v({new ValidatorRequired(u"req_field"_qs, m_validatorMessages)});
+        Validator v({new ValidatorRequired(u"req_field"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::BodyParamsOnly));
     }
 
@@ -214,7 +215,7 @@ public:
     C_ATTR(queryParamsOnly, :Local :AutoArgs)
     void queryParamsOnly(Context *c)
     {
-        Validator v({new ValidatorRequired(u"req_field"_qs, m_validatorMessages)});
+        Validator v({new ValidatorRequired(u"req_field"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::QueryParamsOnly));
     }
 
@@ -222,7 +223,7 @@ public:
     C_ATTR(accepted, :Local :AutoArgs)
     void accepted(Context *c)
     {
-        Validator v({new ValidatorAccepted(u"accepted_field"_qs, m_validatorMessages)});
+        Validator v({new ValidatorAccepted(u"accepted_field"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -231,7 +232,7 @@ public:
     void afterDate(Context *c)
     {
         Validator v({new ValidatorAfter(
-            u"after_field"_qs, QDate::currentDate(), QString(), nullptr, m_validatorMessages)});
+            u"after_field"_s, QDate::currentDate(), QString(), nullptr, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -240,7 +241,7 @@ public:
     void afterTime(Context *c)
     {
         Validator v({new ValidatorAfter(
-            u"after_field"_qs, QTime(12, 0), QString(), nullptr, m_validatorMessages)});
+            u"after_field"_s, QTime(12, 0), QString(), nullptr, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -248,7 +249,7 @@ public:
     C_ATTR(afterDateTime, :Local :AutoArgs)
     void afterDateTime(Context *c)
     {
-        Validator v({new ValidatorAfter(u"after_field"_qs,
+        Validator v({new ValidatorAfter(u"after_field"_s,
                                         QDateTime::currentDateTime(),
                                         QString(),
                                         nullptr,
@@ -260,7 +261,7 @@ public:
     C_ATTR(afterFormat, :Local :AutoArgs)
     void afterFormat(Context *c)
     {
-        Validator v({new ValidatorAfter(u"after_field"_qs,
+        Validator v({new ValidatorAfter(u"after_field"_s,
                                         QDateTime::currentDateTime(),
                                         QString(),
                                         "yyyy d MM HH:mm",
@@ -273,7 +274,7 @@ public:
     void afterInvalidValidationData(Context *c)
     {
         Validator v({new ValidatorAfter(
-            u"after_field"_qs, QDate(), QString(), nullptr, m_validatorMessages)});
+            u"after_field"_s, QDate(), QString(), nullptr, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -282,7 +283,7 @@ public:
     void afterInvalidValidationData2(Context *c)
     {
         Validator v({new ValidatorAfter(
-            u"after_field"_qs, u"schiet"_qs, QString(), nullptr, m_validatorMessages)});
+            u"after_field"_s, u"schiet"_s, QString(), nullptr, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -290,11 +291,11 @@ public:
     C_ATTR(afterValidWithTimeZone, :Local :AutoArgs)
     void afterValidWithTimeZone(Context *c)
     {
-        Validator v({new ValidatorAfter(u"after_field"_qs,
+        Validator v({new ValidatorAfter(u"after_field"_s,
                                         QDateTime(QDate(2018, 1, 15),
                                                   QTime(12, 0),
                                                   QTimeZone(QByteArrayLiteral("Indian/Christmas"))),
-                                        u"Europe/Berlin"_qs,
+                                        u"Europe/Berlin"_s,
                                         nullptr,
                                         m_validatorMessages)});
         checkResponse(c, v.validate(c));
@@ -304,11 +305,11 @@ public:
     C_ATTR(afterValidWithTimeZoneField, :Local :AutoArgs)
     void afterValidWithTimeZoneField(Context *c)
     {
-        Validator v({new ValidatorAfter(u"after_field"_qs,
+        Validator v({new ValidatorAfter(u"after_field"_s,
                                         QDateTime(QDate(2018, 1, 15),
                                                   QTime(12, 0),
                                                   QTimeZone(QByteArrayLiteral("Indian/Christmas"))),
-                                        u"tz_field"_qs,
+                                        u"tz_field"_s,
                                         nullptr,
                                         m_validatorMessages)});
         checkResponse(c, v.validate(c));
@@ -318,7 +319,7 @@ public:
     C_ATTR(alpha, :Local :AutoArgs)
     void alpha(Context *c)
     {
-        Validator v({new ValidatorAlpha(u"alpha_field"_qs, false, m_validatorMessages)});
+        Validator v({new ValidatorAlpha(u"alpha_field"_s, false, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -326,7 +327,7 @@ public:
     C_ATTR(alphaAscii, :Local :AutoArgs)
     void alphaAscii(Context *c)
     {
-        Validator v({new ValidatorAlpha(u"alpha_field"_qs, true, m_validatorMessages)});
+        Validator v({new ValidatorAlpha(u"alpha_field"_s, true, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -334,7 +335,7 @@ public:
     C_ATTR(alphaDash, :Local :AutoArgs)
     void alphaDash(Context *c)
     {
-        Validator v({new ValidatorAlphaDash(u"alphadash_field"_qs, false, m_validatorMessages)});
+        Validator v({new ValidatorAlphaDash(u"alphadash_field"_s, false, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -342,7 +343,7 @@ public:
     C_ATTR(alphaDashAscii, :Local :AutoArgs)
     void alphaDashAscii(Context *c)
     {
-        Validator v({new ValidatorAlphaDash(u"alphadash_field"_qs, true, m_validatorMessages)});
+        Validator v({new ValidatorAlphaDash(u"alphadash_field"_s, true, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -350,7 +351,7 @@ public:
     C_ATTR(alphaNum, :Local :AutoArgs)
     void alphaNum(Context *c)
     {
-        Validator v({new ValidatorAlphaNum(u"alphanum_field"_qs, false, m_validatorMessages)});
+        Validator v({new ValidatorAlphaNum(u"alphanum_field"_s, false, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -358,7 +359,7 @@ public:
     C_ATTR(alphaNumAscii, :Local :AutoArgs)
     void alphaNumAscii(Context *c)
     {
-        Validator v({new ValidatorAlphaNum(u"alphanum_field"_qs, true, m_validatorMessages)});
+        Validator v({new ValidatorAlphaNum(u"alphanum_field"_s, true, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -367,7 +368,7 @@ public:
     void beforeDate(Context *c)
     {
         Validator v({new ValidatorBefore(
-            u"before_field"_qs, QDate::currentDate(), QString(), nullptr, m_validatorMessages)});
+            u"before_field"_s, QDate::currentDate(), QString(), nullptr, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -376,7 +377,7 @@ public:
     void beforeTime(Context *c)
     {
         Validator v({new ValidatorBefore(
-            u"before_field"_qs, QTime(12, 0), QString(), nullptr, m_validatorMessages)});
+            u"before_field"_s, QTime(12, 0), QString(), nullptr, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -384,7 +385,7 @@ public:
     C_ATTR(beforeDateTime, :Local :AutoArgs)
     void beforeDateTime(Context *c)
     {
-        Validator v({new ValidatorBefore(u"before_field"_qs,
+        Validator v({new ValidatorBefore(u"before_field"_s,
                                          QDateTime::currentDateTime(),
                                          QString(),
                                          nullptr,
@@ -396,7 +397,7 @@ public:
     C_ATTR(beforeFormat, :Local :AutoArgs)
     void beforeFormat(Context *c)
     {
-        Validator v({new ValidatorBefore(u"before_field"_qs,
+        Validator v({new ValidatorBefore(u"before_field"_s,
                                          QDateTime::currentDateTime(),
                                          QString(),
                                          "yyyy d MM HH:mm",
@@ -409,7 +410,7 @@ public:
     void beforeInvalidValidationData(Context *c)
     {
         Validator v({new ValidatorBefore(
-            u"before_field"_qs, QDate(), QString(), nullptr, m_validatorMessages)});
+            u"before_field"_s, QDate(), QString(), nullptr, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -418,7 +419,7 @@ public:
     void beforeInvalidValidationData2(Context *c)
     {
         Validator v({new ValidatorBefore(
-            u"before_field"_qs, u"schiet"_qs, QString(), nullptr, m_validatorMessages)});
+            u"before_field"_s, u"schiet"_s, QString(), nullptr, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -426,11 +427,11 @@ public:
     C_ATTR(beforeValidWithTimeZone, :Local :AutoArgs)
     void beforeValidWithTimeZone(Context *c)
     {
-        Validator v({new ValidatorBefore(u"after_field"_qs,
+        Validator v({new ValidatorBefore(u"after_field"_s,
                                          QDateTime(QDate(2018, 1, 15),
                                                    QTime(12, 0),
                                                    QTimeZone(QByteArrayLiteral("America/Tijuana"))),
-                                         u"Europe/Berlin"_qs,
+                                         u"Europe/Berlin"_s,
                                          nullptr,
                                          m_validatorMessages)});
         checkResponse(c, v.validate(c));
@@ -440,11 +441,11 @@ public:
     C_ATTR(beforeValidWithTimeZoneField, :Local :AutoArgs)
     void beforeValidWithTimeZoneField(Context *c)
     {
-        Validator v({new ValidatorBefore(u"after_field"_qs,
+        Validator v({new ValidatorBefore(u"after_field"_s,
                                          QDateTime(QDate(2018, 1, 15),
                                                    QTime(12, 0),
                                                    QTimeZone(QByteArrayLiteral("America/Tijuana"))),
-                                         u"tz_field"_qs,
+                                         u"tz_field"_s,
                                          nullptr,
                                          m_validatorMessages)});
         checkResponse(c, v.validate(c));
@@ -455,7 +456,7 @@ public:
     void betweenInt(Context *c)
     {
         Validator v({new ValidatorBetween(
-            u"between_field"_qs, QMetaType::Int, -10, 10, m_validatorMessages)});
+            u"between_field"_s, QMetaType::Int, -10, 10, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -464,7 +465,7 @@ public:
     void betweenUint(Context *c)
     {
         Validator v({new ValidatorBetween(
-            u"between_field"_qs, QMetaType::UInt, 10, 20, m_validatorMessages)});
+            u"between_field"_s, QMetaType::UInt, 10, 20, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -473,7 +474,7 @@ public:
     void betweenFloat(Context *c)
     {
         Validator v({new ValidatorBetween(
-            u"between_field"_qs, QMetaType::Float, -10.0, 10.0, m_validatorMessages)});
+            u"between_field"_s, QMetaType::Float, -10.0, 10.0, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -482,7 +483,7 @@ public:
     void betweenString(Context *c)
     {
         Validator v({new ValidatorBetween(
-            u"between_field"_qs, QMetaType::QString, 5, 10, m_validatorMessages)});
+            u"between_field"_s, QMetaType::QString, 5, 10, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -490,7 +491,7 @@ public:
     C_ATTR(boolean, :Local :AutoArgs)
     void boolean(Context *c)
     {
-        Validator v({new ValidatorBoolean(u"boolean_field"_qs, m_validatorMessages)});
+        Validator v({new ValidatorBoolean(u"boolean_field"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -499,7 +500,7 @@ public:
     void charNotAllowed(Context *c)
     {
         Validator v({new ValidatorCharNotAllowed(
-            u"char_not_allowed_field"_qs, u"#%*."_qs, m_validatorMessages)});
+            u"char_not_allowed_field"_s, u"#%*."_s, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -507,7 +508,7 @@ public:
     C_ATTR(confirmed, :Local :AutoArgs)
     void confirmed(Context *c)
     {
-        Validator v({new ValidatorConfirmed(u"pass"_qs, m_validatorMessages)});
+        Validator v({new ValidatorConfirmed(u"pass"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -515,7 +516,7 @@ public:
     C_ATTR(date, :Local :AutoArgs)
     void date(Context *c)
     {
-        Validator v({new ValidatorDate(u"field"_qs, nullptr, m_validatorMessages)});
+        Validator v({new ValidatorDate(u"field"_s, nullptr, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -523,7 +524,7 @@ public:
     C_ATTR(dateFormat, :Local :AutoArgs)
     void dateFormat(Context *c)
     {
-        Validator v({new ValidatorDate(u"field"_qs, "yyyy d MM", m_validatorMessages)});
+        Validator v({new ValidatorDate(u"field"_s, "yyyy d MM", m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -531,7 +532,7 @@ public:
     C_ATTR(dateTime, :Local :AutoArgs)
     void dateTime(Context *c)
     {
-        Validator v({new ValidatorDateTime(u"field"_qs, QString(), nullptr, m_validatorMessages)});
+        Validator v({new ValidatorDateTime(u"field"_s, QString(), nullptr, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -539,8 +540,8 @@ public:
     C_ATTR(dateTimeFormat, :Local :AutoArgs)
     void dateTimeFormat(Context *c)
     {
-        Validator v({new ValidatorDateTime(
-            u"field"_qs, QString(), "yyyy d MM mm:HH", m_validatorMessages)});
+        Validator v(
+            {new ValidatorDateTime(u"field"_s, QString(), "yyyy d MM mm:HH", m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -548,8 +549,7 @@ public:
     C_ATTR(different, :Local :AutoArgs)
     void different(Context *c)
     {
-        Validator v(
-            {new ValidatorDifferent(u"field"_qs, u"other"_qs, nullptr, m_validatorMessages)});
+        Validator v({new ValidatorDifferent(u"field"_s, u"other"_s, nullptr, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -557,7 +557,7 @@ public:
     C_ATTR(digits, :Local :AutoArgs)
     void digits(Context *c)
     {
-        Validator v({new ValidatorDigits(u"field"_qs, -1, m_validatorMessages)});
+        Validator v({new ValidatorDigits(u"field"_s, -1, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -565,7 +565,7 @@ public:
     C_ATTR(digitsLength, :Local :AutoArgs)
     void digitsLength(Context *c)
     {
-        Validator v({new ValidatorDigits(u"field"_qs, 10, m_validatorMessages)});
+        Validator v({new ValidatorDigits(u"field"_s, 10, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -573,7 +573,7 @@ public:
     C_ATTR(digitsBetween, :Local :AutoArgs)
     void digitsBetween(Context *c)
     {
-        Validator v({new ValidatorDigitsBetween(u"field"_qs, 5, 10, m_validatorMessages)});
+        Validator v({new ValidatorDigitsBetween(u"field"_s, 5, 10, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -581,7 +581,7 @@ public:
     C_ATTR(domain, :Local :AutoArgs)
     void domain(Context *c)
     {
-        Validator v({new ValidatorDomain(u"field"_qs, false, m_validatorMessages)});
+        Validator v({new ValidatorDomain(u"field"_s, false, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -589,7 +589,7 @@ public:
     C_ATTR(domainDns, :Local :AutoArgs)
     void domainDns(Context *c)
     {
-        Validator v({new ValidatorDomain(u"field"_qs, true, m_validatorMessages)});
+        Validator v({new ValidatorDomain(u"field"_s, true, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -598,7 +598,7 @@ public:
     void emailValid(Context *c)
     {
         Validator v({new ValidatorEmail(
-            u"field"_qs, ValidatorEmail::Valid, ValidatorEmail::NoOption, m_validatorMessages)});
+            u"field"_s, ValidatorEmail::Valid, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming | Validator::BodyParamsOnly));
     }
 
@@ -607,7 +607,7 @@ public:
     void emailDnsWarnValid(Context *c)
     {
         Validator v({new ValidatorEmail(
-            u"field"_qs, ValidatorEmail::Valid, ValidatorEmail::CheckDNS, m_validatorMessages)});
+            u"field"_s, ValidatorEmail::Valid, ValidatorEmail::CheckDNS, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming | Validator::BodyParamsOnly));
     }
 
@@ -616,7 +616,7 @@ public:
     void emailRfc5321Valid(Context *c)
     {
         Validator v({new ValidatorEmail(
-            u"field"_qs, ValidatorEmail::RFC5321, ValidatorEmail::NoOption, m_validatorMessages)});
+            u"field"_s, ValidatorEmail::RFC5321, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming | Validator::BodyParamsOnly));
     }
 
@@ -625,7 +625,7 @@ public:
     void emailRfc5321Invalid(Context *c)
     {
         Validator v({new ValidatorEmail(
-            u"field"_qs, ValidatorEmail::DNSWarn, ValidatorEmail::NoOption, m_validatorMessages)});
+            u"field"_s, ValidatorEmail::DNSWarn, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming | Validator::BodyParamsOnly));
     }
 
@@ -634,7 +634,7 @@ public:
     void emailCfwsValid(Context *c)
     {
         Validator v({new ValidatorEmail(
-            u"field"_qs, ValidatorEmail::CFWS, ValidatorEmail::NoOption, m_validatorMessages)});
+            u"field"_s, ValidatorEmail::CFWS, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming | Validator::BodyParamsOnly));
     }
 
@@ -643,7 +643,7 @@ public:
     void emailCfwsInvalid(Context *c)
     {
         Validator v({new ValidatorEmail(
-            u"field"_qs, ValidatorEmail::RFC5321, ValidatorEmail::NoOption, m_validatorMessages)});
+            u"field"_s, ValidatorEmail::RFC5321, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming | Validator::BodyParamsOnly));
     }
 
@@ -651,7 +651,7 @@ public:
     C_ATTR(emailDeprecatedValid, :Local :AutoArgs)
     void emailDeprecatedValid(Context *c)
     {
-        Validator v({new ValidatorEmail(u"field"_qs,
+        Validator v({new ValidatorEmail(u"field"_s,
                                         ValidatorEmail::Deprecated,
                                         ValidatorEmail::NoOption,
                                         m_validatorMessages)});
@@ -663,7 +663,7 @@ public:
     void emailDeprecatedInvalid(Context *c)
     {
         Validator v({new ValidatorEmail(
-            u"field"_qs, ValidatorEmail::CFWS, ValidatorEmail::NoOption, m_validatorMessages)});
+            u"field"_s, ValidatorEmail::CFWS, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming | Validator::BodyParamsOnly));
     }
 
@@ -672,7 +672,7 @@ public:
     void emailRfc5322Valid(Context *c)
     {
         Validator v({new ValidatorEmail(
-            u"field"_qs, ValidatorEmail::RFC5322, ValidatorEmail::NoOption, m_validatorMessages)});
+            u"field"_s, ValidatorEmail::RFC5322, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming | Validator::BodyParamsOnly));
     }
 
@@ -680,7 +680,7 @@ public:
     C_ATTR(emailRfc5322Invalid, :Local :AutoArgs)
     void emailRfc5322Invalid(Context *c)
     {
-        Validator v({new ValidatorEmail(u"field"_qs,
+        Validator v({new ValidatorEmail(u"field"_s,
                                         ValidatorEmail::Deprecated,
                                         ValidatorEmail::NoOption,
                                         m_validatorMessages)});
@@ -692,7 +692,7 @@ public:
     void emailErrors(Context *c)
     {
         Validator v({new ValidatorEmail(
-            u"field"_qs, ValidatorEmail::RFC5322, ValidatorEmail::NoOption, m_validatorMessages)});
+            u"field"_s, ValidatorEmail::RFC5322, ValidatorEmail::NoOption, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming | Validator::BodyParamsOnly));
     }
 
@@ -701,7 +701,7 @@ public:
     void emailIdnAllowed(Context *c)
     {
         Validator v({new ValidatorEmail(
-            u"field"_qs, ValidatorEmail::Valid, ValidatorEmail::AllowIDN, m_validatorMessages)});
+            u"field"_s, ValidatorEmail::Valid, ValidatorEmail::AllowIDN, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming | Validator::BodyParamsOnly));
     }
 
@@ -710,7 +710,7 @@ public:
     void emailUtf8Local(Context *c)
     {
         Validator v({new ValidatorEmail(
-            u"field"_qs, ValidatorEmail::Valid, ValidatorEmail::UTF8Local, m_validatorMessages)});
+            u"field"_s, ValidatorEmail::Valid, ValidatorEmail::UTF8Local, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming | Validator::BodyParamsOnly));
     }
 
@@ -719,7 +719,7 @@ public:
     void emailUtf8(Context *c)
     {
         Validator v({new ValidatorEmail(
-            u"field"_qs, ValidatorEmail::Valid, ValidatorEmail::AllowUTF8, m_validatorMessages)});
+            u"field"_s, ValidatorEmail::Valid, ValidatorEmail::AllowUTF8, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming | Validator::BodyParamsOnly));
     }
 
@@ -728,7 +728,7 @@ public:
     void fileSize(Context *c)
     {
         ValidatorFileSize::Option option = ValidatorFileSize::NoOption;
-        const QString opt                = c->req()->bodyParameter(u"option"_qs);
+        const QString opt                = c->req()->bodyParameter(u"option"_s);
         if (opt == QLatin1String("OnlyBinary")) {
             option = ValidatorFileSize::OnlyBinary;
         } else if (opt == QLatin1String("OnlyDecimal")) {
@@ -738,10 +738,10 @@ public:
         } else if (opt == QLatin1String("ForceDecimal")) {
             option = ValidatorFileSize::ForceDecimal;
         }
-        const double min = c->req()->bodyParameter(u"min"_qs, u"-1.0"_qs).toDouble();
-        const double max = c->req()->bodyParameter(u"max"_qs, u"-1.0"_qs).toDouble();
-        c->setLocale(QLocale(c->req()->bodyParameter(u"locale"_qs, u"C"_qs)));
-        Validator v({new ValidatorFileSize(u"field"_qs, option, min, max, m_validatorMessages)});
+        const double min = c->req()->bodyParameter(u"min"_s, u"-1.0"_s).toDouble();
+        const double max = c->req()->bodyParameter(u"max"_s, u"-1.0"_s).toDouble();
+        c->setLocale(QLocale(c->req()->bodyParameter(u"locale"_s, u"C"_s)));
+        Validator v({new ValidatorFileSize(u"field"_s, option, min, max, m_validatorMessages)});
         checkResponse(c, v.validate(c, Validator::NoTrimming));
     }
 
@@ -750,11 +750,11 @@ public:
     void fileSizeValue(Context *c)
     {
         c->setLocale(QLocale::c());
-        Validator v({new ValidatorFileSize(u"field"_qs)});
+        Validator v({new ValidatorFileSize(u"field"_s)});
         const ValidatorResult r = v.validate(c);
         if (r) {
             QString sizeString;
-            const QVariant rv = r.value(u"field"_qs);
+            const QVariant rv = r.value(u"field"_s);
             if (rv.typeId() == QMetaType::Double) {
                 sizeString = QString::number(rv.toDouble(), 'f', 2);
             } else {
@@ -770,7 +770,7 @@ public:
     C_ATTR(filled, :Local :AutoArgs)
     void filled(Context *c)
     {
-        Validator v({new ValidatorFilled(u"field"_qs, m_validatorMessages)});
+        Validator v({new ValidatorFilled(u"field"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -778,8 +778,8 @@ public:
     C_ATTR(in, :Local :AutoArgs)
     void in(Context *c)
     {
-        Validator v({new ValidatorIn(u"field"_qs,
-                                     QStringList({u"eins"_qs, u"zwei"_qs, u"drei"_qs}),
+        Validator v({new ValidatorIn(u"field"_s,
+                                     QStringList({u"eins"_s, u"zwei"_s, u"drei"_s}),
                                      Qt::CaseSensitive,
                                      m_validatorMessages)});
         checkResponse(c, v.validate(c));
@@ -789,7 +789,7 @@ public:
     C_ATTR(integer, :Local :AutoArgs)
     void integer(Context *c)
     {
-        Validator v({new ValidatorInteger(u"field"_qs, QMetaType::Int, m_validatorMessages)});
+        Validator v({new ValidatorInteger(u"field"_s, QMetaType::Int, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -798,29 +798,29 @@ public:
     void ip(Context *c)
     {
         ValidatorIp::Constraints constraints = ValidatorIp::NoConstraint;
-        if (!c->request()->bodyParameter(u"constraints"_qs).isEmpty()) {
-            QStringList cons = c->request()->bodyParameter(u"constraints"_qs).split(u","_qs);
-            if (cons.contains(u"IPv4Only"_qs)) {
+        if (!c->request()->bodyParameter(u"constraints"_s).isEmpty()) {
+            QStringList cons = c->request()->bodyParameter(u"constraints"_s).split(u","_s);
+            if (cons.contains(u"IPv4Only"_s)) {
                 constraints |= ValidatorIp::IPv4Only;
             }
 
-            if (cons.contains(u"IPv6Only"_qs)) {
+            if (cons.contains(u"IPv6Only"_s)) {
                 constraints |= ValidatorIp::IPv6Only;
             }
 
-            if (cons.contains(u"NoPrivateRange"_qs)) {
+            if (cons.contains(u"NoPrivateRange"_s)) {
                 constraints |= ValidatorIp::NoPrivateRange;
             }
 
-            if (cons.contains(u"NoReservedRange"_qs)) {
+            if (cons.contains(u"NoReservedRange"_s)) {
                 constraints |= ValidatorIp::NoReservedRange;
             }
 
-            if (cons.contains(u"NoMultiCast"_qs)) {
+            if (cons.contains(u"NoMultiCast"_s)) {
                 constraints |= ValidatorIp::NoMultiCast;
             }
         }
-        Validator v({new ValidatorIp(u"field"_qs, constraints, m_validatorMessages)});
+        Validator v({new ValidatorIp(u"field"_s, constraints, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -828,8 +828,8 @@ public:
     C_ATTR(json, :Local :AutoArgs)
     void json(Context *c)
     {
-        Validator v({new ValidatorJson(
-            u"field"_qs, ValidatorJson::ExpectedType::All, m_validatorMessages)});
+        Validator v(
+            {new ValidatorJson(u"field"_s, ValidatorJson::ExpectedType::All, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -838,7 +838,7 @@ public:
     void jsonObject(Context *c)
     {
         Validator v({new ValidatorJson(
-            u"field"_qs, ValidatorJson::ExpectedType::Object, m_validatorMessages)});
+            u"field"_s, ValidatorJson::ExpectedType::Object, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -847,7 +847,7 @@ public:
     void jsonArray(Context *c)
     {
         Validator v({new ValidatorJson(
-            u"field"_qs, ValidatorJson::ExpectedType::Array, m_validatorMessages)});
+            u"field"_s, ValidatorJson::ExpectedType::Array, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -857,8 +857,8 @@ public:
     {
         QMetaType::Type type = QMetaType::UnknownType;
 
-        if (!c->request()->bodyParameter(u"type"_qs).isEmpty()) {
-            const QString t = c->request()->bodyParameter(u"type"_qs);
+        if (!c->request()->bodyParameter(u"type"_s).isEmpty()) {
+            const QString t = c->request()->bodyParameter(u"type"_s);
             if (t == QLatin1String("sint")) {
                 type = QMetaType::Int;
             } else if (t == QLatin1String("uint")) {
@@ -869,7 +869,7 @@ public:
                 type = QMetaType::QString;
             }
         }
-        Validator v({new ValidatorMax(u"field"_qs, type, 10, m_validatorMessages)});
+        Validator v({new ValidatorMax(u"field"_s, type, 10, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -877,11 +877,11 @@ public:
     C_ATTR(min, :Local :AutoArgs)
     void min(Context *c)
     {
-        c->setStash(u"compval"_qs, 10);
+        c->setStash(u"compval"_s, 10);
         QMetaType::Type type = QMetaType::UnknownType;
 
-        if (!c->request()->bodyParameter(u"type"_qs).isEmpty()) {
-            const QString t = c->request()->bodyParameter(u"type"_qs);
+        if (!c->request()->bodyParameter(u"type"_s).isEmpty()) {
+            const QString t = c->request()->bodyParameter(u"type"_s);
             if (t == QLatin1String("sint")) {
                 type = QMetaType::Int;
             } else if (t == QLatin1String("uint")) {
@@ -892,7 +892,7 @@ public:
                 type = QMetaType::QString;
             }
         }
-        Validator v({new ValidatorMin(u"field"_qs, type, u"compval"_qs, m_validatorMessages)});
+        Validator v({new ValidatorMin(u"field"_s, type, u"compval"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -900,11 +900,10 @@ public:
     C_ATTR(notIn, :Local :AutoArgs)
     void notIn(Context *c)
     {
-        Validator v(
-            {new ValidatorNotIn(u"field"_qs,
-                                QStringList({u"eins"_qs, u"zwei"_qs, u"drei"_qs, u"vier"_qs}),
-                                Qt::CaseSensitive,
-                                m_validatorMessages)});
+        Validator v({new ValidatorNotIn(u"field"_s,
+                                        QStringList({u"eins"_s, u"zwei"_s, u"drei"_s, u"vier"_s}),
+                                        Qt::CaseSensitive,
+                                        m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -912,7 +911,7 @@ public:
     C_ATTR(numeric, :Local :AutoArgs)
     void numeric(Context *c)
     {
-        Validator v({new ValidatorNumeric(u"field"_qs, m_validatorMessages)});
+        Validator v({new ValidatorNumeric(u"field"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -920,7 +919,7 @@ public:
     C_ATTR(present, :Local :AutoArgs)
     void present(Context *c)
     {
-        Validator v({new ValidatorPresent(u"field"_qs, m_validatorMessages)});
+        Validator v({new ValidatorPresent(u"field"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -929,21 +928,21 @@ public:
     C_ATTR(pwQuality, :Local :AutoArgs)
     void pwQuality(Context *c)
     {
-        static const QVariantMap options({{u"difok"_qs, 1},
-                                          {u"minlen"_qs, 8},
-                                          {u"dcredit"_qs, 0},
-                                          {u"ucredit"_qs, 0},
-                                          {u"ocredit"_qs, 0},
-                                          {u"lcredit"_qs, 0},
-                                          {u"minclass"_qs, 0},
-                                          {u"maxrepeat"_qs, 0},
-                                          {u"maxclassrepeat"_qs, 0},
-                                          {u"maxsequence"_qs, 0},
-                                          {u"gecoscheck"_qs, 0},
-                                          {u"dictcheck"_qs, 1},
-                                          {u"usercheck"_qs, 0}});
+        static const QVariantMap options({{u"difok"_s, 1},
+                                          {u"minlen"_s, 8},
+                                          {u"dcredit"_s, 0},
+                                          {u"ucredit"_s, 0},
+                                          {u"ocredit"_s, 0},
+                                          {u"lcredit"_s, 0},
+                                          {u"minclass"_s, 0},
+                                          {u"maxrepeat"_s, 0},
+                                          {u"maxclassrepeat"_s, 0},
+                                          {u"maxsequence"_s, 0},
+                                          {u"gecoscheck"_s, 0},
+                                          {u"dictcheck"_s, 1},
+                                          {u"usercheck"_s, 0}});
         static Validator v({new ValidatorPwQuality(
-            u"field"_qs, 50, options, QString(), QString(), m_validatorMessages)});
+            u"field"_s, 50, options, QString(), QString(), m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 #endif
@@ -953,8 +952,8 @@ public:
     void regex(Context *c)
     {
         Validator v({new ValidatorRegularExpression(
-            u"field"_qs,
-            QRegularExpression(u"^(\\d\\d)/(\\d\\d)/(\\d\\d\\d\\d)$"_qs),
+            u"field"_s,
+            QRegularExpression(u"^(\\d\\d)/(\\d\\d)/(\\d\\d\\d\\d)$"_s),
             m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
@@ -963,7 +962,7 @@ public:
     C_ATTR(required, :Local :AutoArgs)
     void required(Context *c)
     {
-        Validator v({new ValidatorRequired(u"field"_qs, m_validatorMessages)});
+        Validator v({new ValidatorRequired(u"field"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -971,10 +970,8 @@ public:
     C_ATTR(requiredIf, :Local :AutoArgs)
     void requiredIf(Context *c)
     {
-        Validator v({new ValidatorRequiredIf(u"field"_qs,
-                                             u"field2"_qs,
-                                             QStringList({u"eins"_qs, u"zwei"_qs}),
-                                             m_validatorMessages)});
+        Validator v({new ValidatorRequiredIf(
+            u"field"_s, u"field2"_s, QStringList({u"eins"_s, u"zwei"_s}), m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -982,11 +979,9 @@ public:
     C_ATTR(requiredIfStashMatch, :Local :AutoArgs)
     void requiredIfStashMatch(Context *c)
     {
-        c->setStash(u"stashkey"_qs, u"eins"_qs);
-        Validator v({new ValidatorRequiredIfStash(u"field"_qs,
-                                                  u"stashkey"_qs,
-                                                  QVariantList({u"eins"_qs, u"zwei"_qs}),
-                                                  m_validatorMessages)});
+        c->setStash(u"stashkey"_s, u"eins"_s);
+        Validator v({new ValidatorRequiredIfStash(
+            u"field"_s, u"stashkey"_s, QVariantList({u"eins"_s, u"zwei"_s}), m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -994,10 +989,10 @@ public:
     C_ATTR(requiredIfStashMatchStashKey, :Local :AutoArgs)
     void requiredIfStashMatchStashKey(Context *c)
     {
-        c->setStash(u"stashkey"_qs, u"eins"_qs);
-        c->setStash(u"otherStashKey"_qs, QStringList({u"eins"_qs, u"zwei"_qs}));
+        c->setStash(u"stashkey"_s, u"eins"_s);
+        c->setStash(u"otherStashKey"_s, QStringList({u"eins"_s, u"zwei"_s}));
         Validator v({new ValidatorRequiredIfStash(
-            u"field"_qs, u"stashkey"_qs, u"otherStashKey"_qs, m_validatorMessages)});
+            u"field"_s, u"stashkey"_s, u"otherStashKey"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1005,11 +1000,9 @@ public:
     C_ATTR(requiredIfStashNotMatch, :Local :AutoArgs)
     void requiredIfStashNotMatch(Context *c)
     {
-        c->setStash(u"stashkey"_qs, u"drei"_qs);
-        Validator v({new ValidatorRequiredIfStash(u"field"_qs,
-                                                  u"stashkey"_qs,
-                                                  QVariantList({u"eins"_qs, u"zwei"_qs}),
-                                                  m_validatorMessages)});
+        c->setStash(u"stashkey"_s, u"drei"_s);
+        Validator v({new ValidatorRequiredIfStash(
+            u"field"_s, u"stashkey"_s, QVariantList({u"eins"_s, u"zwei"_s}), m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1017,10 +1010,10 @@ public:
     C_ATTR(requiredIfStashNotMatchStashKey, :Local :AutoArgs)
     void requiredIfStashNotMatchStashKey(Context *c)
     {
-        c->setStash(u"stashkey"_qs, u"drei"_qs);
-        c->setStash(u"otherStashKey"_qs, QStringList({u"eins"_qs, u"zwei"_qs}));
+        c->setStash(u"stashkey"_s, u"drei"_s);
+        c->setStash(u"otherStashKey"_s, QStringList({u"eins"_s, u"zwei"_s}));
         Validator v({new ValidatorRequiredIfStash(
-            u"field"_qs, u"stashkey"_qs, u"otherStashKey"_qs, m_validatorMessages)});
+            u"field"_s, u"stashkey"_s, u"otherStashKey"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1028,10 +1021,8 @@ public:
     C_ATTR(requiredUnless, :Local :AutoArgs)
     void requiredUnless(Context *c)
     {
-        Validator v({new ValidatorRequiredUnless(u"field"_qs,
-                                                 u"field2"_qs,
-                                                 QStringList({u"eins"_qs, u"zwei"_qs}),
-                                                 m_validatorMessages)});
+        Validator v({new ValidatorRequiredUnless(
+            u"field"_s, u"field2"_s, QStringList({u"eins"_s, u"zwei"_s}), m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1039,11 +1030,9 @@ public:
     C_ATTR(requiredUnlessStashMatch, :Local :AutoArgs)
     void requiredUnlessStashMatch(Context *c)
     {
-        c->setStash(u"stashkey"_qs, u"eins"_qs);
-        Validator v({new ValidatorRequiredUnlessStash(u"field"_qs,
-                                                      u"stashkey"_qs,
-                                                      QVariantList({u"eins"_qs, u"zwei"_qs}),
-                                                      m_validatorMessages)});
+        c->setStash(u"stashkey"_s, u"eins"_s);
+        Validator v({new ValidatorRequiredUnlessStash(
+            u"field"_s, u"stashkey"_s, QVariantList({u"eins"_s, u"zwei"_s}), m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1051,10 +1040,10 @@ public:
     C_ATTR(requiredUnlessStashMatchStashKey, :Local :AutoArgs)
     void requiredUnlessStashMatchStashKey(Context *c)
     {
-        c->setStash(u"stashkey"_qs, u"eins"_qs);
-        c->setStash(u"otherStashKey"_qs, QStringList({u"eins"_qs, u"zwei"_qs}));
+        c->setStash(u"stashkey"_s, u"eins"_s);
+        c->setStash(u"otherStashKey"_s, QStringList({u"eins"_s, u"zwei"_s}));
         Validator v({new ValidatorRequiredUnlessStash(
-            u"field"_qs, u"stashkey"_qs, u"otherStashKey"_qs, m_validatorMessages)});
+            u"field"_s, u"stashkey"_s, u"otherStashKey"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1062,11 +1051,9 @@ public:
     C_ATTR(requiredUnlessStashNotMatch, :Local :AutoArgs)
     void requiredUnlessStashNotMatch(Context *c)
     {
-        c->setStash(u"stashkey"_qs, u"drei"_qs);
-        Validator v({new ValidatorRequiredUnlessStash(u"field"_qs,
-                                                      u"stashkey"_qs,
-                                                      QVariantList({u"eins"_qs, u"zwei"_qs}),
-                                                      m_validatorMessages)});
+        c->setStash(u"stashkey"_s, u"drei"_s);
+        Validator v({new ValidatorRequiredUnlessStash(
+            u"field"_s, u"stashkey"_s, QVariantList({u"eins"_s, u"zwei"_s}), m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1074,10 +1061,10 @@ public:
     C_ATTR(requiredUnlessStashNotMatchStashKey, :Local :AutoArgs)
     void requiredUnlessStashNotMatchStashKey(Context *c)
     {
-        c->setStash(u"stashkey"_qs, u"drei"_qs);
-        c->setStash(u"otherStashKey"_qs, QStringList({u"eins"_qs, u"zwei"_qs}));
+        c->setStash(u"stashkey"_s, u"drei"_s);
+        c->setStash(u"otherStashKey"_s, QStringList({u"eins"_s, u"zwei"_s}));
         Validator v({new ValidatorRequiredUnlessStash(
-            u"field"_qs, u"stashkey"_qs, u"otherStashKey"_qs, m_validatorMessages)});
+            u"field"_s, u"stashkey"_s, u"otherStashKey"_s, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1086,7 +1073,7 @@ public:
     void requiredWith(Context *c)
     {
         Validator v({new ValidatorRequiredWith(
-            u"field"_qs, QStringList({u"field2"_qs, u"field3"_qs}), m_validatorMessages)});
+            u"field"_s, QStringList({u"field2"_s, u"field3"_s}), m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1095,8 +1082,8 @@ public:
     void requiredWithAll(Context *c)
     {
         Validator v(
-            {new ValidatorRequiredWithAll(u"field"_qs,
-                                          QStringList({u"field2"_qs, u"field3"_qs, u"field4"_qs}),
+            {new ValidatorRequiredWithAll(u"field"_s,
+                                          QStringList({u"field2"_s, u"field3"_s, u"field4"_s}),
                                           m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
@@ -1106,7 +1093,7 @@ public:
     void requiredWithout(Context *c)
     {
         Validator v({new ValidatorRequiredWithout(
-            u"field"_qs, QStringList({u"field2"_qs, u"field3"_qs}), m_validatorMessages)});
+            u"field"_s, QStringList({u"field2"_s, u"field3"_s}), m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1115,7 +1102,7 @@ public:
     void requiredWithoutAll(Context *c)
     {
         Validator v({new ValidatorRequiredWithoutAll(
-            u"field"_qs, QStringList({u"field2"_qs, u"field3"_qs}), m_validatorMessages)});
+            u"field"_s, QStringList({u"field2"_s, u"field3"_s}), m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1123,7 +1110,7 @@ public:
     C_ATTR(same, :Local :AutoArgs)
     void same(Context *c)
     {
-        Validator v({new ValidatorSame(u"field"_qs, u"other"_qs, nullptr, m_validatorMessages)});
+        Validator v({new ValidatorSame(u"field"_s, u"other"_s, nullptr, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1133,8 +1120,8 @@ public:
     {
         QMetaType::Type type = QMetaType::UnknownType;
 
-        if (!c->request()->bodyParameter(u"type"_qs).isEmpty()) {
-            const QString t = c->request()->bodyParameter(u"type"_qs);
+        if (!c->request()->bodyParameter(u"type"_s).isEmpty()) {
+            const QString t = c->request()->bodyParameter(u"type"_s);
             if (t == QLatin1String("sint")) {
                 type = QMetaType::Int;
             } else if (t == QLatin1String("uint")) {
@@ -1145,7 +1132,7 @@ public:
                 type = QMetaType::QString;
             }
         }
-        Validator v({new ValidatorSize(u"field"_qs, type, 10, m_validatorMessages)});
+        Validator v({new ValidatorSize(u"field"_s, type, 10, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1153,7 +1140,7 @@ public:
     C_ATTR(time, :Local :AutoArgs)
     void time(Context *c)
     {
-        Validator v({new ValidatorTime(u"field"_qs, nullptr, m_validatorMessages)});
+        Validator v({new ValidatorTime(u"field"_s, nullptr, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1161,7 +1148,7 @@ public:
     C_ATTR(timeFormat, :Local :AutoArgs)
     void timeFormat(Context *c)
     {
-        Validator v({new ValidatorTime(u"field"_qs, "m:hh", m_validatorMessages)});
+        Validator v({new ValidatorTime(u"field"_s, "m:hh", m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1171,31 +1158,31 @@ public:
     {
         ValidatorUrl::Constraints constraints = ValidatorUrl::NoConstraint;
         QStringList schemes;
-        QString scheme = c->request()->bodyParameter(u"schemes"_qs);
+        QString scheme = c->request()->bodyParameter(u"schemes"_s);
         if (!scheme.isEmpty()) {
-            schemes = scheme.split(u","_qs);
+            schemes = scheme.split(u","_s);
         }
 
-        if (!c->request()->bodyParameter(u"constraints"_qs).isEmpty()) {
-            const QStringList cons = c->request()->bodyParameter(u"constraints"_qs).split(u","_qs);
-            if (cons.contains(u"StrictParsing"_qs)) {
+        if (!c->request()->bodyParameter(u"constraints"_s).isEmpty()) {
+            const QStringList cons = c->request()->bodyParameter(u"constraints"_s).split(u","_s);
+            if (cons.contains(u"StrictParsing"_s)) {
                 constraints |= ValidatorUrl::StrictParsing;
             }
 
-            if (cons.contains(u"NoRelative"_qs)) {
+            if (cons.contains(u"NoRelative"_s)) {
                 constraints |= ValidatorUrl::NoRelative;
             }
 
-            if (cons.contains(u"NoLocalFile"_qs)) {
+            if (cons.contains(u"NoLocalFile"_s)) {
                 constraints |= ValidatorUrl::NoLocalFile;
             }
 
-            if (cons.contains(u"WebsiteOnly"_qs)) {
+            if (cons.contains(u"WebsiteOnly"_s)) {
                 constraints |= ValidatorUrl::WebsiteOnly;
             }
         }
 
-        Validator v({new ValidatorUrl(u"field"_qs, constraints, schemes, m_validatorMessages)});
+        Validator v({new ValidatorUrl(u"field"_s, constraints, schemes, m_validatorMessages)});
         checkResponse(c, v.validate(c));
     }
 
@@ -1206,7 +1193,7 @@ private:
     void checkResponse(Context *c, const ValidatorResult &r)
     {
         if (r) {
-            c->response()->setBody("valid"_qba);
+            c->response()->setBody("valid"_ba);
         } else {
             c->response()->setBody(r.errorStrings().constFirst());
         }
@@ -1243,7 +1230,7 @@ void TestValidator::doTest()
     QFETCH(QByteArray, output);
 
     const QUrl urlAux(u"/validator/test" + url);
-    static const Headers headers{{"Content-Type"_qba, "application/x-www-form-urlencoded"_qba}};
+    static const Headers headers{{"Content-Type"_ba, "application/x-www-form-urlencoded"_ba}};
 
     const auto result = m_engine->createRequest(
         "POST", urlAux.path(), urlAux.query(QUrl::FullyEncoded).toLatin1(), headers, &body);
@@ -1260,16 +1247,16 @@ void TestValidator::testValidator_data()
     // **** Start testing if the correct parameters are extracted according to the validator flags
 
     QTest::newRow("body-params-only-valid")
-        << u"/bodyParamsOnly"_qs << QByteArrayLiteral("req_field=hallo") << valid;
+        << u"/bodyParamsOnly"_s << QByteArrayLiteral("req_field=hallo") << valid;
 
     QTest::newRow("body-params-only-invalid")
-        << u"/bodyParamsOnly?req_field=hallo"_qs << QByteArray() << invalid;
+        << u"/bodyParamsOnly?req_field=hallo"_s << QByteArray() << invalid;
 
     QTest::newRow("query-params-only-valid")
-        << u"/queryParamsOnly?req_field=hallo"_qs << QByteArray() << valid;
+        << u"/queryParamsOnly?req_field=hallo"_s << QByteArray() << valid;
 
     QTest::newRow("query-params-only-invalid")
-        << u"/queryParamsOnly"_qs << QByteArrayLiteral("req_field=hallo") << invalid;
+        << u"/queryParamsOnly"_s << QByteArrayLiteral("req_field=hallo") << invalid;
 }
 
 void TestValidator::testValidatorAccepted_data()
@@ -1281,17 +1268,17 @@ void TestValidator::testValidatorAccepted_data()
     // **** Start testing ValidatorAccepted *****
 
     int count = 0;
-    for (const QString &val : {u"yes"_qs, u"on"_qs, u"1"_qs, u"true"_qs}) {
-        QTest::newRow(u"valid0%1"_qs.arg(count).toUtf8().constData())
-            << u"/accepted?accepted_field="_qs + val << QByteArray() << valid;
+    for (const QString &val : {u"yes"_s, u"on"_s, u"1"_s, u"true"_s}) {
+        QTest::newRow(u"valid0%1"_s.arg(count).toUtf8().constData())
+            << u"/accepted?accepted_field="_s + val << QByteArray() << valid;
         count++;
     }
 
-    QTest::newRow("invalid") << u"/accepted?accepted_field=asdf"_qs << QByteArray() << invalid;
+    QTest::newRow("invalid") << u"/accepted?accepted_field=asdf"_s << QByteArray() << invalid;
 
-    QTest::newRow("empty") << u"/accepted?accepted_field="_qs << QByteArray() << invalid;
+    QTest::newRow("empty") << u"/accepted?accepted_field="_s << QByteArray() << invalid;
 
-    QTest::newRow("missing") << u"/accepted"_qs << QByteArray() << invalid;
+    QTest::newRow("missing") << u"/accepted"_s << QByteArray() << invalid;
 }
 
 void TestValidator::testValidatorAfter_data()
@@ -1305,89 +1292,89 @@ void TestValidator::testValidatorAfter_data()
     int count = 0;
     for (Qt::DateFormat df : dateFormats) {
         QUrlQuery query;
-        query.addQueryItem(u"after_field"_qs, QDate::currentDate().addDays(2).toString(df));
-        QTest::newRow(u"date-valid0%1"_qs.arg(count).toUtf8().constData())
-            << u"/afterDate?"_qs + query.toString(QUrl::FullyEncoded) << QByteArray() << valid;
+        query.addQueryItem(u"after_field"_s, QDate::currentDate().addDays(2).toString(df));
+        QTest::newRow(u"date-valid0%1"_s.arg(count).toUtf8().constData())
+            << u"/afterDate?"_s + query.toString(QUrl::FullyEncoded) << QByteArray() << valid;
 
         query.clear();
-        query.addQueryItem(u"after_field"_qs, QDate(1999, 9, 9).toString(df));
-        QTest::newRow(u"date-invalid0%1"_qs.arg(count).toUtf8().constData())
-            << u"/afterDate?"_qs + query.toString(QUrl::FullyEncoded) << QByteArray() << invalid;
+        query.addQueryItem(u"after_field"_s, QDate(1999, 9, 9).toString(df));
+        QTest::newRow(u"date-invalid0%1"_s.arg(count).toUtf8().constData())
+            << u"/afterDate?"_s + query.toString(QUrl::FullyEncoded) << QByteArray() << invalid;
 
         count++;
     }
 
     QTest::newRow("date-parsingerror")
-        << u"/afterDate?after_field=lökjasdfjh"_qs << QByteArray() << parsingError;
+        << u"/afterDate?after_field=lökjasdfjh"_s << QByteArray() << parsingError;
 
     count = 0;
     for (Qt::DateFormat df : dateFormats) {
         QUrlQuery query;
-        query.addQueryItem(u"after_field"_qs, QTime(13, 0).toString(df));
-        QTest::newRow(u"time-valid0%1"_qs.arg(count).toUtf8().constData())
-            << u"/afterTime?"_qs + query.toString(QUrl::FullyEncoded) << QByteArray() << valid;
+        query.addQueryItem(u"after_field"_s, QTime(13, 0).toString(df));
+        QTest::newRow(u"time-valid0%1"_s.arg(count).toUtf8().constData())
+            << u"/afterTime?"_s + query.toString(QUrl::FullyEncoded) << QByteArray() << valid;
 
         query.clear();
-        query.addQueryItem(u"after_field"_qs, QTime(11, 0).toString(df));
-        QTest::newRow(u"time-invalid0%1"_qs.arg(count).toUtf8().constData())
-            << u"/afterTime?"_qs + query.toString(QUrl::FullyEncoded) << QByteArray() << invalid;
+        query.addQueryItem(u"after_field"_s, QTime(11, 0).toString(df));
+        QTest::newRow(u"time-invalid0%1"_s.arg(count).toUtf8().constData())
+            << u"/afterTime?"_s + query.toString(QUrl::FullyEncoded) << QByteArray() << invalid;
 
         count++;
     }
 
     QTest::newRow("time-parsingerror")
-        << u"/afterTime?after_field=kjnagiuh"_qs << QByteArray() << parsingError;
+        << u"/afterTime?after_field=kjnagiuh"_s << QByteArray() << parsingError;
 
     count = 0;
     for (Qt::DateFormat df : dateFormats) {
-        QString queryPath = u"/afterDateTime?after_field="_qs +
+        QString queryPath = u"/afterDateTime?after_field="_s +
                             QString::fromLatin1(QUrl::toPercentEncoding(
                                 QDateTime::currentDateTime().addDays(2).toString(df),
                                 QByteArray(),
                                 QByteArrayLiteral("+")));
-        QTest::newRow(u"after-datetime-valid0%1"_qs.arg(count).toUtf8().constData())
+        QTest::newRow(u"after-datetime-valid0%1"_s.arg(count).toUtf8().constData())
             << queryPath << QByteArray() << valid;
 
-        queryPath = u"/afterDateTime?after_field="_qs +
+        queryPath = u"/afterDateTime?after_field="_s +
                     QString::fromLatin1(QUrl::toPercentEncoding(
                         QDateTime(QDate(1999, 9, 9), QTime(19, 19)).toString(df),
                         QByteArray(),
                         QByteArrayLiteral("+")));
-        QTest::newRow(u"after-datetime-invalid0%1"_qs.arg(count).toUtf8().constData())
+        QTest::newRow(u"after-datetime-invalid0%1"_s.arg(count).toUtf8().constData())
             << queryPath << QByteArray() << invalid;
 
         count++;
     }
 
     QTest::newRow("datetime-parsingerror")
-        << u"/afterDateTime?after_field=aio,aü"_qs << QByteArray() << parsingError;
+        << u"/afterDateTime?after_field=aio,aü"_s << QByteArray() << parsingError;
 
     QTest::newRow("invalidvalidationdata00")
-        << u"/afterInvalidValidationData?after_field="_qs +
+        << u"/afterInvalidValidationData?after_field="_s +
                QDate::currentDate().addDays(2).toString(Qt::ISODate)
         << QByteArray() << validationDataError;
 
     QTest::newRow("invalidvalidationdata01")
-        << u"/afterInvalidValidationData2?after_field="_qs +
+        << u"/afterInvalidValidationData2?after_field="_s +
                QDate::currentDate().addDays(2).toString(Qt::ISODate)
         << QByteArray() << validationDataError;
 
-    QTest::newRow("format-valid") << u"/afterFormat?after_field="_qs +
+    QTest::newRow("format-valid") << u"/afterFormat?after_field="_s +
                                          QDateTime::currentDateTime().addDays(2).toString(
-                                             u"yyyy d MM HH:mm"_qs)
+                                             u"yyyy d MM HH:mm"_s)
                                   << QByteArray() << valid;
 
     QTest::newRow("format-invalid")
-        << u"/afterFormat?after_field="_qs +
-               QDateTime(QDate(1999, 9, 9), QTime(19, 19)).toString(u"yyyy d MM HH:mm"_qs)
+        << u"/afterFormat?after_field="_s +
+               QDateTime(QDate(1999, 9, 9), QTime(19, 19)).toString(u"yyyy d MM HH:mm"_s)
         << QByteArray() << invalid;
 
     QTest::newRow("format-parsingerror")
-        << u"/afterFormat?after_field=23590uj09"_qs << QByteArray() << parsingError;
+        << u"/afterFormat?after_field=23590uj09"_s << QByteArray() << parsingError;
 
     {
         const QString queryPath =
-            u"/afterValidWithTimeZone?after_field="_qs +
+            u"/afterValidWithTimeZone?after_field="_s +
             QString::fromLatin1(QUrl::toPercentEncoding(
                 QDateTime(QDate(2018, 1, 15), QTime(13, 0)).toString(Qt::ISODate),
                 QByteArray(),
@@ -1397,7 +1384,7 @@ void TestValidator::testValidatorAfter_data()
 
     {
         const QString queryPath =
-            u"/afterValidWithTimeZoneField?after_field="_qs +
+            u"/afterValidWithTimeZoneField?after_field="_s +
             QString::fromLatin1(QUrl::toPercentEncoding(
                 QDateTime(QDate(2018, 1, 15), QTime(13, 0)).toString(Qt::ISODate),
                 QByteArray(),
@@ -1415,18 +1402,18 @@ void TestValidator::testValidatorAlpha_data()
 
     // **** Start testing ValidatorAlpha *****
 
-    QTest::newRow("valid") << u"/alpha?alpha_field=adsfä"_qs << QByteArray() << valid;
+    QTest::newRow("valid") << u"/alpha?alpha_field=adsfä"_s << QByteArray() << valid;
 
-    QTest::newRow("invalid") << u"/alpha?alpha_field=ad_sf 2ä!"_qs << QByteArray() << invalid;
+    QTest::newRow("invalid") << u"/alpha?alpha_field=ad_sf 2ä!"_s << QByteArray() << invalid;
 
-    QTest::newRow("empty") << u"/alpha?alpha_field="_qs << QByteArray() << valid;
+    QTest::newRow("empty") << u"/alpha?alpha_field="_s << QByteArray() << valid;
 
-    QTest::newRow("missing") << u"/alpha"_qs << QByteArray() << valid;
+    QTest::newRow("missing") << u"/alpha"_s << QByteArray() << valid;
 
-    QTest::newRow("ascii-valid") << u"/alphaAscii?alpha_field=basdf"_qs << QByteArray() << valid;
+    QTest::newRow("ascii-valid") << u"/alphaAscii?alpha_field=basdf"_s << QByteArray() << valid;
 
     QTest::newRow("ascii-invalid")
-        << u"/alphaAscii?alpha_field=asdfös"_qs << QByteArray() << invalid;
+        << u"/alphaAscii?alpha_field=asdfös"_s << QByteArray() << invalid;
 }
 
 void TestValidator::testValidatorAlphaDash_data()
@@ -1437,20 +1424,20 @@ void TestValidator::testValidatorAlphaDash_data()
 
     // **** Start testing ValidatorAlphaDash *****
 
-    QTest::newRow("valid") << u"/alphaDash?alphadash_field=ads2-fä_3"_qs << QByteArray() << valid;
+    QTest::newRow("valid") << u"/alphaDash?alphadash_field=ads2-fä_3"_s << QByteArray() << valid;
 
-    QTest::newRow("invalid") << u"/alphaDash?alphadash_field=ad sf_2ä!"_qs << QByteArray()
+    QTest::newRow("invalid") << u"/alphaDash?alphadash_field=ad sf_2ä!"_s << QByteArray()
                              << invalid;
 
-    QTest::newRow("empty") << u"/alphaDash?alphadash_field="_qs << QByteArray() << valid;
+    QTest::newRow("empty") << u"/alphaDash?alphadash_field="_s << QByteArray() << valid;
 
-    QTest::newRow("missing") << u"/alphaDash"_qs << QByteArray() << valid;
+    QTest::newRow("missing") << u"/alphaDash"_s << QByteArray() << valid;
 
-    QTest::newRow("ascii-valid") << u"/alphaDashAscii?alphadash_field=s342-4d_3"_qs << QByteArray()
+    QTest::newRow("ascii-valid") << u"/alphaDashAscii?alphadash_field=s342-4d_3"_s << QByteArray()
                                  << valid;
 
     QTest::newRow("ascii-invalid")
-        << u"/alphaDashAscii?alphadash_field=s342 4ä_3"_qs << QByteArray() << invalid;
+        << u"/alphaDashAscii?alphadash_field=s342 4ä_3"_s << QByteArray() << invalid;
 }
 
 void TestValidator::testValidatorAlphaNum_data()
@@ -1461,19 +1448,19 @@ void TestValidator::testValidatorAlphaNum_data()
 
     // **** Start testing ValidatorAlphaNum *****
 
-    QTest::newRow("valid") << u"/alphaNum?alphanum_field=ads2fä3"_qs << QByteArray() << valid;
+    QTest::newRow("valid") << u"/alphaNum?alphanum_field=ads2fä3"_s << QByteArray() << valid;
 
-    QTest::newRow("invalid") << u"/alphaNum?alphanum_field=ad sf_2ä!"_qs << QByteArray() << invalid;
+    QTest::newRow("invalid") << u"/alphaNum?alphanum_field=ad sf_2ä!"_s << QByteArray() << invalid;
 
-    QTest::newRow("empty") << u"/alphaNum?alphanum_field="_qs << QByteArray() << valid;
+    QTest::newRow("empty") << u"/alphaNum?alphanum_field="_s << QByteArray() << valid;
 
-    QTest::newRow("missing") << u"/alphaNum"_qs << QByteArray() << valid;
+    QTest::newRow("missing") << u"/alphaNum"_s << QByteArray() << valid;
 
-    QTest::newRow("ascii-valid") << u"/alphaNumAscii?alphanum_field=ba34sdf"_qs << QByteArray()
+    QTest::newRow("ascii-valid") << u"/alphaNumAscii?alphanum_field=ba34sdf"_s << QByteArray()
                                  << valid;
 
     QTest::newRow("ascii-invalid")
-        << u"/alphaNumAscii?alphanum_field=as3dfös"_qs << QByteArray() << invalid;
+        << u"/alphaNumAscii?alphanum_field=as3dfös"_s << QByteArray() << invalid;
 }
 
 void TestValidator::testValidatorBefore_data()
@@ -1488,89 +1475,88 @@ void TestValidator::testValidatorBefore_data()
     QUrlQuery query;
     for (Qt::DateFormat df : dateFormats) {
         query.clear();
-        query.addQueryItem(u"before_field"_qs, QDate(1999, 9, 9).toString(df));
-        QTest::newRow(u"before-date-valid0%1"_qs.arg(count).toUtf8().constData())
-            << u"/beforeDate?"_qs + query.toString(QUrl::FullyEncoded) << QByteArray() << valid;
+        query.addQueryItem(u"before_field"_s, QDate(1999, 9, 9).toString(df));
+        QTest::newRow(u"before-date-valid0%1"_s.arg(count).toUtf8().constData())
+            << u"/beforeDate?"_s + query.toString(QUrl::FullyEncoded) << QByteArray() << valid;
 
         query.clear();
-        query.addQueryItem(u"before_field"_qs, QDate::currentDate().addDays(2).toString(df));
-        QTest::newRow(u"before-date-invalid0%1"_qs.arg(count).toUtf8().constData())
-            << u"/beforeDate?"_qs + query.toString(QUrl::FullyEncoded) << QByteArray() << invalid;
+        query.addQueryItem(u"before_field"_s, QDate::currentDate().addDays(2).toString(df));
+        QTest::newRow(u"before-date-invalid0%1"_s.arg(count).toUtf8().constData())
+            << u"/beforeDate?"_s + query.toString(QUrl::FullyEncoded) << QByteArray() << invalid;
 
         count++;
     }
 
     QTest::newRow("before-date-parsingerror")
-        << u"/beforeDate?before_field=lökjasdfjh"_qs << QByteArray() << parsingError;
+        << u"/beforeDate?before_field=lökjasdfjh"_s << QByteArray() << parsingError;
 
     count = 0;
     for (Qt::DateFormat df : dateFormats) {
         query.clear();
-        query.addQueryItem(u"before_field"_qs, QTime(11, 0).toString(df));
-        QTest::newRow(u"before-time-valid0%1"_qs.arg(count).toUtf8().constData())
-            << u"/beforeTime?"_qs + query.toString(QUrl::FullyEncoded) << QByteArray() << valid;
+        query.addQueryItem(u"before_field"_s, QTime(11, 0).toString(df));
+        QTest::newRow(u"before-time-valid0%1"_s.arg(count).toUtf8().constData())
+            << u"/beforeTime?"_s + query.toString(QUrl::FullyEncoded) << QByteArray() << valid;
 
         query.clear();
-        query.addQueryItem(u"before_field"_qs, QTime(13, 0).toString(df));
-        QTest::newRow(u"before-time-invalid0%1"_qs.arg(count).toUtf8().constData())
-            << u"/beforeTime?"_qs + query.toString(QUrl::FullyEncoded) << QByteArray() << invalid;
+        query.addQueryItem(u"before_field"_s, QTime(13, 0).toString(df));
+        QTest::newRow(u"before-time-invalid0%1"_s.arg(count).toUtf8().constData())
+            << u"/beforeTime?"_s + query.toString(QUrl::FullyEncoded) << QByteArray() << invalid;
 
         count++;
     }
 
     QTest::newRow("before-time-parsingerror")
-        << u"/beforeTime?before_field=kjnagiuh"_qs << QByteArray() << parsingError;
+        << u"/beforeTime?before_field=kjnagiuh"_s << QByteArray() << parsingError;
 
     count = 0;
     for (Qt::DateFormat df : dateFormats) {
-        QString pathQuery = u"/beforeDateTime?before_field="_qs +
+        QString pathQuery = u"/beforeDateTime?before_field="_s +
                             QString::fromLatin1(QUrl::toPercentEncoding(
                                 QDateTime(QDate(1999, 9, 9), QTime(19, 19)).toString(df),
                                 QByteArray(),
                                 QByteArrayLiteral("+")));
-        QTest::newRow(QString(u"before-datetime-valid0%1"_qs.arg(count)).toUtf8().constData())
+        QTest::newRow(QString(u"before-datetime-valid0%1"_s.arg(count)).toUtf8().constData())
             << pathQuery << QByteArray() << valid;
 
-        pathQuery = u"/beforeDateTime?before_field="_qs +
+        pathQuery = u"/beforeDateTime?before_field="_s +
                     QString::fromLatin1(QUrl::toPercentEncoding(
                         QDateTime::currentDateTime().addDays(2).toString(df),
                         QByteArray(),
                         QByteArrayLiteral("+")));
-        QTest::newRow(u"before-datetime-invalid0%1"_qs.arg(count).toUtf8().constData())
+        QTest::newRow(u"before-datetime-invalid0%1"_s.arg(count).toUtf8().constData())
             << pathQuery << QByteArray() << invalid;
 
         count++;
     }
 
     QTest::newRow("before-datetime-parsingerror")
-        << u"/beforeDateTime?before_field=aio,aü"_qs << QByteArray() << parsingError;
+        << u"/beforeDateTime?before_field=aio,aü"_s << QByteArray() << parsingError;
 
     QTest::newRow("before-invalidvalidationdata00")
-        << u"/beforeInvalidValidationData?before_field="_qs +
-               QDate(1999, 9, 9).toString(Qt::ISODate)
+        << u"/beforeInvalidValidationData?before_field="_s + QDate(1999, 9, 9).toString(Qt::ISODate)
         << QByteArray() << validationDataError;
 
     QTest::newRow("before-invalidvalidationdata01")
-        << u"/beforeInvalidValidationData2?before_field="_qs +
+        << u"/beforeInvalidValidationData2?before_field="_s +
                QDate(1999, 9, 9).toString(Qt::ISODate)
         << QByteArray() << validationDataError;
 
     QTest::newRow("before-format-valid")
-        << u"/beforeFormat?before_field="_qs +
-               QDateTime(QDate(1999, 9, 9), QTime(19, 19)).toString(u"yyyy d MM HH:mm"_qs)
+        << u"/beforeFormat?before_field="_s +
+               QDateTime(QDate(1999, 9, 9), QTime(19, 19)).toString(u"yyyy d MM HH:mm"_s)
         << QByteArray() << valid;
 
     QTest::newRow("before-format-invalid")
-        << u"/beforeFormat?before_field="_qs +
-               QDateTime::currentDateTime().addDays(2).toString(u"yyyy d MM HH:mm"_qs)
+        << u"/beforeFormat?before_field="_s +
+               QDateTime::currentDateTime().addDays(2).toString(u"yyyy d MM HH:mm"_s)
         << QByteArray() << invalid;
 
     QTest::newRow("before-format-parsingerror")
-        << u"/beforeFormat?before_field=23590uj09"_qs << QByteArray() << parsingError;
+        << u"/beforeFormat?before_field=23590uj09"_s << QByteArray() << parsingError;
 
     {
         const QString pathQuery =
-            u"/beforeValidWithTimeZone?after_field="_qs +
+            u"/beforeValidWithTimeZone?after_field="_s +
             QString::fromLatin1(QUrl::toPercentEncoding(
                 QDateTime(QDate(2018, 1, 15), QTime(11, 0)).toString(Qt::ISODate),
                 QByteArray(),
@@ -1580,7 +1566,7 @@ void TestValidator::testValidatorBefore_data()
 
     {
         const QString pathQuery =
-            u"/beforeValidWithTimeZoneField?after_field="_qs +
+            u"/beforeValidWithTimeZoneField?after_field="_s +
             QString::fromLatin1(QUrl::toPercentEncoding(
                 QDateTime(QDate(2018, 1, 15), QTime(11, 0)).toString(Qt::ISODate),
                 QByteArray(),
@@ -1598,46 +1584,46 @@ void TestValidator::testValidatorBetween_data()
 
     // **** Start testing ValidatorBetween *****
 
-    QTest::newRow("int-valid") << u"/betweenInt?between_field=0"_qs << QByteArray() << valid;
+    QTest::newRow("int-valid") << u"/betweenInt?between_field=0"_s << QByteArray() << valid;
 
     QTest::newRow("int-invalid-lower")
-        << u"/betweenInt?between_field=-15"_qs << QByteArray() << invalid;
+        << u"/betweenInt?between_field=-15"_s << QByteArray() << invalid;
 
     QTest::newRow("int-invalid-greater")
-        << u"/betweenInt?between_field=15"_qs << QByteArray() << invalid;
+        << u"/betweenInt?between_field=15"_s << QByteArray() << invalid;
 
-    QTest::newRow("int-empty") << u"/betweenInt?between_field="_qs << QByteArray() << valid;
+    QTest::newRow("int-empty") << u"/betweenInt?between_field="_s << QByteArray() << valid;
 
-    QTest::newRow("uint-valid") << u"/betweenUint?between_field=15"_qs << QByteArray() << valid;
+    QTest::newRow("uint-valid") << u"/betweenUint?between_field=15"_s << QByteArray() << valid;
 
     QTest::newRow("uint-invalid-lower")
-        << u"/betweenUint?between_field=5"_qs << QByteArray() << invalid;
+        << u"/betweenUint?between_field=5"_s << QByteArray() << invalid;
 
     QTest::newRow("uint-invalid-greater")
-        << u"/betweenUint?between_field=25"_qs << QByteArray() << invalid;
+        << u"/betweenUint?between_field=25"_s << QByteArray() << invalid;
 
-    QTest::newRow("uint-empty") << u"/betweenUint?between_field="_qs << QByteArray() << valid;
+    QTest::newRow("uint-empty") << u"/betweenUint?between_field="_s << QByteArray() << valid;
 
-    QTest::newRow("float-valid") << u"/betweenFloat?between_field=0.0"_qs << QByteArray() << valid;
+    QTest::newRow("float-valid") << u"/betweenFloat?between_field=0.0"_s << QByteArray() << valid;
 
     QTest::newRow("float-invalid-lower")
-        << u"/betweenFloat?between_field=-15.2"_qs << QByteArray() << invalid;
+        << u"/betweenFloat?between_field=-15.2"_s << QByteArray() << invalid;
 
     QTest::newRow("float-invalid-greater")
-        << u"/betweenFloat?between_field=15.2"_qs << QByteArray() << invalid;
+        << u"/betweenFloat?between_field=15.2"_s << QByteArray() << invalid;
 
-    QTest::newRow("float-empty") << u"/betweenFloat?between_field="_qs << QByteArray() << valid;
+    QTest::newRow("float-empty") << u"/betweenFloat?between_field="_s << QByteArray() << valid;
 
-    QTest::newRow("string-valid") << u"/betweenString?between_field=abcdefg"_qs << QByteArray()
+    QTest::newRow("string-valid") << u"/betweenString?between_field=abcdefg"_s << QByteArray()
                                   << valid;
 
     QTest::newRow("string-invalid-lower")
-        << u"/betweenString?between_field=abc"_qs << QByteArray() << invalid;
+        << u"/betweenString?between_field=abc"_s << QByteArray() << invalid;
 
     QTest::newRow("string-invalid-greater")
-        << u"/betweenString?between_field=abcdefghijklmn"_qs << QByteArray() << invalid;
+        << u"/betweenString?between_field=abcdefghijklmn"_s << QByteArray() << invalid;
 
-    QTest::newRow("string-empty") << u"/betweenString?between_field="_qs << QByteArray() << valid;
+    QTest::newRow("string-empty") << u"/betweenString?between_field="_s << QByteArray() << valid;
 }
 
 void TestValidator::testValidatorBoolean_data()
@@ -1648,17 +1634,17 @@ void TestValidator::testValidatorBoolean_data()
 
     // **** Start testing ValidatorBoolean *****
 
-    for (const QString &bv : {u"1"_qs, u"0"_qs, u"true"_qs, u"false"_qs, u"on"_qs, u"off"_qs}) {
-        QTest::newRow(u"valid-%1"_qs.arg(bv).toUtf8().constData())
-            << u"/boolean?boolean_field="_qs + bv << QByteArray() << valid;
+    for (const QString &bv : {u"1"_s, u"0"_s, u"true"_s, u"false"_s, u"on"_s, u"off"_s}) {
+        QTest::newRow(u"valid-%1"_s.arg(bv).toUtf8().constData())
+            << u"/boolean?boolean_field="_s + bv << QByteArray() << valid;
     }
 
-    for (const QString &bv : {u"2"_qs, u"-45"_qs, u"wahr"_qs, u"unwahr"_qs, u"ja"_qs}) {
-        QTest::newRow(u"invalid-%1"_qs.arg(bv).toUtf8().constData())
-            << u"/boolean?boolean_field="_qs + bv << QByteArray() << invalid;
+    for (const QString &bv : {u"2"_s, u"-45"_s, u"wahr"_s, u"unwahr"_s, u"ja"_s}) {
+        QTest::newRow(u"invalid-%1"_s.arg(bv).toUtf8().constData())
+            << u"/boolean?boolean_field="_s + bv << QByteArray() << invalid;
     }
 
-    QTest::newRow("empty") << u"/boolean?boolean_field="_qs << QByteArray() << valid;
+    QTest::newRow("empty") << u"/boolean?boolean_field="_s << QByteArray() << valid;
 }
 
 void TestValidator::testValidatorCharNotAllowed_data()
@@ -1669,13 +1655,12 @@ void TestValidator::testValidatorCharNotAllowed_data()
 
     // **** Start testing ValidatorCharNotAllowed *****
 
-    QTest::newRow("empty") << u"/charNotAllowed?char_not_allowed_field="_qs << QByteArray()
-                           << valid;
+    QTest::newRow("empty") << u"/charNotAllowed?char_not_allowed_field="_s << QByteArray() << valid;
 
-    QTest::newRow("valid") << u"/charNotAllowed?char_not_allowed_field=holladiewaldfee"_qs
+    QTest::newRow("valid") << u"/charNotAllowed?char_not_allowed_field=holladiewaldfee"_s
                            << QByteArray() << valid;
 
-    QTest::newRow("invalid") << u"/charNotAllowed?char_not_allowed_field=holla.die.waldfee"_qs
+    QTest::newRow("invalid") << u"/charNotAllowed?char_not_allowed_field=holla.die.waldfee"_s
                              << QByteArray() << invalid;
 }
 
@@ -1687,17 +1672,17 @@ void TestValidator::testValidatorConfirmed_data()
 
     // **** Start testing ValidatorConfirmed *****
 
-    QTest::newRow("valid") << u"/confirmed?pass=abcdefg&pass_confirmation=abcdefg"_qs
-                           << QByteArray() << valid;
+    QTest::newRow("valid") << u"/confirmed?pass=abcdefg&pass_confirmation=abcdefg"_s << QByteArray()
+                           << valid;
 
-    QTest::newRow("invalid") << u"/confirmed?pass=abcdefg&pass_confirmation=hijklmn"_qs
+    QTest::newRow("invalid") << u"/confirmed?pass=abcdefg&pass_confirmation=hijklmn"_s
                              << QByteArray() << invalid;
 
-    QTest::newRow("empty") << u"/confirmed?pass&pass_confirmation=abcdefg"_qs << QByteArray()
+    QTest::newRow("empty") << u"/confirmed?pass&pass_confirmation=abcdefg"_s << QByteArray()
                            << valid;
 
     QTest::newRow("missing-confirmation")
-        << u"/confirmed?pass=abcdefg"_qs << QByteArray() << invalid;
+        << u"/confirmed?pass=abcdefg"_s << QByteArray() << invalid;
 }
 
 void TestValidator::testValidatorDate_data()
@@ -1710,21 +1695,21 @@ void TestValidator::testValidatorDate_data()
 
     int count = 0;
     for (Qt::DateFormat df : dateFormats) {
-        QTest::newRow(u"valid0%1"_qs.arg(count).toUtf8().constData())
-            << u"/date?field="_qs + QDate::currentDate().toString(df) << QByteArray() << valid;
+        QTest::newRow(u"valid0%1"_s.arg(count).toUtf8().constData())
+            << u"/date?field="_s + QDate::currentDate().toString(df) << QByteArray() << valid;
         count++;
     }
 
-    QTest::newRow("invalid") << u"/date?field=123456789"_qs << QByteArray() << invalid;
+    QTest::newRow("invalid") << u"/date?field=123456789"_s << QByteArray() << invalid;
 
-    QTest::newRow("empty") << u"/date?field="_qs << QByteArray() << valid;
+    QTest::newRow("empty") << u"/date?field="_s << QByteArray() << valid;
 
-    QTest::newRow("format-valid") << u"/dateFormat?field="_qs +
-                                         QDate::currentDate().toString(u"yyyy d MM"_qs)
+    QTest::newRow("format-valid") << u"/dateFormat?field="_s +
+                                         QDate::currentDate().toString(u"yyyy d MM"_s)
                                   << QByteArray() << valid;
 
     QTest::newRow("format-invalid")
-        << u"/dateFormat?field="_qs + QDate::currentDate().toString(u"MM yyyy d"_qs) << QByteArray()
+        << u"/dateFormat?field="_s + QDate::currentDate().toString(u"MM yyyy d"_s) << QByteArray()
         << invalid;
 }
 
@@ -1739,26 +1724,24 @@ void TestValidator::testValidatorDateTime_data()
     int count = 0;
     for (Qt::DateFormat df : dateFormats) {
         const QString pathQuery =
-            u"/dateTime?field="_qs +
+            u"/dateTime?field="_s +
             QString::fromLatin1(QUrl::toPercentEncoding(
                 QDateTime::currentDateTime().toString(df), QByteArray(), QByteArrayLiteral("+")));
-        QTest::newRow(u"datetime-valid0%1"_qs.arg(count).toUtf8().constData())
+        QTest::newRow(u"datetime-valid0%1"_s.arg(count).toUtf8().constData())
             << pathQuery << QByteArray() << valid;
         count++;
     }
 
-    QTest::newRow("invalid") << u"/dateTime?field=123456789"_qs << QByteArray() << invalid;
+    QTest::newRow("invalid") << u"/dateTime?field=123456789"_s << QByteArray() << invalid;
 
-    QTest::newRow("empty") << u"/dateTime?field="_qs << QByteArray() << valid;
+    QTest::newRow("empty") << u"/dateTime?field="_s << QByteArray() << valid;
 
-    QTest::newRow("format-valid") << u"/dateTimeFormat?field="_qs +
-                                         QDateTime::currentDateTime().toString(
-                                             u"yyyy d MM mm:HH"_qs)
+    QTest::newRow("format-valid") << u"/dateTimeFormat?field="_s +
+                                         QDateTime::currentDateTime().toString(u"yyyy d MM mm:HH"_s)
                                   << QByteArray() << valid;
 
     QTest::newRow("format-invalid")
-        << u"/dateTimeFormat?field="_qs +
-               QDateTime::currentDateTime().toString(u"MM mm yyyy HH d"_qs)
+        << u"/dateTimeFormat?field="_s + QDateTime::currentDateTime().toString(u"MM mm yyyy HH d"_s)
         << QByteArray() << invalid;
 }
 
@@ -1770,15 +1753,14 @@ void TestValidator::testValidatorDifferent_data()
 
     // **** Start testing ValidatorDifferent *****
 
-    QTest::newRow("valid") << u"/different?field=abcdefg&other=hijklmno"_qs << QByteArray()
-                           << valid;
+    QTest::newRow("valid") << u"/different?field=abcdefg&other=hijklmno"_s << QByteArray() << valid;
 
-    QTest::newRow("invalid") << u"/different?field=abcdefg&other=abcdefg"_qs << QByteArray()
+    QTest::newRow("invalid") << u"/different?field=abcdefg&other=abcdefg"_s << QByteArray()
                              << invalid;
 
-    QTest::newRow("empty") << u"/different?field=&other=hijklmno"_qs << QByteArray() << valid;
+    QTest::newRow("empty") << u"/different?field=&other=hijklmno"_s << QByteArray() << valid;
 
-    QTest::newRow("other-missing") << u"/different?field=abcdefg"_qs << QByteArray() << valid;
+    QTest::newRow("other-missing") << u"/different?field=abcdefg"_s << QByteArray() << valid;
 }
 
 void TestValidator::testValidatorDigits_data()
@@ -1789,15 +1771,15 @@ void TestValidator::testValidatorDigits_data()
 
     // **** Start testing ValidatorDigits *****
 
-    QTest::newRow("valid") << u"/digits?field=0123456"_qs << QByteArray() << valid;
+    QTest::newRow("valid") << u"/digits?field=0123456"_s << QByteArray() << valid;
 
-    QTest::newRow("invalid") << u"/digits?field=01234asdf56"_qs << QByteArray() << invalid;
+    QTest::newRow("invalid") << u"/digits?field=01234asdf56"_s << QByteArray() << invalid;
 
-    QTest::newRow("empty") << u"/digits?field="_qs << QByteArray() << valid;
+    QTest::newRow("empty") << u"/digits?field="_s << QByteArray() << valid;
 
-    QTest::newRow("length-valid") << u"/digitsLength?field=0123456789"_qs << QByteArray() << valid;
+    QTest::newRow("length-valid") << u"/digitsLength?field=0123456789"_s << QByteArray() << valid;
 
-    QTest::newRow("length-invalid") << u"/digitsLength?field=012345"_qs << QByteArray() << invalid;
+    QTest::newRow("length-invalid") << u"/digitsLength?field=012345"_s << QByteArray() << invalid;
 }
 
 void TestValidator::testValidatorDigitsBetween_data()
@@ -1808,16 +1790,16 @@ void TestValidator::testValidatorDigitsBetween_data()
 
     // **** Start testing ValidatorDigitsBetween *****
 
-    QTest::newRow("valid") << u"/digitsBetween?field=0123456"_qs << QByteArray() << valid;
+    QTest::newRow("valid") << u"/digitsBetween?field=0123456"_s << QByteArray() << valid;
 
-    QTest::newRow("invalid") << u"/digitsBetween?field=01234ad56"_qs << QByteArray() << invalid;
+    QTest::newRow("invalid") << u"/digitsBetween?field=01234ad56"_s << QByteArray() << invalid;
 
-    QTest::newRow("empty") << u"/digitsBetween?field="_qs << QByteArray() << valid;
+    QTest::newRow("empty") << u"/digitsBetween?field="_s << QByteArray() << valid;
 
-    QTest::newRow("invalid-lower") << u"/digitsBetween?field=0123"_qs << QByteArray() << invalid;
+    QTest::newRow("invalid-lower") << u"/digitsBetween?field=0123"_s << QByteArray() << invalid;
 
     QTest::newRow("invalid-greater")
-        << u"/digitsBetween?field=0123456789123"_qs << QByteArray() << invalid;
+        << u"/digitsBetween?field=0123456789123"_s << QByteArray() << invalid;
 }
 
 void TestValidator::testValidatorDomain_data()
@@ -1829,26 +1811,26 @@ void TestValidator::testValidatorDomain_data()
     // **** Start testing ValidatorDomain *****
 
     QByteArray domainBody =
-        QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"huessenbergnetz.de"_qs);
-    QTest::newRow("valid01") << u"/domain"_qs << domainBody << valid;
+        QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"huessenbergnetz.de"_s);
+    QTest::newRow("valid01") << u"/domain"_s << domainBody << valid;
 
-    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"a.de"_qs);
-    QTest::newRow("valid02") << u"/domain"_qs << domainBody << valid;
+    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"a.de"_s);
+    QTest::newRow("valid02") << u"/domain"_s << domainBody << valid;
 
-    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"a1.de"_qs);
-    QTest::newRow("valid03") << u"/domain"_qs << domainBody << valid;
+    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"a1.de"_s);
+    QTest::newRow("valid03") << u"/domain"_s << domainBody << valid;
 
-    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.com."_qs);
-    QTest::newRow("valid04") << u"/domain"_qs << domainBody << valid;
+    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.com."_s);
+    QTest::newRow("valid04") << u"/domain"_s << domainBody << valid;
 
-    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"test-1.example.com."_qs);
-    QTest::newRow("valid05") << u"/domain"_qs << domainBody << valid;
+    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"test-1.example.com."_s);
+    QTest::newRow("valid05") << u"/domain"_s << domainBody << valid;
 
     // label with max length of 63 chars
     domainBody = QByteArrayLiteral("field=") +
                  QUrl::toPercentEncoding(
-                     u"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com"_qs);
-    QTest::newRow("valid06") << u"/domain"_qs << domainBody << valid;
+                     u"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com"_s);
+    QTest::newRow("valid06") << u"/domain"_s << domainBody << valid;
 
     // total length of 253 chars
     domainBody = QByteArrayLiteral("field=") +
@@ -1856,40 +1838,40 @@ void TestValidator::testValidatorDomain_data()
                      u"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcde."
                      "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk."
                      "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk."
-                     "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com"_qs);
-    QTest::newRow("valid07") << u"/domain"_qs << domainBody << valid;
+                     "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com"_s);
+    QTest::newRow("valid07") << u"/domain"_s << domainBody << valid;
 
     // disabled on MSVC because that shit still has problems with utf8 in 2018...
 #ifndef _MSC_VER
-    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"hüssenbergnetz.de"_qs);
-    QTest::newRow("valid08") << u"/domain"_qs << domainBody << valid;
+    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"hüssenbergnetz.de"_s);
+    QTest::newRow("valid08") << u"/domain"_s << domainBody << valid;
 
     domainBody =
-        QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"موقع.وزارة-الاتصالات.مصر"_qs);
-    QTest::newRow("valid09") << u"/domain"_qs << domainBody << valid;
+        QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"موقع.وزارة-الاتصالات.مصر"_s);
+    QTest::newRow("valid09") << u"/domain"_s << domainBody << valid;
 #endif
 
     // digit in non puny code TLD
-    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.com1"_qs);
-    QTest::newRow("invalid01") << u"/domain"_qs << domainBody << invalid;
+    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.com1"_s);
+    QTest::newRow("invalid01") << u"/domain"_s << domainBody << invalid;
 
     // one char tld
-    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.c"_qs);
-    QTest::newRow("invalid02") << u"/domain"_qs << domainBody << invalid;
+    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.c"_s);
+    QTest::newRow("invalid02") << u"/domain"_s << domainBody << invalid;
 
     // starts with digit
-    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.3com"_qs);
-    QTest::newRow("invalid03") << u"/domain"_qs << domainBody << invalid;
+    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.3com"_s);
+    QTest::newRow("invalid03") << u"/domain"_s << domainBody << invalid;
 
     // contains digit
-    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.co3m"_qs);
-    QTest::newRow("invalid04") << u"/domain"_qs << domainBody << invalid;
+    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.co3m"_s);
+    QTest::newRow("invalid04") << u"/domain"_s << domainBody << invalid;
 
     // label too long, 64 chars
     domainBody = QByteArrayLiteral("field=") +
                  QUrl::toPercentEncoding(
-                     u"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com"_qs);
-    QTest::newRow("invalid05") << u"/domain"_qs << domainBody << invalid;
+                     u"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com"_s);
+    QTest::newRow("invalid05") << u"/domain"_s << domainBody << invalid;
 
     // too long, 254 chars
     domainBody = QByteArrayLiteral("field=") +
@@ -1897,42 +1879,42 @@ void TestValidator::testValidatorDomain_data()
                      u"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef."
                      "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk."
                      "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk."
-                     "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com"_qs);
-    QTest::newRow("invalid06") << u"/domain"_qs << domainBody << invalid;
+                     "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com"_s);
+    QTest::newRow("invalid06") << u"/domain"_s << domainBody << invalid;
 
     // contains dash in tld
-    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.co-m"_qs);
-    QTest::newRow("invalid07") << u"/domain"_qs << domainBody << invalid;
+    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.co-m"_s);
+    QTest::newRow("invalid07") << u"/domain"_s << domainBody << invalid;
 
     // contains dash at label start
-    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"-example.com"_qs);
-    QTest::newRow("invalid08") << u"/domain"_qs << domainBody << invalid;
+    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"-example.com"_s);
+    QTest::newRow("invalid08") << u"/domain"_s << domainBody << invalid;
 
     // contains digit at label start
-    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"3example.com"_qs);
-    QTest::newRow("invalid09") << u"/domain"_qs << domainBody << invalid;
+    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"3example.com"_s);
+    QTest::newRow("invalid09") << u"/domain"_s << domainBody << invalid;
 
     // contains dash at label end
-    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example-.com"_qs);
-    QTest::newRow("invalid10") << u"/domain"_qs << domainBody << invalid;
+    domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example-.com"_s);
+    QTest::newRow("invalid10") << u"/domain"_s << domainBody << invalid;
 
     // disabled on MSVC because that shit still has problems with utf8 in 2018...
 #ifndef _MSC_VER
     domainBody =
-        QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"موقع.وزارة-الاتصالات.مصر1"_qs);
-    QTest::newRow("invalid11") << u"/domain"_qs << domainBody << invalid;
+        QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"موقع.وزارة-الاتصالات.مصر1"_s);
+    QTest::newRow("invalid11") << u"/domain"_s << domainBody << invalid;
 
     domainBody =
-        QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"موقع.وزارة-الاتصالات.مصر-"_qs);
-    QTest::newRow("invalid12") << u"/domain"_qs << domainBody << invalid;
+        QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"موقع.وزارة-الاتصالات.مصر-"_s);
+    QTest::newRow("invalid12") << u"/domain"_s << domainBody << invalid;
 #endif
 
     if (qEnvironmentVariableIsSet("CUTELYST_VALIDATORS_TEST_NETWORK")) {
-        domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.com"_qs);
-        QTest::newRow("dns-valid") << u"/domainDns"_qs << domainBody << valid;
+        domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"example.com"_s);
+        QTest::newRow("dns-valid") << u"/domainDns"_s << domainBody << valid;
 
-        domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"test.example.com"_qs);
-        QTest::newRow("dns-invalid") << u"/domainDns"_qs << domainBody << invalid;
+        domainBody = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"test.example.com"_s);
+        QTest::newRow("dns-invalid") << u"/domainDns"_s << domainBody << invalid;
     }
 }
 
@@ -1945,323 +1927,323 @@ void TestValidator::testValidatorEmail_data()
     // **** Start testing ValidatorEmail *****
 
     const QList<QString> validEmails(
-        {u"test@huessenbergnetz.de"_qs,
+        {u"test@huessenbergnetz.de"_s,
          // addresses are taken from
          // https://github.com/dominicsayers/isemail/blob/master/test/tests.xml
-         u"test@iana.org"_qs,
-         u"test@nominet.org.uk"_qs,
-         u"test@about.museum"_qs,
-         u"a@iana.org"_qs,
-         u"test.test@iana.org"_qs,
-         u"!#$%&`*+/=?^`{|}~@iana.org"_qs,
-         u"123@iana.org"_qs,
-         u"test@123.com"_qs,
-         u"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@iana.org"_qs,
-         u"test@mason-dixon.com"_qs,
-         u"test@c--n.com"_qs,
-         u"test@xn--hxajbheg2az3al.xn--jxalpdlp"_qs,
-         u"xn--test@iana.org"_qs,
+         u"test@iana.org"_s,
+         u"test@nominet.org.uk"_s,
+         u"test@about.museum"_s,
+         u"a@iana.org"_s,
+         u"test.test@iana.org"_s,
+         u"!#$%&`*+/=?^`{|}~@iana.org"_s,
+         u"123@iana.org"_s,
+         u"test@123.com"_s,
+         u"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@iana.org"_s,
+         u"test@mason-dixon.com"_s,
+         u"test@c--n.com"_s,
+         u"test@xn--hxajbheg2az3al.xn--jxalpdlp"_s,
+         u"xn--test@iana.org"_s,
          // addresses are taken from
          // https://github.com/dominicsayers/isemail/blob/master/test/tests-original.xml
-         u"first.last@iana.org"_qs,
-         u"1234567890123456789012345678901234567890123456789012345678901234@iana.org"_qs,
-         u"first.last@3com.com"_qs,
-         u"user+mailbox@iana.org"_qs,
-         u"customer/department=shipping@iana.org"_qs,
-         u"$A12345@iana.org"_qs,
-         u"!def!xyz%abc@iana.org"_qs,
-         u"_somename@iana.org"_qs,
-         u"dclo@us.ibm.com"_qs,
-         u"peter.piper@iana.org"_qs,
-         u"TEST@iana.org"_qs,
-         u"1234567890@iana.org"_qs,
-         u"test+test@iana.org"_qs,
-         u"test-test@iana.org"_qs,
-         u"t*est@iana.org"_qs,
-         u"+1~1+@iana.org"_qs,
-         u"{_test_}@iana.org"_qs,
-         u"test.test@iana.org"_qs,
-         u"customer/department@iana.org"_qs,
-         u"Yosemite.Sam@iana.org"_qs,
-         u"~@iana.org"_qs,
-         u"Ima.Fool@iana.org"_qs,
-         u"name.lastname@domain.com"_qs,
-         u"a@bar.com"_qs,
-         u"a-b@bar.com"_qs,
-         u"valid@about.museum"_qs,
-         u"user%uucp!path@berkeley.edu"_qs,
-         u"cdburgess+!#$%&'*-/=?+_{}|~test@gmail.com"_qs});
+         u"first.last@iana.org"_s,
+         u"1234567890123456789012345678901234567890123456789012345678901234@iana.org"_s,
+         u"first.last@3com.com"_s,
+         u"user+mailbox@iana.org"_s,
+         u"customer/department=shipping@iana.org"_s,
+         u"$A12345@iana.org"_s,
+         u"!def!xyz%abc@iana.org"_s,
+         u"_somename@iana.org"_s,
+         u"dclo@us.ibm.com"_s,
+         u"peter.piper@iana.org"_s,
+         u"TEST@iana.org"_s,
+         u"1234567890@iana.org"_s,
+         u"test+test@iana.org"_s,
+         u"test-test@iana.org"_s,
+         u"t*est@iana.org"_s,
+         u"+1~1+@iana.org"_s,
+         u"{_test_}@iana.org"_s,
+         u"test.test@iana.org"_s,
+         u"customer/department@iana.org"_s,
+         u"Yosemite.Sam@iana.org"_s,
+         u"~@iana.org"_s,
+         u"Ima.Fool@iana.org"_s,
+         u"name.lastname@domain.com"_s,
+         u"a@bar.com"_s,
+         u"a-b@bar.com"_s,
+         u"valid@about.museum"_s,
+         u"user%uucp!path@berkeley.edu"_s,
+         u"cdburgess+!#$%&'*-/=?+_{}|~test@gmail.com"_s});
 
     const QList<QString> dnsWarnEmails({
-        u"test@example.com"_qs, // no mx record
+        u"test@example.com"_s, // no mx record
         // addresses are taken from
         // https://github.com/dominicsayers/isemail/blob/master/test/tests.xml
-        u"test@e.com"_qs,                                                               // no record
-        u"test@iana.a"_qs,                                                              // no record
-        u"test@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.com"_qs, // no record
-        u"test@iana.co-uk"_qs,                                                          // no record
+        u"test@e.com"_s,                                                               // no record
+        u"test@iana.a"_s,                                                              // no record
+        u"test@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.com"_s, // no record
+        u"test@iana.co-uk"_s,                                                          // no record
         u"a@a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.a.b.c.d.e.f.g.h.i.j."
         "k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u."
         "v.w.x.y.z.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.a.b.c.d.e.f."
-        "g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v"_qs, // no record
+        "g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v"_s, // no record
         u"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@"
         "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl."
         "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl."
-        "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi"_qs,
+        "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi"_s,
         // addresses are taken from
         // https://github.com/dominicsayers/isemail/blob/master/test/tests-original.xml
         u"x@x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789."
         "x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789."
         "x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789."
-        "x23456789.x23456789.x23456789.x23456789.x2"_qs, // no record
+        "x23456789.x23456789.x23456789.x23456789.x2"_s, // no record
         u"1234567890123456789012345678901234567890123456789012345678901@"
         "12345678901234567890123456789012345678901234567890123456789."
         "12345678901234567890123456789012345678901234567890123456789."
-        "123456789012345678901234567890123456789012345678901234567890123.iana.org"_qs, // no record
+        "123456789012345678901234567890123456789012345678901234567890123.iana.org"_s, // no record
         // no record
-        u"first.last@x23456789012345678901234567890123456789012345678901234567890123.iana.org"_qs,
-        u"first.last@123.iana.org"_qs,          // no record
-        u"test@123.123.123.x123"_qs,            // no record
-        u"test@example.iana.org"_qs,            // no record
-        u"test@example.example.iana.org"_qs,    // no record
-        u"+@b.c"_qs,                            // no record
-        u"+@b.com"_qs,                          // no record
-        u"a@b.co-foo.uk"_qs,                    // no record
-        u"shaitan@my-domain.thisisminekthx"_qs, // no record
-        u"test@xn--example.com"_qs              // no record
+        u"first.last@x23456789012345678901234567890123456789012345678901234567890123.iana.org"_s,
+        u"first.last@123.iana.org"_s,          // no record
+        u"test@123.123.123.x123"_s,            // no record
+        u"test@example.iana.org"_s,            // no record
+        u"test@example.example.iana.org"_s,    // no record
+        u"+@b.c"_s,                            // no record
+        u"+@b.com"_s,                          // no record
+        u"a@b.co-foo.uk"_s,                    // no record
+        u"shaitan@my-domain.thisisminekthx"_s, // no record
+        u"test@xn--example.com"_s              // no record
     });
 
     const QList<QString> rfc5321Emails({
         // addresses are taken from
         // https://github.com/dominicsayers/isemail/blob/master/test/tests-original.xml
-        u"\"first\\\"last\"@iana.org"_qs,                                  // quoted string
-        u"\"first@last\"@iana.org"_qs,                                     // quoted string
-        u"\"first\\\\last\"@iana.org"_qs,                                  // quoted string
-        u"first.last@[12.34.56.78]"_qs,                                    // address literal
-        u"first.last@[IPv6:::12.34.56.78]"_qs,                             // address literal
-        u"first.last@[IPv6:1111:2222:3333::4444:12.34.56.78]"_qs,          // address literal
-        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666:12.34.56.78]"_qs, // address literal
-        u"first.last@[IPv6:::1111:2222:3333:4444:5555:6666]"_qs,           // address literal
-        u"first.last@[IPv6:1111:2222:3333::4444:5555:6666]"_qs,            // address literal
-        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666::]"_qs,           // address literal
-        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888]"_qs,   // address literal
-        u"\"first\\last\"@iana.org"_qs,                                    // quoted string
-        u"\"\"@iana.org"_qs,                                               // quoted string
-        u"first.last@[IPv6:1111:2222:3333::4444:5555:12.34.56.78]"_qs,     // ipv6 deprecated
-        u"first.last@example.123"_qs,                                      // tld numeric
-        u"first.last@com"_qs,                                              // tld
-        u"\"Abc\\@def\"@iana.org"_qs,                                      // quoted string
-        u"\"Fred\\ Bloggs\"@iana.org"_qs,                                  // quoted string
-        u"\"Joe.\\\\Blow\"@iana.org"_qs,                                   // quoted string
-        u"\"Abc@def\"@iana.org"_qs,                                        // quoted string
-        u"\"Fred Bloggs\"@iana.org"_qs,                                    // quoted string
-        u"\"Doug \\\"Ace\\\" L.\"@iana.org"_qs,                            // quoted string
-        u"\"[[ test ]]\"@iana.org"_qs,                                     // quoted string
-        u"\"test.test\"@iana.org"_qs,                                      // quoted string
-        u"\"test@test\"@iana.org"_qs,                                      // quoted string
-        u"test@123.123.123.123"_qs,                                        // tld numeric
-        u"test@[123.123.123.123]"_qs,                                      // address literal
-        u"\"test\\test\"@iana.org"_qs,                                     // quoted string
-        u"test@example"_qs,                                                // tld
-        u"\"test\\\\blah\"@iana.org"_qs,                                   // quoted string
-        u"\"test\\blah\"@iana.org"_qs,                                     // quoted string
-        u"\"test\\\"blah\"@iana.org"_qs,                                   // quoted string
-        u"\"Austin@Powers\"@iana.org"_qs,                                  // quoted string
-        u"\"Ima.Fool\"@iana.org"_qs,                                       // quoted string
-        u"\"Ima Fool\"@iana.org"_qs,                                       // quoted string
-        u"\"first.middle.last\"@iana.org"_qs,                              // quoted string
-        u"\"first..last\"@iana.org"_qs,                                    // quoted string
-        u"\"first\\\\\\\"last\"@iana.org"_qs,                              // quoted string
-        u"a@b"_qs,                                                         // tld
-        u"aaa@[123.123.123.123]"_qs,                                       // address literal
-        u"a@bar"_qs,                                                       // tld
-        u"\"hello my name is\"@stutter.com"_qs,                            // quoted string
-        u"\"Test \\\"Fail\\\" Ing\"@iana.org"_qs,                          // quoted string
-        u"foobar@192.168.0.1"_qs,                                          // tld numeric
-        u"\"Joe\\\\Blow\"@iana.org"_qs,                                    // quoted string
-        u"\"first(last)\"@iana.org"_qs,                                    // quoted string
-        u"first.last@[IPv6:::a2:a3:a4:b1:b2:b3:b4]"_qs,                    // ipv6 deprecated
-        u"first.last@[IPv6:a1:a2:a3:a4:b1:b2:b3::]"_qs,                    // ipv6 deprecated
-        u"first.last@[IPv6:::]"_qs,                                        // address literal
-        u"first.last@[IPv6:::b4]"_qs,                                      // address literal
-        u"first.last@[IPv6:::b3:b4]"_qs,                                   // address literal
-        u"first.last@[IPv6:a1::b4]"_qs,                                    // address literal
-        u"first.last@[IPv6:a1::]"_qs,                                      // address literal
-        u"first.last@[IPv6:a1:a2::]"_qs,                                   // address literal
-        u"first.last@[IPv6:0123:4567:89ab:cdef::]"_qs,                     // address literal
-        u"first.last@[IPv6:0123:4567:89ab:CDEF::]"_qs,                     // address literal
-        u"first.last@[IPv6:::a3:a4:b1:ffff:11.22.33.44]"_qs,               // address literal
-        u"first.last@[IPv6:::a2:a3:a4:b1:ffff:11.22.33.44]"_qs,            // ipv6 deprecated
-        u"first.last@[IPv6:a1:a2:a3:a4::11.22.33.44]"_qs,                  // address literal
-        u"first.last@[IPv6:a1:a2:a3:a4:b1::11.22.33.44]"_qs,               // ipv6 deprecated
-        u"first.last@[IPv6:a1::11.22.33.44]"_qs,                           // address literal
-        u"first.last@[IPv6:a1:a2::11.22.33.44]"_qs,                        // address literal
-        u"first.last@[IPv6:0123:4567:89ab:cdef::11.22.33.44]"_qs,          // address literal
-        u"first.last@[IPv6:0123:4567:89ab:CDEF::11.22.33.44]"_qs,          // address literal
-        u"first.last@[IPv6:a1::b2:11.22.33.44]"_qs,                        // address literal
+        u"\"first\\\"last\"@iana.org"_s,                                  // quoted string
+        u"\"first@last\"@iana.org"_s,                                     // quoted string
+        u"\"first\\\\last\"@iana.org"_s,                                  // quoted string
+        u"first.last@[12.34.56.78]"_s,                                    // address literal
+        u"first.last@[IPv6:::12.34.56.78]"_s,                             // address literal
+        u"first.last@[IPv6:1111:2222:3333::4444:12.34.56.78]"_s,          // address literal
+        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666:12.34.56.78]"_s, // address literal
+        u"first.last@[IPv6:::1111:2222:3333:4444:5555:6666]"_s,           // address literal
+        u"first.last@[IPv6:1111:2222:3333::4444:5555:6666]"_s,            // address literal
+        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666::]"_s,           // address literal
+        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888]"_s,   // address literal
+        u"\"first\\last\"@iana.org"_s,                                    // quoted string
+        u"\"\"@iana.org"_s,                                               // quoted string
+        u"first.last@[IPv6:1111:2222:3333::4444:5555:12.34.56.78]"_s,     // ipv6 deprecated
+        u"first.last@example.123"_s,                                      // tld numeric
+        u"first.last@com"_s,                                              // tld
+        u"\"Abc\\@def\"@iana.org"_s,                                      // quoted string
+        u"\"Fred\\ Bloggs\"@iana.org"_s,                                  // quoted string
+        u"\"Joe.\\\\Blow\"@iana.org"_s,                                   // quoted string
+        u"\"Abc@def\"@iana.org"_s,                                        // quoted string
+        u"\"Fred Bloggs\"@iana.org"_s,                                    // quoted string
+        u"\"Doug \\\"Ace\\\" L.\"@iana.org"_s,                            // quoted string
+        u"\"[[ test ]]\"@iana.org"_s,                                     // quoted string
+        u"\"test.test\"@iana.org"_s,                                      // quoted string
+        u"\"test@test\"@iana.org"_s,                                      // quoted string
+        u"test@123.123.123.123"_s,                                        // tld numeric
+        u"test@[123.123.123.123]"_s,                                      // address literal
+        u"\"test\\test\"@iana.org"_s,                                     // quoted string
+        u"test@example"_s,                                                // tld
+        u"\"test\\\\blah\"@iana.org"_s,                                   // quoted string
+        u"\"test\\blah\"@iana.org"_s,                                     // quoted string
+        u"\"test\\\"blah\"@iana.org"_s,                                   // quoted string
+        u"\"Austin@Powers\"@iana.org"_s,                                  // quoted string
+        u"\"Ima.Fool\"@iana.org"_s,                                       // quoted string
+        u"\"Ima Fool\"@iana.org"_s,                                       // quoted string
+        u"\"first.middle.last\"@iana.org"_s,                              // quoted string
+        u"\"first..last\"@iana.org"_s,                                    // quoted string
+        u"\"first\\\\\\\"last\"@iana.org"_s,                              // quoted string
+        u"a@b"_s,                                                         // tld
+        u"aaa@[123.123.123.123]"_s,                                       // address literal
+        u"a@bar"_s,                                                       // tld
+        u"\"hello my name is\"@stutter.com"_s,                            // quoted string
+        u"\"Test \\\"Fail\\\" Ing\"@iana.org"_s,                          // quoted string
+        u"foobar@192.168.0.1"_s,                                          // tld numeric
+        u"\"Joe\\\\Blow\"@iana.org"_s,                                    // quoted string
+        u"\"first(last)\"@iana.org"_s,                                    // quoted string
+        u"first.last@[IPv6:::a2:a3:a4:b1:b2:b3:b4]"_s,                    // ipv6 deprecated
+        u"first.last@[IPv6:a1:a2:a3:a4:b1:b2:b3::]"_s,                    // ipv6 deprecated
+        u"first.last@[IPv6:::]"_s,                                        // address literal
+        u"first.last@[IPv6:::b4]"_s,                                      // address literal
+        u"first.last@[IPv6:::b3:b4]"_s,                                   // address literal
+        u"first.last@[IPv6:a1::b4]"_s,                                    // address literal
+        u"first.last@[IPv6:a1::]"_s,                                      // address literal
+        u"first.last@[IPv6:a1:a2::]"_s,                                   // address literal
+        u"first.last@[IPv6:0123:4567:89ab:cdef::]"_s,                     // address literal
+        u"first.last@[IPv6:0123:4567:89ab:CDEF::]"_s,                     // address literal
+        u"first.last@[IPv6:::a3:a4:b1:ffff:11.22.33.44]"_s,               // address literal
+        u"first.last@[IPv6:::a2:a3:a4:b1:ffff:11.22.33.44]"_s,            // ipv6 deprecated
+        u"first.last@[IPv6:a1:a2:a3:a4::11.22.33.44]"_s,                  // address literal
+        u"first.last@[IPv6:a1:a2:a3:a4:b1::11.22.33.44]"_s,               // ipv6 deprecated
+        u"first.last@[IPv6:a1::11.22.33.44]"_s,                           // address literal
+        u"first.last@[IPv6:a1:a2::11.22.33.44]"_s,                        // address literal
+        u"first.last@[IPv6:0123:4567:89ab:cdef::11.22.33.44]"_s,          // address literal
+        u"first.last@[IPv6:0123:4567:89ab:CDEF::11.22.33.44]"_s,          // address literal
+        u"first.last@[IPv6:a1::b2:11.22.33.44]"_s,                        // address literal
 
         // addresses are taken from
         // https://github.com/dominicsayers/isemail/blob/master/test/tests.xml
-        u"test@iana.123"_qs,                                             // tld numeric
-        u"test@255.255.255.255"_qs,                                      // tld numeric
-        u"\"test\"@iana.org"_qs,                                         // quoted string
-        u"\"\"@iana.org"_qs,                                             // quoted string
-        u"\"\\a\"@iana.org"_qs,                                          // quoted string
-        u"\"\\\"\"@iana.org"_qs,                                         // quoted string
-        u"\"\\\\\"@iana.org"_qs,                                         // quoted string
-        u"\"test\\ test\"@iana.org"_qs,                                  // quoted string
-        u"test@[255.255.255.255]"_qs,                                    // address literal
-        u"test@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888]"_qs,       // address literal
-        u"test@[IPv6:1111:2222:3333:4444:5555:6666::8888]"_qs,           // ipv6 deprecated
-        u"test@[IPv6:1111:2222:3333:4444:5555::8888]"_qs,                // address literal
-        u"test@[IPv6:::3333:4444:5555:6666:7777:8888]"_qs,               // address literal
-        u"test@[IPv6:::]"_qs,                                            // address literal
-        u"test@[IPv6:1111:2222:3333:4444:5555:6666:255.255.255.255]"_qs, // address literal
-        u"test@[IPv6:1111:2222:3333:4444::255.255.255.255]"_qs,          // address literal
-        u"test@org"_qs                                                   // tld
+        u"test@iana.123"_s,                                             // tld numeric
+        u"test@255.255.255.255"_s,                                      // tld numeric
+        u"\"test\"@iana.org"_s,                                         // quoted string
+        u"\"\"@iana.org"_s,                                             // quoted string
+        u"\"\\a\"@iana.org"_s,                                          // quoted string
+        u"\"\\\"\"@iana.org"_s,                                         // quoted string
+        u"\"\\\\\"@iana.org"_s,                                         // quoted string
+        u"\"test\\ test\"@iana.org"_s,                                  // quoted string
+        u"test@[255.255.255.255]"_s,                                    // address literal
+        u"test@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888]"_s,       // address literal
+        u"test@[IPv6:1111:2222:3333:4444:5555:6666::8888]"_s,           // ipv6 deprecated
+        u"test@[IPv6:1111:2222:3333:4444:5555::8888]"_s,                // address literal
+        u"test@[IPv6:::3333:4444:5555:6666:7777:8888]"_s,               // address literal
+        u"test@[IPv6:::]"_s,                                            // address literal
+        u"test@[IPv6:1111:2222:3333:4444:5555:6666:255.255.255.255]"_s, // address literal
+        u"test@[IPv6:1111:2222:3333:4444::255.255.255.255]"_s,          // address literal
+        u"test@org"_s                                                   // tld
     });
 
     const QList<QString> cfwsEmails({
         // addresses are taken from
         // https://github.com/dominicsayers/isemail/blob/master/test/tests.xml
-        u"\r\n test@iana.org"_qs,              // folding white space
-        u"(comment)test@iana.org"_qs,          // comment
-        u"(comment(comment))test@iana.org"_qs, // coment
-        u"(comment)abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@iana.org"_qs, // comment
+        u"\r\n test@iana.org"_s,              // folding white space
+        u"(comment)test@iana.org"_s,          // comment
+        u"(comment(comment))test@iana.org"_s, // coment
+        u"(comment)abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@iana.org"_s, // comment
         u"(comment)test@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghik."
         "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghik."
         "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk."
-        "abcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstu"_qs, // comment
-        u" \r\n test@iana.org"_qs,                                        // folding white space
-        u"test@iana.org\r\n "_qs,                                         // folding white space
-        u"test@iana.org \r\n "_qs,                                        // folding white space
-        u" test@iana.org"_qs,                                             // folding white space
-        u"test@iana.org "_qs,                                             // folding white space
+        "abcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstu"_s, // comment
+        u" \r\n test@iana.org"_s,                                        // folding white space
+        u"test@iana.org\r\n "_s,                                         // folding white space
+        u"test@iana.org \r\n "_s,                                        // folding white space
+        u" test@iana.org"_s,                                             // folding white space
+        u"test@iana.org "_s,                                             // folding white space
 
         // addresses are taken from
         // https://github.com/dominicsayers/isemail/blob/master/test/tests-original.xml
-        u"\"test\r\n blah\"@iana.org"_qs, // folding white space
+        u"\"test\r\n blah\"@iana.org"_s, // folding white space
         u"first.last@iana("
         "1234567890123456789012345678901234567890123456789012345678901234567890)."
-        "org"_qs // comment
+        "org"_s // comment
     });
 
     const QList<QString> deprecatedEmails({
         // addresses are taken from
         // https://github.com/dominicsayers/isemail/blob/master/test/tests.xml
-        u"\"test\".\"test\"@iana.org"_qs, // local part
-        u"\"test\".test@iana.org"_qs,     // local part
-        // u"\"test\\\0\"@iana.org"_qs, // quoted pair
-        u" test @iana.org"_qs,                 // folding white space near at
-        u"test@ iana .com"_qs,                 // folding white space near at
-        u"test . test@iana.org"_qs,            // folding white space
-        u"\r\n \r\n test@iana.org"_qs,         // folding white space
-        u"test@(comment)iana.org"_qs,          // comment near at
-        u"test@(comment)[255.255.255.255]"_qs, // comment near at
+        u"\"test\".\"test\"@iana.org"_s, // local part
+        u"\"test\".test@iana.org"_s,     // local part
+        // u"\"test\\\0\"@iana.org"_s, // quoted pair
+        u" test @iana.org"_s,                 // folding white space near at
+        u"test@ iana .com"_s,                 // folding white space near at
+        u"test . test@iana.org"_s,            // folding white space
+        u"\r\n \r\n test@iana.org"_s,         // folding white space
+        u"test@(comment)iana.org"_s,          // comment near at
+        u"test@(comment)[255.255.255.255]"_s, // comment near at
         // comment near at
-        u"test@(comment)abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.com"_qs,
+        u"test@(comment)abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.com"_s,
         // quoted string with deprecated char - currently also not working on upstream
-        // u"\"\"@iana.org"_qs,
+        // u"\"\"@iana.org"_s,
         // quoted string with deprecated char
-        // u"\"\\\"@iana.org"_qs,
+        // u"\"\\\"@iana.org"_s,
         // comment string with deprecated char - currently also not working on upstream
-        // u"()test@iana.org"_qs,
-        u"\"\\\n\"@iana.org"_qs,           // quoted pair with deprecated char
-        u"\"\a\"@iana.org"_qs,             // quoted string with deprecated char
-        u"\"\\\a\"@iana.org"_qs,           // quoted pair with deprecated char
-        u"(\a)test@iana.org"_qs,           // comment with deprecated char
-        u"test@iana.org\r\n \r\n "_qs,     // obsolete folding white space
-        u"test.(comment)test@iana.org"_qs, // deprecated comment position
+        // u"()test@iana.org"_s,
+        u"\"\\\n\"@iana.org"_s,           // quoted pair with deprecated char
+        u"\"\a\"@iana.org"_s,             // quoted string with deprecated char
+        u"\"\\\a\"@iana.org"_s,           // quoted pair with deprecated char
+        u"(\a)test@iana.org"_s,           // comment with deprecated char
+        u"test@iana.org\r\n \r\n "_s,     // obsolete folding white space
+        u"test.(comment)test@iana.org"_s, // deprecated comment position
 
         // addresses are taken from
         // https://github.com/dominicsayers/isemail/blob/master/test/tests-original.xml
-        u"test.\"test\"@iana.org"_qs,                     // local part
-        u"\"test\\\rblah\"@iana.org"_qs,                  // quoted pair with deprecated char
-        u"\"first\".\"last\"@iana.org"_qs,                // local part
-        u"\"first\".middle.\"last\"@iana.org"_qs,         // local part
-        u"\"first\".last@iana.org"_qs,                    // local part
-        u"first.\"last\"@iana.org"_qs,                    // local part
-        u"\"first\".\"middle\".\"last\"@iana.org"_qs,     // local part
-        u"\"first.middle\".\"last\"@iana.org"_qs,         // local part
-        u"first.\"mid\\dle\".\"last\"@iana.org"_qs,       // local part
-        u"Test.\r\n Folding.\r\n Whitespace@iana.org"_qs, // folding white space
-        u"first.\"\".last@iana.org"_qs,                   // local part
-        u"(foo)cal(bar)@(baz)iamcal.com(quux)"_qs,        // comment near at
-        u"cal@iamcal(woo).(yay)com"_qs,                   // comment position
-        u"\"foo\"(yay)@(hoopla)[1.2.3.4]"_qs,             // comment near at
-        u"cal(woo(yay)hoopla)@iamcal.com"_qs,             // comment near at
-        u"cal(foo\\@bar)@iamcal.com"_qs,                  // comment near at
-        u"cal(foo\\)bar)@iamcal.com"_qs,                  // comment near at
-        u"first().last@iana.org"_qs,                      // local part
-        u"first.(\r\n middle\r\n )last@iana.org"_qs,      // deprecated comment
+        u"test.\"test\"@iana.org"_s,                     // local part
+        u"\"test\\\rblah\"@iana.org"_s,                  // quoted pair with deprecated char
+        u"\"first\".\"last\"@iana.org"_s,                // local part
+        u"\"first\".middle.\"last\"@iana.org"_s,         // local part
+        u"\"first\".last@iana.org"_s,                    // local part
+        u"first.\"last\"@iana.org"_s,                    // local part
+        u"\"first\".\"middle\".\"last\"@iana.org"_s,     // local part
+        u"\"first.middle\".\"last\"@iana.org"_s,         // local part
+        u"first.\"mid\\dle\".\"last\"@iana.org"_s,       // local part
+        u"Test.\r\n Folding.\r\n Whitespace@iana.org"_s, // folding white space
+        u"first.\"\".last@iana.org"_s,                   // local part
+        u"(foo)cal(bar)@(baz)iamcal.com(quux)"_s,        // comment near at
+        u"cal@iamcal(woo).(yay)com"_s,                   // comment position
+        u"\"foo\"(yay)@(hoopla)[1.2.3.4]"_s,             // comment near at
+        u"cal(woo(yay)hoopla)@iamcal.com"_s,             // comment near at
+        u"cal(foo\\@bar)@iamcal.com"_s,                  // comment near at
+        u"cal(foo\\)bar)@iamcal.com"_s,                  // comment near at
+        u"first().last@iana.org"_s,                      // local part
+        u"first.(\r\n middle\r\n )last@iana.org"_s,      // deprecated comment
         // comment near at
-        u"first(Welcome to\r\n the (\"wonderful\" (!)) world\r\n of email)@iana.org"_qs,
-        u"pete(his account)@silly.test(his host)"_qs, // comment near at
-        u"c@(Chris's host.)public.example"_qs,        // comment near at
-        u"jdoe@machine(comment). example"_qs,         // folding white space
-        u"1234 @ local(blah) .machine .example"_qs,   // white space near at
-        u"first(abc.def).last@iana.org"_qs,           // local part
-        u"first(a\"bc.def).last@iana.org"_qs,         // local part
-        u"first.(\")middle.last(\")@iana.org"_qs,     // local part
-        u"first(abc\\(def)@iana.org"_qs,              // comment near at
-        u"a(a(b(c)d(e(f))g)h(i)j)@iana.org"_qs,
-        u"HM2Kinsists@(that comments are allowed)this.is.ok"_qs, // comment near at
+        u"first(Welcome to\r\n the (\"wonderful\" (!)) world\r\n of email)@iana.org"_s,
+        u"pete(his account)@silly.test(his host)"_s, // comment near at
+        u"c@(Chris's host.)public.example"_s,        // comment near at
+        u"jdoe@machine(comment). example"_s,         // folding white space
+        u"1234 @ local(blah) .machine .example"_s,   // white space near at
+        u"first(abc.def).last@iana.org"_s,           // local part
+        u"first(a\"bc.def).last@iana.org"_s,         // local part
+        u"first.(\")middle.last(\")@iana.org"_s,     // local part
+        u"first(abc\\(def)@iana.org"_s,              // comment near at
+        u"a(a(b(c)d(e(f))g)h(i)j)@iana.org"_s,
+        u"HM2Kinsists@(that comments are allowed)this.is.ok"_s, // comment near at
         u" \r\n (\r\n x \r\n ) \r\n first\r\n ( \r\n x\r\n ) \r\n .\r\n ( \r\n x) "
-        "\r\n last \r\n ( x \r\n ) \r\n @iana.org"_qs, // folding white space near at
-        u"first.last @iana.org"_qs,                    // folding white space near at
-        u"test. \r\n \r\n obs@syntax.com"_qs           // folding white space
-        // u"\"Unicode NULL\\\0\"@char.com"_qs // quoted pair contains deprecated char
+        "\r\n last \r\n ( x \r\n ) \r\n @iana.org"_s, // folding white space near at
+        u"first.last @iana.org"_s,                    // folding white space near at
+        u"test. \r\n \r\n obs@syntax.com"_s           // folding white space
+        // u"\"Unicode NULL\\\0\"@char.com"_s // quoted pair contains deprecated char
     });
 
     const QList<QString> rfc5322Emails({
         // addresses are taken from
         // https://github.com/dominicsayers/isemail/blob/master/test/tests.xml
         // local too long
-        u"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklmn@iana.org"_qs,
+        u"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklmn@iana.org"_s,
         // label too long
-        u"test@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm.com"_qs,
+        u"test@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm.com"_s,
         u"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@"
         "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl."
         "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl."
-        "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghij"_qs, // too long
+        "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghij"_s, // too long
         u"a@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl."
         "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl."
         "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl."
-        "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefg.hij"_qs, // too long
+        "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefg.hij"_s, // too long
         u"a@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl."
         "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl."
         "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl."
-        "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefg.hijk"_qs, // too long
+        "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefg.hijk"_s, // too long
         // local too long
-        u"\"abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghj\"@iana.org"_qs,
+        u"\"abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghj\"@iana.org"_s,
         // local too long
-        u"\"abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefg\\h\"@iana.org"_qs,
-        u"test@[255.255.255]"_qs,                                       // invalid domain literal
-        u"test@[255.255.255.255.255]"_qs,                               // invalid domain litearl
-        u"test@[255.255.255.256]"_qs,                                   // invalid domain literal
-        u"test@[1111:2222:3333:4444:5555:6666:7777:8888]"_qs,           // invalid domain literal
-        u"test@[IPv6:1111:2222:3333:4444:5555:6666:7777]"_qs,           // ipv6 group count
-        u"test@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888:9999]"_qs, // ipv6 group count
-        u"test@[IPv6:1111:2222:3333:4444:5555:6666:7777:888G]"_qs,      // ipv6 bad char
-        u"test@[IPv6:1111:2222:3333:4444:5555:6666::7777:8888]"_qs,     // ipv6 max groups
-        u"test@[IPv6::3333:4444:5555:6666:7777:8888]"_qs,               // ipv6 colon start
-        u"test@[IPv6:1111::4444:5555::8888]"_qs,                        // ipv6 2x2x colon
-        u"test@[IPv6:1111:2222:3333:4444:5555:255.255.255.255]"_qs,     // ipv6 group count
-        u"test@[IPv6:1111:2222:3333:4444:5555:6666:7777:255.255.255.255]"_qs, // ipv6 group count
-        u"test@[IPv6:1111:2222:3333:4444:5555:6666::255.255.255.255]"_qs,     // ipv6 max groups
-        u"test@[IPv6:1111:2222:3333:4444:::255.255.255.255]"_qs,              // ipv6 2x2x colon
-        u"test@[IPv6::255.255.255.255]"_qs,                                   // ipv6 colon start
-        u"test@[RFC-5322-domain-literal]"_qs, // invalid domain literal
+        u"\"abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefg\\h\"@iana.org"_s,
+        u"test@[255.255.255]"_s,                                       // invalid domain literal
+        u"test@[255.255.255.255.255]"_s,                               // invalid domain litearl
+        u"test@[255.255.255.256]"_s,                                   // invalid domain literal
+        u"test@[1111:2222:3333:4444:5555:6666:7777:8888]"_s,           // invalid domain literal
+        u"test@[IPv6:1111:2222:3333:4444:5555:6666:7777]"_s,           // ipv6 group count
+        u"test@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888:9999]"_s, // ipv6 group count
+        u"test@[IPv6:1111:2222:3333:4444:5555:6666:7777:888G]"_s,      // ipv6 bad char
+        u"test@[IPv6:1111:2222:3333:4444:5555:6666::7777:8888]"_s,     // ipv6 max groups
+        u"test@[IPv6::3333:4444:5555:6666:7777:8888]"_s,               // ipv6 colon start
+        u"test@[IPv6:1111::4444:5555::8888]"_s,                        // ipv6 2x2x colon
+        u"test@[IPv6:1111:2222:3333:4444:5555:255.255.255.255]"_s,     // ipv6 group count
+        u"test@[IPv6:1111:2222:3333:4444:5555:6666:7777:255.255.255.255]"_s, // ipv6 group count
+        u"test@[IPv6:1111:2222:3333:4444:5555:6666::255.255.255.255]"_s,     // ipv6 max groups
+        u"test@[IPv6:1111:2222:3333:4444:::255.255.255.255]"_s,              // ipv6 2x2x colon
+        u"test@[IPv6::255.255.255.255]"_s,                                   // ipv6 colon start
+        u"test@[RFC-5322-domain-literal]"_s, // invalid domain literal
         // invalid domain literal containing obsolete chars
-        u"test@[RFC-5322-\\\a-domain-literal]"_qs,
+        u"test@[RFC-5322-\\\a-domain-literal]"_s,
         // invalid domain literal containing obsolete chars
-        u"test@[RFC-5322-\\\t-domain-literal]"_qs,
+        u"test@[RFC-5322-\\\t-domain-literal]"_s,
         // invalid domain literal containing obsolete chars
-        u"test@[RFC-5322-\\]-domain-literal]"_qs,
-        u"test@[RFC 5322 domain literal]"_qs,           // invalid domain literal
-        u"test@[RFC-5322-domain-literal] (comment)"_qs, // invalid domain literal
-        u"test@[IPv6:1::2:]"_qs,                        // ipv6 colon end
-        u"test@iana/icann.org"_qs,                      // domain invalid for DNS
+        u"test@[RFC-5322-\\]-domain-literal]"_s,
+        u"test@[RFC 5322 domain literal]"_s,           // invalid domain literal
+        u"test@[RFC-5322-domain-literal] (comment)"_s, // invalid domain literal
+        u"test@[IPv6:1::2:]"_s,                        // ipv6 colon end
+        u"test@iana/icann.org"_s,                      // domain invalid for DNS
 
         // addresses are taken from
         // https://github.com/dominicsayers/isemail/blob/master/test/tests-original.xml
@@ -2269,258 +2251,257 @@ void TestValidator::testValidatorEmail_data()
         "12345678901234567890123456789012345678901234567890123456789."
         "12345678901234567890123456789012345678901234567890123456789."
         "12345678901234567890123456789012345678901234567890123456789.12345.iana."
-        "org"_qs, // too long
+        "org"_s, // too long
         u"12345678901234567890123456789012345678901234567890123456789012345@iana."
-        "org"_qs, // local too long
+        "org"_s, // local too long
         u"x@x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789."
         "x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789."
         "x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789."
-        "x23456789.x23456"_qs,                                        // domain too long
-        u"first.last@[.12.34.56.78]"_qs,                              // invalid domain literal
-        u"first.last@[12.34.56.789]"_qs,                              // invalid domain literal
-        u"first.last@[::12.34.56.78]"_qs,                             // invalid domain literal
-        u"first.last@[IPv5:::12.34.56.78]"_qs,                        // invalid domain literal
-        u"first.last@[IPv6:1111:2222:3333:4444:5555:12.34.56.78]"_qs, // ipv6 group count
-        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777:12.34.56.78]"_qs, // ipv6 group count
-        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777]"_qs,             // ipv6 group count
-        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888:9999]"_qs,   // ipv6 group count
-        u"first.last@[IPv6:1111:2222::3333::4444:5555:6666]"_qs,                // ipv6 2x2x colon
-        u"first.last@[IPv6:1111:2222:333x::4444:5555]"_qs,                      // ipv6 bad char
-        u"first.last@[IPv6:1111:2222:33333::4444:5555]"_qs,                     // ipv6 bad char
+        "x23456789.x23456"_s,                                        // domain too long
+        u"first.last@[.12.34.56.78]"_s,                              // invalid domain literal
+        u"first.last@[12.34.56.789]"_s,                              // invalid domain literal
+        u"first.last@[::12.34.56.78]"_s,                             // invalid domain literal
+        u"first.last@[IPv5:::12.34.56.78]"_s,                        // invalid domain literal
+        u"first.last@[IPv6:1111:2222:3333:4444:5555:12.34.56.78]"_s, // ipv6 group count
+        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777:12.34.56.78]"_s, // ipv6 group count
+        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777]"_s,             // ipv6 group count
+        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888:9999]"_s,   // ipv6 group count
+        u"first.last@[IPv6:1111:2222::3333::4444:5555:6666]"_s,                // ipv6 2x2x colon
+        u"first.last@[IPv6:1111:2222:333x::4444:5555]"_s,                      // ipv6 bad char
+        u"first.last@[IPv6:1111:2222:33333::4444:5555]"_s,                     // ipv6 bad char
         // label too long
-        u"first.last@x234567890123456789012345678901234567890123456789012345678901234.iana.org"_qs,
+        u"first.last@x234567890123456789012345678901234567890123456789012345678901234.iana.org"_s,
         u"test@123456789012345678901234567890123456789012345678901234567890123."
         "123456789012345678901234567890123456789012345678901234567890123."
         "123456789012345678901234567890123456789012345678901234567890123."
-        "123456789012345678901234567890123456789012345678901234567890.com"_qs, // domain too long
-        u"foo@[\\1.2.3.4]"_qs, // invalid domain literal containing obsolete chars
-        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666:12.34.567.89]"_qs, // ipv6 bad char
-        u"aaa@[123.123.123.333]"_qs,                               // invalid domain literal
-        u"first.last@[IPv6::]"_qs,                                 // ipv6 colon start
-        u"first.last@[IPv6::::]"_qs,                               // ipv6 2x2x colon
-        u"first.last@[IPv6::b4]"_qs,                               // ipv6 colon start
-        u"first.last@[IPv6::::b4]"_qs,                             // ipv6 2x2x colon
-        u"first.last@[IPv6::b3:b4]"_qs,                            // ipv6 colon start
-        u"first.last@[IPv6::::b3:b4]"_qs,                          // ipv6 2x2x colon
-        u"first.last@[IPv6:a1:::b4]"_qs,                           // ipv6 2x2x colon
-        u"first.last@[IPv6:a1:]"_qs,                               // ipv6 colon end
-        u"first.last@[IPv6:a1:::]"_qs,                             // ipv6 2x2x colon
-        u"first.last@[IPv6:a1:a2:]"_qs,                            // ipv6 colon end
-        u"first.last@[IPv6:a1:a2:::]"_qs,                          // ipv6 2x2x colon
-        u"first.last@[IPv6::11.22.33.44]"_qs,                      // ipv6 colon start
-        u"first.last@[IPv6::::11.22.33.44]"_qs,                    // ipv6 2x2x colon
-        u"first.last@[IPv6:a1:11.22.33.44]"_qs,                    // ipv6 group count
-        u"first.last@[IPv6:a1:::11.22.33.44]"_qs,                  // ipv6 2x2x colon
-        u"first.last@[IPv6:a1:a2:::11.22.33.44]"_qs,               // ipv6 2x2x colon
-        u"first.last@[IPv6:0123:4567:89ab:cdef::11.22.33.xx]"_qs,  // ipv6 bad char
-        u"first.last@[IPv6:0123:4567:89ab:CDEFF::11.22.33.44]"_qs, // ipv6 bad char
-        u"first.last@[IPv6:a1::a4:b1::b4:11.22.33.44]"_qs,         // ipv6 2x2x colon
-        u"first.last@[IPv6:a1::11.22.33]"_qs,                      // ipv6 bad char
-        u"first.last@[IPv6:a1::11.22.33.44.55]"_qs,                // ipv6 bad char
-        u"first.last@[IPv6:a1::b211.22.33.44]"_qs,                 // ipv6 bad char
-        u"first.last@[IPv6:a1::b2::11.22.33.44]"_qs,               // ipv6 2x2x colon
-        u"first.last@[IPv6:a1::b3:]"_qs,                           // ipv6 colon end
-        u"first.last@[IPv6::a2::b4]"_qs,                           // ipv6 colon start
-        u"first.last@[IPv6:a1:a2:a3:a4:b1:b2:b3:]"_qs,             // ipv6 colon end
-        u"first.last@[IPv6::a2:a3:a4:b1:b2:b3:b4]"_qs,             // ipv6 colon end
-        u"first.last@[IPv6:a1:a2:a3:a4::b1:b2:b3:b4]"_qs           // ipv6 max groups
+        "123456789012345678901234567890123456789012345678901234567890.com"_s, // domain too long
+        u"foo@[\\1.2.3.4]"_s, // invalid domain literal containing obsolete chars
+        u"first.last@[IPv6:1111:2222:3333:4444:5555:6666:12.34.567.89]"_s, // ipv6 bad char
+        u"aaa@[123.123.123.333]"_s,                                        // invalid domain literal
+        u"first.last@[IPv6::]"_s,                                          // ipv6 colon start
+        u"first.last@[IPv6::::]"_s,                                        // ipv6 2x2x colon
+        u"first.last@[IPv6::b4]"_s,                                        // ipv6 colon start
+        u"first.last@[IPv6::::b4]"_s,                                      // ipv6 2x2x colon
+        u"first.last@[IPv6::b3:b4]"_s,                                     // ipv6 colon start
+        u"first.last@[IPv6::::b3:b4]"_s,                                   // ipv6 2x2x colon
+        u"first.last@[IPv6:a1:::b4]"_s,                                    // ipv6 2x2x colon
+        u"first.last@[IPv6:a1:]"_s,                                        // ipv6 colon end
+        u"first.last@[IPv6:a1:::]"_s,                                      // ipv6 2x2x colon
+        u"first.last@[IPv6:a1:a2:]"_s,                                     // ipv6 colon end
+        u"first.last@[IPv6:a1:a2:::]"_s,                                   // ipv6 2x2x colon
+        u"first.last@[IPv6::11.22.33.44]"_s,                               // ipv6 colon start
+        u"first.last@[IPv6::::11.22.33.44]"_s,                             // ipv6 2x2x colon
+        u"first.last@[IPv6:a1:11.22.33.44]"_s,                             // ipv6 group count
+        u"first.last@[IPv6:a1:::11.22.33.44]"_s,                           // ipv6 2x2x colon
+        u"first.last@[IPv6:a1:a2:::11.22.33.44]"_s,                        // ipv6 2x2x colon
+        u"first.last@[IPv6:0123:4567:89ab:cdef::11.22.33.xx]"_s,           // ipv6 bad char
+        u"first.last@[IPv6:0123:4567:89ab:CDEFF::11.22.33.44]"_s,          // ipv6 bad char
+        u"first.last@[IPv6:a1::a4:b1::b4:11.22.33.44]"_s,                  // ipv6 2x2x colon
+        u"first.last@[IPv6:a1::11.22.33]"_s,                               // ipv6 bad char
+        u"first.last@[IPv6:a1::11.22.33.44.55]"_s,                         // ipv6 bad char
+        u"first.last@[IPv6:a1::b211.22.33.44]"_s,                          // ipv6 bad char
+        u"first.last@[IPv6:a1::b2::11.22.33.44]"_s,                        // ipv6 2x2x colon
+        u"first.last@[IPv6:a1::b3:]"_s,                                    // ipv6 colon end
+        u"first.last@[IPv6::a2::b4]"_s,                                    // ipv6 colon start
+        u"first.last@[IPv6:a1:a2:a3:a4:b1:b2:b3:]"_s,                      // ipv6 colon end
+        u"first.last@[IPv6::a2:a3:a4:b1:b2:b3:b4]"_s,                      // ipv6 colon end
+        u"first.last@[IPv6:a1:a2:a3:a4::b1:b2:b3:b4]"_s                    // ipv6 max groups
     });
 
     QList<QString> errorEmails({
         // addresses are taken from
         // https://github.com/dominicsayers/isemail/blob/master/test/tests.xml
-        u" "_qs,                         // no domain
-        u"test"_qs,                      // no domain
-        u"@"_qs,                         // no local part
-        u"test@"_qs,                     // no domain
-        u"@io"_qs,                       // no local part
-        u"@iana.org"_qs,                 // no local part
-        u".test@iana.org"_qs,            // dot start
-        u"test.@iana.org"_qs,            // dot end
-        u"test..iana.org"_qs,            // consecutive dots
-        u"test_exa-mple.com"_qs,         // no domain
-        u"test\\@test@iana.org"_qs,      // expecting atext
-        u"test@-iana.org"_qs,            // domain hypen start
-        u"test@iana-.com"_qs,            // domain hypen end
-        u"test@.iana.org"_qs,            // dot start
-        u"test@iana.org."_qs,            // dot end
-        u"test@iana..com"_qs,            // consecutive dots
-        u"\"\"\"@iana.org"_qs,           // expecting atext
-        u"\"\\\"@iana.org"_qs,           // unclosed quoted string
-        u"test\"@iana.org"_qs,           // expecting atext
-        u"\"test@iana.org"_qs,           // unclosed quoted string
-        u"\"test\"test@iana.org"_qs,     // atext after quoted string
-        u"test\"text\"@iana.org"_qs,     // expecting atext
-        u"\"test\"\"test\"@iana.org"_qs, // expecting atext
-        // u"\"test\0\"@iana.org"_qs, // expecting qtext
-        u"test@a[255.255.255.255]"_qs,          // expecting atext
-        u"((comment)test@iana.org"_qs,          // unclosed comment
-        u"test(comment)test@iana.org"_qs,       // atext after comment
-        u"test@iana.org\n"_qs,                  // expecting atext
-        u"test@iana.org-"_qs,                   // domain hypehn end
-        u"\"test@iana.org"_qs,                  // unclosed quoted string
-        u"(test@iana.org"_qs,                   // unclosed comment
-        u"test@(iana.org"_qs,                   // unclosed comment
-        u"test@[1.2.3.4"_qs,                    // unclosed domain literal
-        u"\"test\\\"@iana.org"_qs,              // unclosed quoted string
-        u"(comment\\)test@iana.org"_qs,         // unclosed comment
-        u"test@iana.org(comment\\)"_qs,         // unclosed comment
-        u"test@iana.org(comment\\"_qs,          // backslash end
-        u"test@[RFC-5322]-domain-literal]"_qs,  // atext after domain literal
-        u"test@[RFC-5322-[domain-literal]"_qs,  // expecting dtext
-        u"test@[RFC-5322-domain-literal\\]"_qs, // unclosed domain literal
-        u"test@[RFC-5322-domain-literal\\"_qs,  // backslash end
-        u"@iana.org"_qs,                        // expecting atext
-        u"test@.org"_qs,                        // expecting atext
-        u"test@iana.org\r"_qs,                  // no lf after cr
-        u"\rtest@iana.org"_qs,                  // no lf after cr
-        u"\"\rtest\"@iana.org"_qs,              // no lf after cr
-        u"(\r)test@iana.org"_qs,                // no lf after cr
-        u"test@iana.org(\r)"_qs,                // no lf after cr
-        u"\ntest@iana.org"_qs,                  // expecting atext
-        u"\"\n\"@iana.org"_qs,                  // expecting qtext
-        u"(\n)test@iana.org"_qs,                // expecting ctext
-        u"\a@iana.org"_qs,                      // expecting atext
-        u"test@\a.org"_qs,                      // expecting atext
-        u"\r\ntest@iana.org"_qs,                // folding white space ends with CRLF
-        u"\r\n \r\ntest@iana.org"_qs,           // folding white space ends with CRLF
-        u" \r\ntest@iana.org"_qs,               // folding white space ends with CRLF
-        u" \r\n \r\ntest@iana.org"_qs,          // folding white space ends with CRLF
-        u" \r\n\r\ntest@iana.org"_qs,  // Folding White Space contains consecutive CRLF sequences
-        u" \r\n\r\n test@iana.org"_qs, // Folding White Space contains consecutive CRLF sequences
-        u"test@iana.org\r\n"_qs,       // Folding White Space ends with a CRLF sequence
-        u"test@iana.org\r\n \r\n"_qs,  // Folding White Space ends with a CRLF sequence
-        u"test@iana.org \r\n"_qs,      // Folding White Space ends with a CRLF sequence
-        u"test@iana.org \r\n \r\n"_qs, // Folding White Space ends with a CRLF sequence
-        u"test@iana.org \r\n\r\n"_qs,  // Folding White Space contains consecutive CRLF sequences
-        u"test@iana.org \r\n\r\n "_qs, // Folding White Space contains consecutive CRLF sequences
-        u"\"test\\©\"@iana.org"_qs,    // expecting quoted pair
+        u" "_s,                         // no domain
+        u"test"_s,                      // no domain
+        u"@"_s,                         // no local part
+        u"test@"_s,                     // no domain
+        u"@io"_s,                       // no local part
+        u"@iana.org"_s,                 // no local part
+        u".test@iana.org"_s,            // dot start
+        u"test.@iana.org"_s,            // dot end
+        u"test..iana.org"_s,            // consecutive dots
+        u"test_exa-mple.com"_s,         // no domain
+        u"test\\@test@iana.org"_s,      // expecting atext
+        u"test@-iana.org"_s,            // domain hypen start
+        u"test@iana-.com"_s,            // domain hypen end
+        u"test@.iana.org"_s,            // dot start
+        u"test@iana.org."_s,            // dot end
+        u"test@iana..com"_s,            // consecutive dots
+        u"\"\"\"@iana.org"_s,           // expecting atext
+        u"\"\\\"@iana.org"_s,           // unclosed quoted string
+        u"test\"@iana.org"_s,           // expecting atext
+        u"\"test@iana.org"_s,           // unclosed quoted string
+        u"\"test\"test@iana.org"_s,     // atext after quoted string
+        u"test\"text\"@iana.org"_s,     // expecting atext
+        u"\"test\"\"test\"@iana.org"_s, // expecting atext
+        // u"\"test\0\"@iana.org"_s, // expecting qtext
+        u"test@a[255.255.255.255]"_s,          // expecting atext
+        u"((comment)test@iana.org"_s,          // unclosed comment
+        u"test(comment)test@iana.org"_s,       // atext after comment
+        u"test@iana.org\n"_s,                  // expecting atext
+        u"test@iana.org-"_s,                   // domain hypehn end
+        u"\"test@iana.org"_s,                  // unclosed quoted string
+        u"(test@iana.org"_s,                   // unclosed comment
+        u"test@(iana.org"_s,                   // unclosed comment
+        u"test@[1.2.3.4"_s,                    // unclosed domain literal
+        u"\"test\\\"@iana.org"_s,              // unclosed quoted string
+        u"(comment\\)test@iana.org"_s,         // unclosed comment
+        u"test@iana.org(comment\\)"_s,         // unclosed comment
+        u"test@iana.org(comment\\"_s,          // backslash end
+        u"test@[RFC-5322]-domain-literal]"_s,  // atext after domain literal
+        u"test@[RFC-5322-[domain-literal]"_s,  // expecting dtext
+        u"test@[RFC-5322-domain-literal\\]"_s, // unclosed domain literal
+        u"test@[RFC-5322-domain-literal\\"_s,  // backslash end
+        u"@iana.org"_s,                        // expecting atext
+        u"test@.org"_s,                        // expecting atext
+        u"test@iana.org\r"_s,                  // no lf after cr
+        u"\rtest@iana.org"_s,                  // no lf after cr
+        u"\"\rtest\"@iana.org"_s,              // no lf after cr
+        u"(\r)test@iana.org"_s,                // no lf after cr
+        u"test@iana.org(\r)"_s,                // no lf after cr
+        u"\ntest@iana.org"_s,                  // expecting atext
+        u"\"\n\"@iana.org"_s,                  // expecting qtext
+        u"(\n)test@iana.org"_s,                // expecting ctext
+        u"\a@iana.org"_s,                      // expecting atext
+        u"test@\a.org"_s,                      // expecting atext
+        u"\r\ntest@iana.org"_s,                // folding white space ends with CRLF
+        u"\r\n \r\ntest@iana.org"_s,           // folding white space ends with CRLF
+        u" \r\ntest@iana.org"_s,               // folding white space ends with CRLF
+        u" \r\n \r\ntest@iana.org"_s,          // folding white space ends with CRLF
+        u" \r\n\r\ntest@iana.org"_s,  // Folding White Space contains consecutive CRLF sequences
+        u" \r\n\r\n test@iana.org"_s, // Folding White Space contains consecutive CRLF sequences
+        u"test@iana.org\r\n"_s,       // Folding White Space ends with a CRLF sequence
+        u"test@iana.org\r\n \r\n"_s,  // Folding White Space ends with a CRLF sequence
+        u"test@iana.org \r\n"_s,      // Folding White Space ends with a CRLF sequence
+        u"test@iana.org \r\n \r\n"_s, // Folding White Space ends with a CRLF sequence
+        u"test@iana.org \r\n\r\n"_s,  // Folding White Space contains consecutive CRLF sequences
+        u"test@iana.org \r\n\r\n "_s, // Folding White Space contains consecutive CRLF sequences
+        u"\"test\\©\"@iana.org"_s,    // expecting quoted pair
 
         // addresses are taken from
         // https://github.com/dominicsayers/isemail/blob/master/test/tests-original.xml
-        u"first.last@sub.do,com"_qs,                // expecting atext
-        u"first\\@last@iana.org"_qs,                // expecting atext
-        u"first.last"_qs,                           // no domain
-        u".first.last@iana.org"_qs,                 // dot start
-        u"first.last.@iana.org"_qs,                 // dot end
-        u"first..last@iana.org"_qs,                 // consecutive dots
-        u"\"first\"last\"@iana.org"_qs,             // atext after quoted string
-        u"\"\"\"@iana.org"_qs,                      // expecting atext
-        u"\"\\\"@iana.org"_qs,                      // unclosed quoted string
-        u"first\\\\@last@iana.org"_qs,              // expecting atext
-        u"first.last@"_qs,                          // no domain
-        u"first.last@-xample.com"_qs,               // domain hyphen start
-        u"first.last@exampl-.com"_qs,               // domain hyphen end
-        u"abc\\@def@iana.org"_qs,                   // expecting atext
-        u"abc\\\\@iana.org"_qs,                     // expecting atext
-        u"Doug\\ \\\"Ace\\\"\\ Lovell@iana.org"_qs, // expecting atext
-        u"abc@def@iana.org"_qs,                     // expecting atext
-        u"abc\\\\@def@iana.org"_qs,                 // expecting atext
-        u"abc\\@iana.org"_qs,                       // expecting atext
-        u"@iana.org"_qs,                            // no local part
-        u"doug@"_qs,                                // no domain
-        u"\"qu@iana.org"_qs,                        // unclosed quoted string
-        u"ote\"@iana.org"_qs,                       // expecting atext
-        u".dot@iana.org"_qs,                        // dot start
-        u"dot.@iana.org"_qs,                        // dot end
-        u"two..dot@iana.org"_qs,                    // consecutive dots
-        u"\"Doug \"Ace\" L.\"@iana.org"_qs,         // atext after quoted string
-        u"Doug\\ \\\"Ace\\\"\\ L\\.@iana.org"_qs,   // expecting atext
-        u"hello world@iana.org"_qs,                 // atext after folding white space
-        u"gatsby@f.sc.ot.t.f.i.tzg.era.l.d."_qs,    // dot end
-        u"test.iana.org"_qs,                        // no domain
-        u"test.@iana.org"_qs,                       // dot end
-        u"test..test@iana.org"_qs,                  // consecutive dots
-        u".test@iana.org"_qs,                       // dot start
-        u"test@test@iana.org"_qs,                   // expecting atext
-        u"test@@iana.org"_qs,                       // expecting atext
-        u"-- test --@iana.org"_qs,                  // atext after folding white space
-        u"[test]@iana.org"_qs,                      // expecting atext
-        u"\"test\"test\"@iana.org"_qs,              // atext after quoted string
-        u"()[]\\;:,><@iana.org"_qs,                 // expecting atext
-        u"test@."_qs,                               // dot start
-        u"test@example."_qs,                        // dot end
-        u"test@.org"_qs,                            // dot start
-        u"test@[123.123.123.123"_qs,                // unclosed domain literal
-        u"test@123.123.123.123]"_qs,                // expecting atext
-        u"NotAnEmail"_qs,                           // no domain
-        u"@NotAnEmail"_qs,                          // no local part
-        u"\"test\rblah\"@iana.org"_qs,              // cr no lf
-        u"\"test\"blah\"@iana.org"_qs,              // atext after quoted string
-        u".wooly@iana.org"_qs,                      // dot start
-        u"wo..oly@iana.org"_qs,                     // consecutive dots
-        u"pootietang.@iana.org"_qs,                 // dot end
-        u".@iana.org"_qs,                           // dot start
-        u"Ima Fool@iana.org"_qs,                    // atext after white space
-        u"phil.h\\@\\@ck@haacked.com"_qs,           // expecting atext
-        u"\"first\\\\\"last\"@iana.org"_qs,         // atext after quoted string
-        u"first\\last@iana.org"_qs,                 // expecting atext
-        u"Abc\\@def@iana.org"_qs,                   // expecting atext
-        u"Fred\\ Bloggs@iana.org"_qs,               // expectin atext
-        u"Joe.\\\\Blow@iana.org"_qs,                // expecting atext
-        u"\"test\\\r\n blah\"@iana.org"_qs,         // expecting qtext
-        u"{^c\\@**Dog^}@cartoon.com"_qs,            // expecting atext
-        u"cal(foo(bar)@iamcal.com"_qs,              // unclosed comment
-        u"cal(foo)bar)@iamcal.com"_qs,              // atext after comment
-        u"cal(foo\\)@iamcal.com"_qs,                // unclosed comment
+        u"first.last@sub.do,com"_s,                // expecting atext
+        u"first\\@last@iana.org"_s,                // expecting atext
+        u"first.last"_s,                           // no domain
+        u".first.last@iana.org"_s,                 // dot start
+        u"first.last.@iana.org"_s,                 // dot end
+        u"first..last@iana.org"_s,                 // consecutive dots
+        u"\"first\"last\"@iana.org"_s,             // atext after quoted string
+        u"\"\"\"@iana.org"_s,                      // expecting atext
+        u"\"\\\"@iana.org"_s,                      // unclosed quoted string
+        u"first\\\\@last@iana.org"_s,              // expecting atext
+        u"first.last@"_s,                          // no domain
+        u"first.last@-xample.com"_s,               // domain hyphen start
+        u"first.last@exampl-.com"_s,               // domain hyphen end
+        u"abc\\@def@iana.org"_s,                   // expecting atext
+        u"abc\\\\@iana.org"_s,                     // expecting atext
+        u"Doug\\ \\\"Ace\\\"\\ Lovell@iana.org"_s, // expecting atext
+        u"abc@def@iana.org"_s,                     // expecting atext
+        u"abc\\\\@def@iana.org"_s,                 // expecting atext
+        u"abc\\@iana.org"_s,                       // expecting atext
+        u"@iana.org"_s,                            // no local part
+        u"doug@"_s,                                // no domain
+        u"\"qu@iana.org"_s,                        // unclosed quoted string
+        u"ote\"@iana.org"_s,                       // expecting atext
+        u".dot@iana.org"_s,                        // dot start
+        u"dot.@iana.org"_s,                        // dot end
+        u"two..dot@iana.org"_s,                    // consecutive dots
+        u"\"Doug \"Ace\" L.\"@iana.org"_s,         // atext after quoted string
+        u"Doug\\ \\\"Ace\\\"\\ L\\.@iana.org"_s,   // expecting atext
+        u"hello world@iana.org"_s,                 // atext after folding white space
+        u"gatsby@f.sc.ot.t.f.i.tzg.era.l.d."_s,    // dot end
+        u"test.iana.org"_s,                        // no domain
+        u"test.@iana.org"_s,                       // dot end
+        u"test..test@iana.org"_s,                  // consecutive dots
+        u".test@iana.org"_s,                       // dot start
+        u"test@test@iana.org"_s,                   // expecting atext
+        u"test@@iana.org"_s,                       // expecting atext
+        u"-- test --@iana.org"_s,                  // atext after folding white space
+        u"[test]@iana.org"_s,                      // expecting atext
+        u"\"test\"test\"@iana.org"_s,              // atext after quoted string
+        u"()[]\\;:,><@iana.org"_s,                 // expecting atext
+        u"test@."_s,                               // dot start
+        u"test@example."_s,                        // dot end
+        u"test@.org"_s,                            // dot start
+        u"test@[123.123.123.123"_s,                // unclosed domain literal
+        u"test@123.123.123.123]"_s,                // expecting atext
+        u"NotAnEmail"_s,                           // no domain
+        u"@NotAnEmail"_s,                          // no local part
+        u"\"test\rblah\"@iana.org"_s,              // cr no lf
+        u"\"test\"blah\"@iana.org"_s,              // atext after quoted string
+        u".wooly@iana.org"_s,                      // dot start
+        u"wo..oly@iana.org"_s,                     // consecutive dots
+        u"pootietang.@iana.org"_s,                 // dot end
+        u".@iana.org"_s,                           // dot start
+        u"Ima Fool@iana.org"_s,                    // atext after white space
+        u"phil.h\\@\\@ck@haacked.com"_s,           // expecting atext
+        u"\"first\\\\\"last\"@iana.org"_s,         // atext after quoted string
+        u"first\\last@iana.org"_s,                 // expecting atext
+        u"Abc\\@def@iana.org"_s,                   // expecting atext
+        u"Fred\\ Bloggs@iana.org"_s,               // expectin atext
+        u"Joe.\\\\Blow@iana.org"_s,                // expecting atext
+        u"\"test\\\r\n blah\"@iana.org"_s,         // expecting qtext
+        u"{^c\\@**Dog^}@cartoon.com"_s,            // expecting atext
+        u"cal(foo(bar)@iamcal.com"_s,              // unclosed comment
+        u"cal(foo)bar)@iamcal.com"_s,              // atext after comment
+        u"cal(foo\\)@iamcal.com"_s,                // unclosed comment
         u"first(12345678901234567890123456789012345678901234567890)last@("
         "123456789012345678901234567890123456789012345678901234567890123456789012345"
         "678901234567890123456789012345678901234567890123456789012345678901234567890"
         "123456789012345678901234567890123456789012345678901234567890123456789012345"
-        "6789012345678901234567890)iana.org"_qs, // atext after comment
-        u"first(middle)last@iana.org"_qs,        // atext after comment
+        "6789012345678901234567890)iana.org"_s, // atext after comment
+        u"first(middle)last@iana.org"_s,        // atext after comment
         u"first(abc(\"def\".ghi).mno)middle(abc(\"def\".ghi).mno).last@(abc(\"def\"."
         "ghi).mno)example(abc(\"def\".ghi).mno).(abc(\"def\".ghi).mno)com(abc("
-        "\"def\".ghi).mno)"_qs,                              // atext after comment
-        u"a(a(b(c)d(e(f))g)(h(i)j)@iana.org"_qs,             // unclosed comment
-        u".@"_qs,                                            // dot start
-        u"@bar.com"_qs,                                      // no local part
-        u"@@bar.com"_qs,                                     // no local part
-        u"aaa.com"_qs,                                       // no domain
-        u"aaa@.com"_qs,                                      // dot start
-        u"aaa@.123"_qs,                                      // dot start
-        u"aaa@[123.123.123.123]a"_qs,                        // atext after domain literal
-        u"a@bar.com."_qs,                                    // dot end
-        u"a@-b.com"_qs,                                      // domain hyphen start
-        u"a@b-.com"_qs,                                      // domain hypen end
-        u"-@..com"_qs,                                       // dot start
-        u"-@a..com"_qs,                                      // consecutive dots
-        u"invalid@about.museum-"_qs,                         // domain hyphen end
-        u"test@...........com"_qs,                           // dot start
-        u"Invalid \\\n Folding \\\n Whitespace@iana.org"_qs, // atext after white space
+        "\"def\".ghi).mno)"_s,                              // atext after comment
+        u"a(a(b(c)d(e(f))g)(h(i)j)@iana.org"_s,             // unclosed comment
+        u".@"_s,                                            // dot start
+        u"@bar.com"_s,                                      // no local part
+        u"@@bar.com"_s,                                     // no local part
+        u"aaa.com"_s,                                       // no domain
+        u"aaa@.com"_s,                                      // dot start
+        u"aaa@.123"_s,                                      // dot start
+        u"aaa@[123.123.123.123]a"_s,                        // atext after domain literal
+        u"a@bar.com."_s,                                    // dot end
+        u"a@-b.com"_s,                                      // domain hyphen start
+        u"a@b-.com"_s,                                      // domain hypen end
+        u"-@..com"_s,                                       // dot start
+        u"-@a..com"_s,                                      // consecutive dots
+        u"invalid@about.museum-"_s,                         // domain hyphen end
+        u"test@...........com"_s,                           // dot start
+        u"Invalid \\\n Folding \\\n Whitespace@iana.org"_s, // atext after white space
         // Folding White Space contains consecutive CRLF sequences
-        u"test.\r\n\r\n obs@syntax.com"_qs,
-        // u"\"Unicode NULL \0\"@char.com"_qs, // expecting qtext
-        // u"Unicode NULL \\0@char.com"_qs, // atext after cfws
-        u"test@example.com\n"_qs // expecting atext
+        u"test.\r\n\r\n obs@syntax.com"_s,
+        // u"\"Unicode NULL \0\"@char.com"_s, // expecting qtext
+        // u"Unicode NULL \\0@char.com"_s, // atext after cfws
+        u"test@example.com\n"_s // expecting atext
     });
 
     int count = 0;
     for (const QString &email : validEmails) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(email);
-        QTest::newRow(u"valid-valid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/emailValid"_qs << body << valid;
+        QTest::newRow(u"valid-valid-%1"_s.arg(count).toUtf8().constData())
+            << u"/emailValid"_s << body << valid;
         count++;
     }
 
     count = 0;
-    for (const QString &email : {u"test@hüssenbergnetz.de"_qs,
-                                 u"täst@huessenbergnetz.de"_qs,
-                                 u"täst@hüssenbergnetz.de"_qs}) {
+    for (const QString &email :
+         {u"test@hüssenbergnetz.de"_s, u"täst@huessenbergnetz.de"_s, u"täst@hüssenbergnetz.de"_s}) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(email);
-        QTest::newRow(u"valid-invalid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/emailValid"_qs << body << invalid;
+        QTest::newRow(u"valid-invalid-%1"_s.arg(count).toUtf8().constData())
+            << u"/emailValid"_s << body << invalid;
         count++;
     }
 
     if (qEnvironmentVariableIsSet("CUTELYST_VALIDATORS_TEST_NETWORK")) {
-        QTest::newRow("valid-dns") << u"/emailDnsWarnValid"_qs
+        QTest::newRow("valid-dns") << u"/emailDnsWarnValid"_s
                                    << QByteArrayLiteral("field=test@huessenbergnetz.de") << valid;
         count = 0;
         for (const QString &email : dnsWarnEmails) {
             const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(email);
-            QTest::newRow(u"dnswarn-valid-%1"_qs.arg(count).toUtf8().constData())
-                << u"/emailDnsWarnValid"_qs << body << invalid;
+            QTest::newRow(u"dnswarn-valid-%1"_s.arg(count).toUtf8().constData())
+                << u"/emailDnsWarnValid"_s << body << invalid;
             count++;
         }
     }
@@ -2528,90 +2509,90 @@ void TestValidator::testValidatorEmail_data()
     count = 0;
     for (const QString &email : rfc5321Emails) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(email);
-        QTest::newRow(u"rfc5321-valid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/emailRfc5321Valid"_qs << body << valid;
+        QTest::newRow(u"rfc5321-valid-%1"_s.arg(count).toUtf8().constData())
+            << u"/emailRfc5321Valid"_s << body << valid;
         count++;
     }
 
     count = 0;
     for (const QString &email : rfc5321Emails) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(email);
-        QTest::newRow(u"rfc5321-invalid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/emailRfc5321Invalid"_qs << body << invalid;
+        QTest::newRow(u"rfc5321-invalid-%1"_s.arg(count).toUtf8().constData())
+            << u"/emailRfc5321Invalid"_s << body << invalid;
         count++;
     }
 
     count = 0;
     for (const QString &email : cfwsEmails) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(email);
-        QTest::newRow(u"cfws-valid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/emailCfwsValid"_qs << body << valid;
+        QTest::newRow(u"cfws-valid-%1"_s.arg(count).toUtf8().constData())
+            << u"/emailCfwsValid"_s << body << valid;
         count++;
     }
 
     count = 0;
     for (const QString &email : deprecatedEmails) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(email);
-        QTest::newRow(u"deprecated-valid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/emailDeprecatedValid"_qs << body << valid;
+        QTest::newRow(u"deprecated-valid-%1"_s.arg(count).toUtf8().constData())
+            << u"/emailDeprecatedValid"_s << body << valid;
         count++;
     }
 
     count = 0;
     for (const QString &email : deprecatedEmails) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(email);
-        QTest::newRow(u"deprecated-invalid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/emailDeprecatedInvalid"_qs << body << invalid;
+        QTest::newRow(u"deprecated-invalid-%1"_s.arg(count).toUtf8().constData())
+            << u"/emailDeprecatedInvalid"_s << body << invalid;
         count++;
     }
 
     count = 0;
     for (const QString &email : rfc5322Emails) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(email);
-        QTest::newRow(u"rfc5322-valid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/emailRfc5322Valid"_qs << body << valid;
+        QTest::newRow(u"rfc5322-valid-%1"_s.arg(count).toUtf8().constData())
+            << u"/emailRfc5322Valid"_s << body << valid;
         count++;
     }
 
     count = 0;
     for (const QString &email : rfc5322Emails) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(email);
-        QTest::newRow(u"rfc5322-invalid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/emailRfc5322Invalid"_qs << body << invalid;
+        QTest::newRow(u"rfc5322-invalid-%1"_s.arg(count).toUtf8().constData())
+            << u"/emailRfc5322Invalid"_s << body << invalid;
         count++;
     }
 
     count = 0;
     for (const QString &email : errorEmails) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(email);
-        QTest::newRow(u"errors-invalid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/emailErrors"_qs << body << invalid;
+        QTest::newRow(u"errors-invalid-%1"_s.arg(count).toUtf8().constData())
+            << u"/emailErrors"_s << body << invalid;
         count++;
     }
 
     {
         QByteArray body =
-            QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"test@hüssenbergnetz.de"_qs);
-        QTest::newRow("idnallowed-valid") << u"/emailIdnAllowed"_qs << body << valid;
+            QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"test@hüssenbergnetz.de"_s);
+        QTest::newRow("idnallowed-valid") << u"/emailIdnAllowed"_s << body << valid;
 
-        body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"täst@hüssenbergnetz.de"_qs);
-        QTest::newRow("idnallowed-invalid") << u"/emailIdnAllowed"_qs << body << invalid;
+        body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"täst@hüssenbergnetz.de"_s);
+        QTest::newRow("idnallowed-invalid") << u"/emailIdnAllowed"_s << body << invalid;
 
-        body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"täst@huessenbergnetz.de"_qs);
-        QTest::newRow("utf8localallowed-valid") << u"/emailUtf8Local"_qs << body << valid;
+        body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"täst@huessenbergnetz.de"_s);
+        QTest::newRow("utf8localallowed-valid") << u"/emailUtf8Local"_s << body << valid;
 
-        body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"täst@hüssenbergnetz.de"_qs);
-        QTest::newRow("utf8localallowed-invalid") << u"/emailUtf8Local"_qs << body << invalid;
+        body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"täst@hüssenbergnetz.de"_s);
+        QTest::newRow("utf8localallowed-invalid") << u"/emailUtf8Local"_s << body << invalid;
 
-        body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"täst@hüssenbergnetz.de"_qs);
-        QTest::newRow("utf8allowed-valid-0") << u"/emailUtf8"_qs << body << valid;
+        body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(u"täst@hüssenbergnetz.de"_s);
+        QTest::newRow("utf8allowed-valid-0") << u"/emailUtf8"_s << body << valid;
     }
 
     count = 1;
     for (const QString &email : validEmails) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(email);
-        QTest::newRow(u"utf8allowed-valid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/emailUtf8"_qs << body << valid;
+        QTest::newRow(u"utf8allowed-valid-%1"_s.arg(count).toUtf8().constData())
+            << u"/emailUtf8"_s << body << valid;
         count++;
     }
 
@@ -2625,12 +2606,12 @@ void TestValidator::testValidatorEmail_data()
     count = 0;
     for (const QString &email : utf8InvalidEmails) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(email);
-        QTest::newRow(u"utf8allowed-invalid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/emailUtf8"_qs << body << invalid;
+        QTest::newRow(u"utf8allowed-invalid-%1"_s.arg(count).toUtf8().constData())
+            << u"/emailUtf8"_s << body << invalid;
         count++;
     }
 
-    QTest::newRow("empty") << u"/emailValid"_qs << QByteArrayLiteral("field=") << valid;
+    QTest::newRow("empty") << u"/emailValid"_s << QByteArrayLiteral("field=") << valid;
 }
 
 void TestValidator::testValidatorFileSize_data()
@@ -2643,167 +2624,167 @@ void TestValidator::testValidatorFileSize_data()
 
     int count = 0;
     for (const QString &size :
-         {u"1M"_qs,      u"M1"_qs,        u"1 G"_qs,      u"G 1"_qs,         u"1.5 G"_qs,
-          u"G 1.5"_qs,   u"2.345 TiB"_qs, u"TiB2.345"_qs, u"5B"_qs,          u"B5"_qs,
-          u"5 B"_qs,     u"B 5"_qs,       u" 2.0 Gi"_qs,  u" Gi 2.0"_qs,     u"2.0 Gi "_qs,
-          u"Gi 2.0 "_qs, u" 2.0 Gi "_qs,  u" Gi 2.0 "_qs, u" 2.0    Gi "_qs, u" Gi    2.0 "_qs,
-          u"3.67YB"_qs,  u"YB3.67"_qs,    u"1"_qs,        u"1024"_qs,        u".5MB"_qs,
-          u"MB.5"_qs}) {
+         {u"1M"_s,      u"M1"_s,        u"1 G"_s,      u"G 1"_s,         u"1.5 G"_s,
+          u"G 1.5"_s,   u"2.345 TiB"_s, u"TiB2.345"_s, u"5B"_s,          u"B5"_s,
+          u"5 B"_s,     u"B 5"_s,       u" 2.0 Gi"_s,  u" Gi 2.0"_s,     u"2.0 Gi "_s,
+          u"Gi 2.0 "_s, u" 2.0 Gi "_s,  u" Gi 2.0 "_s, u" 2.0    Gi "_s, u" Gi    2.0 "_s,
+          u"3.67YB"_s,  u"YB3.67"_s,    u"1"_s,        u"1024"_s,        u".5MB"_s,
+          u"MB.5"_s}) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(size);
-        QTest::newRow(u"valid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/fileSize"_qs << body << valid;
+        QTest::newRow(u"valid-%1"_s.arg(count).toUtf8().constData())
+            << u"/fileSize"_s << body << valid;
         count++;
     }
 
     count = 0;
-    for (const QString &size : {u"1QiB"_qs,
-                                u"QiB1"_qs,
-                                u" 1QiB"_qs,
-                                u" QiB1"_qs,
-                                u"1QiB "_qs,
-                                u"QiB1 "_qs,
-                                u"1 QiB"_qs,
-                                u"Q iB1"_qs,
-                                u"1   QiB"_qs,
-                                u"Q   iB1"_qs,
-                                u"1..4 G"_qs,
-                                u"G 1..4"_qs,
-                                u"1iB"_qs,
-                                u"iB1"_qs,
-                                u"1Byte"_qs,
-                                u"Byte1"_qs,
-                                u"1024iK"_qs,
-                                u"iK 2048"_qs}) {
+    for (const QString &size : {u"1QiB"_s,
+                                u"QiB1"_s,
+                                u" 1QiB"_s,
+                                u" QiB1"_s,
+                                u"1QiB "_s,
+                                u"QiB1 "_s,
+                                u"1 QiB"_s,
+                                u"Q iB1"_s,
+                                u"1   QiB"_s,
+                                u"Q   iB1"_s,
+                                u"1..4 G"_s,
+                                u"G 1..4"_s,
+                                u"1iB"_s,
+                                u"iB1"_s,
+                                u"1Byte"_s,
+                                u"Byte1"_s,
+                                u"1024iK"_s,
+                                u"iK 2048"_s}) {
         const QByteArray body = QByteArrayLiteral("field=") + QUrl::toPercentEncoding(size);
-        QTest::newRow(u"invalid-%1"_qs.arg(count).toUtf8().constData())
-            << u"/fileSize"_qs << body << invalid;
+        QTest::newRow(u"invalid-%1"_s.arg(count).toUtf8().constData())
+            << u"/fileSize"_s << body << invalid;
         count++;
     }
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"1,5M"_qs);
-    query.addQueryItem(u"locale"_qs, u"de"_qs);
+    query.addQueryItem(u"field"_s, u"1,5M"_s);
+    query.addQueryItem(u"locale"_s, u"de"_s);
     QTest::newRow("locale-de-valid")
-        << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"1.5M"_qs);
-    query.addQueryItem(u"locale"_qs, u"de"_qs);
+    query.addQueryItem(u"field"_s, u"1.5M"_s);
+    query.addQueryItem(u"locale"_s, u"de"_s);
     QTest::newRow("locale-de-invalid")
-        << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     // disabled on MSVC because that shit still has problems with utf8 in 2018...
 #ifndef _MSC_VER
     query.clear();
-    query.addQueryItem(u"field"_qs, u"1٫5M"_qs);
-    query.addQueryItem(u"locale"_qs, u"ar"_qs);
+    query.addQueryItem(u"field"_s, u"1٫5M"_s);
+    query.addQueryItem(u"locale"_s, u"ar"_s);
     QTest::newRow("locale-ar-valid")
-        << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 #endif
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"1.5M"_qs);
-    query.addQueryItem(u"locale"_qs, u"ar"_qs);
+    query.addQueryItem(u"field"_s, u"1.5M"_s);
+    query.addQueryItem(u"locale"_s, u"ar"_s);
     QTest::newRow("locale-ar-invalid")
-        << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"1.5TiB"_qs);
-    query.addQueryItem(u"option"_qs, u"OnlyBinary"_qs);
+    query.addQueryItem(u"field"_s, u"1.5TiB"_s);
+    query.addQueryItem(u"option"_s, u"OnlyBinary"_s);
     QTest::newRow("onlybinary-valid")
-        << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"1.5TB"_qs);
-    query.addQueryItem(u"option"_qs, u"OnlyBinary"_qs);
+    query.addQueryItem(u"field"_s, u"1.5TB"_s);
+    query.addQueryItem(u"option"_s, u"OnlyBinary"_s);
     QTest::newRow("onlybinary-invalid")
-        << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"1.5TB"_qs);
-    query.addQueryItem(u"option"_qs, u"OnlyDecimal"_qs);
+    query.addQueryItem(u"field"_s, u"1.5TB"_s);
+    query.addQueryItem(u"option"_s, u"OnlyDecimal"_s);
     QTest::newRow("onlydecimyl-valid")
-        << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"1.5TiB"_qs);
-    query.addQueryItem(u"option"_qs, u"OnlyDecimal"_qs);
+    query.addQueryItem(u"field"_s, u"1.5TiB"_s);
+    query.addQueryItem(u"option"_s, u"OnlyDecimal"_s);
     QTest::newRow("onlydecimyl-invalid")
-        << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"2K"_qs);
-    query.addQueryItem(u"min"_qs, u"1000"_qs);
-    QTest::newRow("min-valid") << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"2K"_s);
+    query.addQueryItem(u"min"_s, u"1000"_s);
+    QTest::newRow("min-valid") << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"2K"_qs);
-    query.addQueryItem(u"min"_qs, u"2048"_qs);
-    QTest::newRow("min-invalid") << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"2K"_s);
+    query.addQueryItem(u"min"_s, u"2048"_s);
+    QTest::newRow("min-invalid") << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                  << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"2KiB"_qs);
-    query.addQueryItem(u"max"_qs, u"2048"_qs);
-    QTest::newRow("max-valid") << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"2KiB"_s);
+    query.addQueryItem(u"max"_s, u"2048"_s);
+    QTest::newRow("max-valid") << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"2KiB"_qs);
-    query.addQueryItem(u"max"_qs, u"2047"_qs);
-    QTest::newRow("max-invalid") << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"2KiB"_s);
+    query.addQueryItem(u"max"_s, u"2047"_s);
+    QTest::newRow("max-invalid") << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                  << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"2KiB"_qs);
-    query.addQueryItem(u"min"_qs, u"2048"_qs);
-    query.addQueryItem(u"max"_qs, u"2048"_qs);
+    query.addQueryItem(u"field"_s, u"2KiB"_s);
+    query.addQueryItem(u"min"_s, u"2048"_s);
+    query.addQueryItem(u"max"_s, u"2048"_s);
     QTest::newRow("min-max-valid")
-        << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"0.5KiB"_qs);
-    query.addQueryItem(u"min"_qs, u"1024"_qs);
-    query.addQueryItem(u"max"_qs, u"2048"_qs);
+    query.addQueryItem(u"field"_s, u"0.5KiB"_s);
+    query.addQueryItem(u"min"_s, u"1024"_s);
+    query.addQueryItem(u"max"_s, u"2048"_s);
     QTest::newRow("min-max-invalid-1")
-        << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"3.5KiB"_qs);
-    query.addQueryItem(u"min"_qs, u"1024"_qs);
-    query.addQueryItem(u"max"_qs, u"2048"_qs);
+    query.addQueryItem(u"field"_s, u"3.5KiB"_s);
+    query.addQueryItem(u"min"_s, u"1024"_s);
+    query.addQueryItem(u"max"_s, u"2048"_s);
     QTest::newRow("min-max-invalid-2")
-        << u"/fileSize"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/fileSize"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     // **** Start testing ValidatorFileSize with return values
 
-    const QMap<QString, QString> fileSizes({{u"1"_qs, u"1"_qs},
-                                            {u"1B"_qs, u"1"_qs},
-                                            {u"1K"_qs, u"1000"_qs},
-                                            {u"1KiB"_qs, u"1024"_qs},
-                                            {u"3.45K"_qs, u"3450"_qs},
-                                            {u"3.45KiB"_qs, u"3533"_qs},
-                                            {u"3456MB"_qs, u"3456000000"_qs},
-                                            {u"3456MiB"_qs, u"3623878656"_qs},
-                                            {u"4.321GB"_qs, u"4321000000"_qs},
-                                            {u"4.321GiB"_qs, u"4639638422"_qs},
-                                            {u"45.7890TB"_qs, u"45789000000000"_qs},
-                                            {u"45.7890TiB"_qs, u"50345537924235"_qs},
-                                            {u"123.456789PB"_qs, u"123456789000000000"_qs},
-                                            {u"123.456789PiB"_qs, u"138999987234189488"_qs},
-                                            {u"1.23EB"_qs, u"1230000000000000000"_qs},
-                                            {u"1.23EiB"_qs, u"1418093450666421760"_qs},
-                                            {u"2ZB"_qs, u"2000000000000000000000.00"_qs},
-                                            {u"2ZiB"_qs, u"2361183241434822606848.00"_qs}});
+    const QMap<QString, QString> fileSizes({{u"1"_s, u"1"_s},
+                                            {u"1B"_s, u"1"_s},
+                                            {u"1K"_s, u"1000"_s},
+                                            {u"1KiB"_s, u"1024"_s},
+                                            {u"3.45K"_s, u"3450"_s},
+                                            {u"3.45KiB"_s, u"3533"_s},
+                                            {u"3456MB"_s, u"3456000000"_s},
+                                            {u"3456MiB"_s, u"3623878656"_s},
+                                            {u"4.321GB"_s, u"4321000000"_s},
+                                            {u"4.321GiB"_s, u"4639638422"_s},
+                                            {u"45.7890TB"_s, u"45789000000000"_s},
+                                            {u"45.7890TiB"_s, u"50345537924235"_s},
+                                            {u"123.456789PB"_s, u"123456789000000000"_s},
+                                            {u"123.456789PiB"_s, u"138999987234189488"_s},
+                                            {u"1.23EB"_s, u"1230000000000000000"_s},
+                                            {u"1.23EiB"_s, u"1418093450666421760"_s},
+                                            {u"2ZB"_s, u"2000000000000000000000.00"_s},
+                                            {u"2ZiB"_s, u"2361183241434822606848.00"_s}});
 
     count            = 0;
     auto fileSizesIt = fileSizes.constBegin();
     while (fileSizesIt != fileSizes.constEnd()) {
         query.clear();
-        query.addQueryItem(u"field"_qs, fileSizesIt.key());
-        QTest::newRow(u"return-value-%1"_qs.arg(count).toUtf8().constData())
-            << u"/fileSizeValue"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+        query.addQueryItem(u"field"_s, fileSizesIt.key());
+        QTest::newRow(u"return-value-%1"_s.arg(count).toUtf8().constData())
+            << u"/fileSizeValue"_s << query.toString(QUrl::FullyEncoded).toLatin1()
             << fileSizesIt.value().toUtf8();
         ++fileSizesIt;
         count++;
@@ -2819,15 +2800,15 @@ void TestValidator::testValidatorFilled_data()
     // **** Start testing ValidatorFilled *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"toll"_qs);
-    QTest::newRow("valid") << u"/filled"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"toll"_s);
+    QTest::newRow("valid") << u"/filled"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                            << valid;
 
-    QTest::newRow("missing") << u"/filled"_qs << QByteArray() << valid;
+    QTest::newRow("missing") << u"/filled"_s << QByteArray() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    QTest::newRow("invalid") << u"/filled"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    QTest::newRow("invalid") << u"/filled"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << invalid;
 }
 
@@ -2840,19 +2821,19 @@ void TestValidator::testValidatorIn_data()
     // **** Start testing ValidatorIn *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"zwei"_qs);
-    QTest::newRow("valid") << u"/in"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+    query.addQueryItem(u"field"_s, u"zwei"_s);
+    QTest::newRow("valid") << u"/in"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"vier"_qs);
-    QTest::newRow("invalid") << u"/in"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"vier"_s);
+    QTest::newRow("invalid") << u"/in"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    QTest::newRow("empty") << u"/in"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    QTest::newRow("empty") << u"/in"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
-    QTest::newRow("missing") << u"/in"_qs << QByteArray() << valid;
+    QTest::newRow("missing") << u"/in"_s << QByteArray() << valid;
 }
 
 void TestValidator::testValidatorInteger_data()
@@ -2864,41 +2845,41 @@ void TestValidator::testValidatorInteger_data()
     // **** Start testing ValidatorInteger *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"2345"_qs);
-    QTest::newRow("valid01") << u"/integer"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"2345"_s);
+    QTest::newRow("valid01") << u"/integer"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"-2345"_qs);
-    QTest::newRow("valid02") << u"/integer"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"-2345"_s);
+    QTest::newRow("valid02") << u"/integer"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, QString::number(std::numeric_limits<int>::max()));
-    QTest::newRow("valid03") << u"/integer"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, QString::number(std::numeric_limits<int>::max()));
+    QTest::newRow("valid03") << u"/integer"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"-23a45 f"_qs);
-    QTest::newRow("invalid01") << u"/integer"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"-23a45 f"_s);
+    QTest::newRow("invalid01") << u"/integer"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"a-23f45"_qs);
-    QTest::newRow("invalid02") << u"/integer"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"a-23f45"_s);
+    QTest::newRow("invalid02") << u"/integer"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, QString::number(std::numeric_limits<qlonglong>::max()));
-    QTest::newRow("invalid03") << u"/integer"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, QString::number(std::numeric_limits<qlonglong>::max()));
+    QTest::newRow("invalid03") << u"/integer"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    QTest::newRow("empty") << u"/integer"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    QTest::newRow("empty") << u"/integer"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                            << valid;
 
-    QTest::newRow("missing") << u"/integer"_qs << QByteArray() << valid;
+    QTest::newRow("missing") << u"/integer"_s << QByteArray() << valid;
 }
 
 void TestValidator::testValidatorIp_data()
@@ -2910,190 +2891,186 @@ void TestValidator::testValidatorIp_data()
     // **** Start testing ValidatorIp *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"192.0.43.8"_qs);
-    QTest::newRow("v4-valid") << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
-                              << valid;
+    query.addQueryItem(u"field"_s, u"192.0.43.8"_s);
+    QTest::newRow("v4-valid") << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
-    const QList<QString> invalidIpv4({u"192.0.s.34"_qs,
-                                      u"192.0.43."_qs,
-                                      u"192.0.43"_qs,
-                                      u"300.167.168.5"_qs,
-                                      u"192.168.178.-5"_qs});
+    const QList<QString> invalidIpv4(
+        {u"192.0.s.34"_s, u"192.0.43."_s, u"192.0.43"_s, u"300.167.168.5"_s, u"192.168.178.-5"_s});
     int count = 0;
     for (const QString &ipv4 : invalidIpv4) {
         query.clear();
-        query.addQueryItem(u"field"_qs, ipv4);
-        QTest::newRow(u"v4-invalid0%1"_qs.arg(count).toUtf8().constData())
-            << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        query.addQueryItem(u"field"_s, ipv4);
+        QTest::newRow(u"v4-invalid0%1"_s.arg(count).toUtf8().constData())
+            << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
         count++;
     }
 
-    const QList<QString> validIpv6({u"::"_qs,
-                                    u"::123"_qs,
-                                    u"::123:456"_qs,
-                                    u"::123:456:789:abc:def:6666"_qs,
-                                    u"::123:456:789:abc:def:6666:7"_qs,
-                                    u"123::456"_qs,
-                                    u"123::456:789"_qs,
-                                    u"123::456:789:abc"_qs,
-                                    u"123::456:789:abc:def"_qs,
-                                    u"123::456:789:abc:def:6"_qs,
-                                    u"123:456::789:abc:def:6666"_qs,
-                                    u"2001:0db8:85a3:08d3:1319:8a2e:0370:7344"_qs,
-                                    u"2001:0db8:0000:08d3:0000:8a2e:0070:7344"_qs,
-                                    u"2001:db8:0:8d3:0:8a2e:70:7344"_qs,
-                                    u"2001:0db8:0:0:0:0:1428:57ab"_qs,
-                                    u"2001:db8::1428:57ab"_qs,
-                                    u"2001:0db8:0:0:8d3:0:0:0"_qs,
-                                    u"2001:db8:0:0:8d3::"_qs,
-                                    u"2001:db8::8d3:0:0:0"_qs,
-                                    u"::ffff:127.0.0.1"_qs,
-                                    u"::ffff:7f00:1"_qs});
+    const QList<QString> validIpv6({u"::"_s,
+                                    u"::123"_s,
+                                    u"::123:456"_s,
+                                    u"::123:456:789:abc:def:6666"_s,
+                                    u"::123:456:789:abc:def:6666:7"_s,
+                                    u"123::456"_s,
+                                    u"123::456:789"_s,
+                                    u"123::456:789:abc"_s,
+                                    u"123::456:789:abc:def"_s,
+                                    u"123::456:789:abc:def:6"_s,
+                                    u"123:456::789:abc:def:6666"_s,
+                                    u"2001:0db8:85a3:08d3:1319:8a2e:0370:7344"_s,
+                                    u"2001:0db8:0000:08d3:0000:8a2e:0070:7344"_s,
+                                    u"2001:db8:0:8d3:0:8a2e:70:7344"_s,
+                                    u"2001:0db8:0:0:0:0:1428:57ab"_s,
+                                    u"2001:db8::1428:57ab"_s,
+                                    u"2001:0db8:0:0:8d3:0:0:0"_s,
+                                    u"2001:db8:0:0:8d3::"_s,
+                                    u"2001:db8::8d3:0:0:0"_s,
+                                    u"::ffff:127.0.0.1"_s,
+                                    u"::ffff:7f00:1"_s});
 
     count = 0;
     for (const QString &ipv6 : validIpv6) {
         query.clear();
-        query.addQueryItem(u"field"_qs, ipv6);
-        QTest::newRow(u"v6-valid0%1"_qs.arg(count).toUtf8().constData())
-            << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        query.addQueryItem(u"field"_s, ipv6);
+        QTest::newRow(u"v6-valid0%1"_s.arg(count).toUtf8().constData())
+            << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
         count++;
     }
 
-    const QList<QString> invalidIpv6({u"2001:db8::8d3::"_qs,
-                                      u"2001:0db8:85a3:08d3:1319:8a2e:0370:7344:1234"_qs,
-                                      u":::08d3:1319:8a2e:0370:7344"_qs,
-                                      u"2001:0db8:85a3:08d3:1319:8a2k:0370:7344"_qs,
-                                      u"127.0.0.1:1319:8a2k:0370:7344"_qs,
-                                      u"2001::0db8:85a3:08d3::1319:8a2k:0370:7344"_qs,
-                                      u"2001::0DB8:85A3:08D3::1319:8a2k:0370:7344"_qs,
-                                      u":::"_qs});
+    const QList<QString> invalidIpv6({u"2001:db8::8d3::"_s,
+                                      u"2001:0db8:85a3:08d3:1319:8a2e:0370:7344:1234"_s,
+                                      u":::08d3:1319:8a2e:0370:7344"_s,
+                                      u"2001:0db8:85a3:08d3:1319:8a2k:0370:7344"_s,
+                                      u"127.0.0.1:1319:8a2k:0370:7344"_s,
+                                      u"2001::0db8:85a3:08d3::1319:8a2k:0370:7344"_s,
+                                      u"2001::0DB8:85A3:08D3::1319:8a2k:0370:7344"_s,
+                                      u":::"_s});
     count = 0;
     for (const QString &ipv6 : invalidIpv6) {
         query.clear();
-        query.addQueryItem(u"field"_qs, ipv6);
-        QTest::newRow(u"v6-invalid0%1"_qs.arg(count).toUtf8().constData())
-            << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        query.addQueryItem(u"field"_s, ipv6);
+        QTest::newRow(u"v6-invalid0%1"_s.arg(count).toUtf8().constData())
+            << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
         count++;
     }
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"192.0.43.8"_qs);
-    query.addQueryItem(u"constraints"_qs, u"IPv4Only"_qs);
+    query.addQueryItem(u"field"_s, u"192.0.43.8"_s);
+    query.addQueryItem(u"constraints"_s, u"IPv4Only"_s);
     QTest::newRow("ipv4only-valid")
-        << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"2a02:810d:22c0:1c8c:5900:83dc:83b6:9ed8"_qs);
-    query.addQueryItem(u"constraints"_qs, u"IPv4Only"_qs);
+    query.addQueryItem(u"field"_s, u"2a02:810d:22c0:1c8c:5900:83dc:83b6:9ed8"_s);
+    query.addQueryItem(u"constraints"_s, u"IPv4Only"_s);
     QTest::newRow("ipv4only-invalid")
-        << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"2a02:810d:22c0:1c8c:5900:83dc:83b6:9ed8"_qs);
-    query.addQueryItem(u"constraints"_qs, u"IPv6Only"_qs);
+    query.addQueryItem(u"field"_s, u"2a02:810d:22c0:1c8c:5900:83dc:83b6:9ed8"_s);
+    query.addQueryItem(u"constraints"_s, u"IPv6Only"_s);
     QTest::newRow("ipv6only-valid")
-        << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"192.0.43.8"_qs);
-    query.addQueryItem(u"constraints"_qs, u"IPv6Only"_qs);
+    query.addQueryItem(u"field"_s, u"192.0.43.8"_s);
+    query.addQueryItem(u"constraints"_s, u"IPv6Only"_s);
     QTest::newRow("ipv6only-invalid")
-        << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"192.0.43.8"_qs);
-    query.addQueryItem(u"constraints"_qs, u"NoPrivateRange"_qs);
+    query.addQueryItem(u"field"_s, u"192.0.43.8"_s);
+    query.addQueryItem(u"constraints"_s, u"NoPrivateRange"_s);
     QTest::newRow("noprivate-valid00")
-        << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"2a02:810d:22c0:1c8c:5900:83dc:83b6:9ed8"_qs);
-    query.addQueryItem(u"constraints"_qs, u"NoPrivateRange"_qs);
+    query.addQueryItem(u"field"_s, u"2a02:810d:22c0:1c8c:5900:83dc:83b6:9ed8"_s);
+    query.addQueryItem(u"constraints"_s, u"NoPrivateRange"_s);
     QTest::newRow("noprivate-valid01")
-        << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
-    const QList<QString> invalidIpNoPrivate({u"10.1.2.3"_qs,
-                                             u"172.21.158.56"_qs,
-                                             u"192.168.178.100"_qs,
-                                             u"169.254.254.254"_qs,
-                                             u"fe80::5652:697b:2531:a7ed"_qs,
-                                             u"fd00:26:5bf0:abd2:15ff:1adb:e8c4:8453"_qs});
+    const QList<QString> invalidIpNoPrivate({u"10.1.2.3"_s,
+                                             u"172.21.158.56"_s,
+                                             u"192.168.178.100"_s,
+                                             u"169.254.254.254"_s,
+                                             u"fe80::5652:697b:2531:a7ed"_s,
+                                             u"fd00:26:5bf0:abd2:15ff:1adb:e8c4:8453"_s});
     count = 0;
     for (const QString &ip : invalidIpNoPrivate) {
         query.clear();
-        query.addQueryItem(u"field"_qs, ip);
-        query.addQueryItem(u"constraints"_qs, u"NoPrivateRange"_qs);
-        QTest::newRow(qUtf8Printable(u"noprivate-invalid0%1"_qs.arg(count)))
-            << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        query.addQueryItem(u"field"_s, ip);
+        query.addQueryItem(u"constraints"_s, u"NoPrivateRange"_s);
+        QTest::newRow(qUtf8Printable(u"noprivate-invalid0%1"_s.arg(count)))
+            << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
         count++;
     }
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"192.0.43.8"_qs);
-    query.addQueryItem(u"constraints"_qs, u"NoReservedRange"_qs);
+    query.addQueryItem(u"field"_s, u"192.0.43.8"_s);
+    query.addQueryItem(u"constraints"_s, u"NoReservedRange"_s);
     QTest::newRow("noreserved-valid00")
-        << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"2a02:810d:22c0:1c8c:5900:83dc:83b6:9ed8"_qs);
-    query.addQueryItem(u"constraints"_qs, u"NoReservedRange"_qs);
+    query.addQueryItem(u"field"_s, u"2a02:810d:22c0:1c8c:5900:83dc:83b6:9ed8"_s);
+    query.addQueryItem(u"constraints"_s, u"NoReservedRange"_s);
     QTest::newRow("noreserved-valid01")
-        << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
-    const QList<QString> invalidIpNoReserved({u"0.1.2.3"_qs,
-                                              u"127.0.0.1"_qs,
-                                              u"100.88.5.89"_qs,
-                                              u"192.0.0.56"_qs,
-                                              u"192.0.2.165"_qs,
-                                              u"192.88.99.67"_qs,
-                                              u"198.18.5.85"_qs,
-                                              u"198.51.100.33"_qs,
-                                              u"203.0.113.97"_qs,
-                                              u"250.240.230.230"_qs,
-                                              u"255.255.255.255"_qs,
-                                              u"::"_qs,
-                                              u"::1"_qs,
-                                              u"0000:0000:0000:0000:0000:ffff:1234:abcd"_qs,
-                                              u"0100:0000:0000:0000:1234:5678:9abc:def0"_qs,
-                                              u"64:ff9b::95.4.66.32"_qs,
-                                              u"2001:0000:1234:5678:90ab:cdef:1234:5678"_qs,
-                                              u"2001:0010:0000:9876:abcd:5432:0000:a5b4"_qs,
-                                              u"2001:0020:0000:9876:abcd:5432:0000:a5b4"_qs,
-                                              u"2001:0db8:5b8e:6b5c:cdab:8546:abde:abdf"_qs,
-                                              u"2002:fd4b:5b8e:6b5c:cdab:8546:abde:abdf"_qs});
+    const QList<QString> invalidIpNoReserved({u"0.1.2.3"_s,
+                                              u"127.0.0.1"_s,
+                                              u"100.88.5.89"_s,
+                                              u"192.0.0.56"_s,
+                                              u"192.0.2.165"_s,
+                                              u"192.88.99.67"_s,
+                                              u"198.18.5.85"_s,
+                                              u"198.51.100.33"_s,
+                                              u"203.0.113.97"_s,
+                                              u"250.240.230.230"_s,
+                                              u"255.255.255.255"_s,
+                                              u"::"_s,
+                                              u"::1"_s,
+                                              u"0000:0000:0000:0000:0000:ffff:1234:abcd"_s,
+                                              u"0100:0000:0000:0000:1234:5678:9abc:def0"_s,
+                                              u"64:ff9b::95.4.66.32"_s,
+                                              u"2001:0000:1234:5678:90ab:cdef:1234:5678"_s,
+                                              u"2001:0010:0000:9876:abcd:5432:0000:a5b4"_s,
+                                              u"2001:0020:0000:9876:abcd:5432:0000:a5b4"_s,
+                                              u"2001:0db8:5b8e:6b5c:cdab:8546:abde:abdf"_s,
+                                              u"2002:fd4b:5b8e:6b5c:cdab:8546:abde:abdf"_s});
     count = 0;
     for (const QString &ip : invalidIpNoReserved) {
         query.clear();
-        query.addQueryItem(u"field"_qs, ip);
-        query.addQueryItem(u"constraints"_qs, u"NoReservedRange"_qs);
-        QTest::newRow(qUtf8Printable(u"noreserved-invalid0%1"_qs.arg(count)))
-            << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        query.addQueryItem(u"field"_s, ip);
+        query.addQueryItem(u"constraints"_s, u"NoReservedRange"_s);
+        QTest::newRow(qUtf8Printable(u"noreserved-invalid0%1"_s.arg(count)))
+            << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
         count++;
     }
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"192.0.43.8"_qs);
-    query.addQueryItem(u"constraints"_qs, u"NoMultiCast"_qs);
+    query.addQueryItem(u"field"_s, u"192.0.43.8"_s);
+    query.addQueryItem(u"constraints"_s, u"NoMultiCast"_s);
     QTest::newRow("nomulticast-valid00")
-        << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"2a02:810d:22c0:1c8c:5900:83dc:83b6:9ed8"_qs);
-    query.addQueryItem(u"constraints"_qs, u"NoMultiCast"_qs);
+    query.addQueryItem(u"field"_s, u"2a02:810d:22c0:1c8c:5900:83dc:83b6:9ed8"_s);
+    query.addQueryItem(u"constraints"_s, u"NoMultiCast"_s);
     QTest::newRow("nomulticast-valid01")
-        << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"229.0.43.8"_qs);
-    query.addQueryItem(u"constraints"_qs, u"NoMultiCast"_qs);
+    query.addQueryItem(u"field"_s, u"229.0.43.8"_s);
+    query.addQueryItem(u"constraints"_s, u"NoMultiCast"_s);
     QTest::newRow("nomulticast-invalid00")
-        << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"ff02:810d:22c0:1c8c:5900:83dc:83b6:9ed8"_qs);
-    query.addQueryItem(u"constraints"_qs, u"NoMultiCast"_qs);
+    query.addQueryItem(u"field"_s, u"ff02:810d:22c0:1c8c:5900:83dc:83b6:9ed8"_s);
+    query.addQueryItem(u"constraints"_s, u"NoMultiCast"_s);
     QTest::newRow("nomulticast-invalid01")
-        << u"/ip"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/ip"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 }
 
 void TestValidator::testValidatorJson_data()
@@ -3105,50 +3082,50 @@ void TestValidator::testValidatorJson_data()
     // **** Start testing ValidatorJson *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs,
+    query.addQueryItem(u"field"_s,
                        u"{\"Herausgeber\":\"Xema\",\"Nummer\":\"1234-5678-9012-3456\",\"Deckung\":"
                        "2e%2B6,\"Waehrung\":\"EURO\",\"Inhaber\":{\"Name\":\"Mustermann\","
                        "\"Vorname\":\"Max\",\"maennlich\":true,\"Hobbys\":[\"Reiten\",\"Golfen\","
-                       "\"Lesen\"],\"Alter\":42,\"Kinder\":[],\"Partner\":null}}"_qs);
-    QTest::newRow("valid") << u"/json"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+                       "\"Lesen\"],\"Alter\":42,\"Kinder\":[],\"Partner\":null}}"_s);
+    QTest::newRow("valid") << u"/json"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
     query.addQueryItem(
-        u"field"_qs,
+        u"field"_s,
         u"{\"Herausgeber\":\"Xema\",\"Nummer\":\"1234-5678-9012-3456\",\"Deckung\":2e "
         "6,\"Waehrung\":\"EURO\",\"Inhaber\":{\"Name\":\"Mustermann\",\"Vorname\":\"Max\","
         "\"maennlich\":true,\"Hobbys\":[\"Reiten\",\"Golfen\",\"Lesen\"],\"Alter\":42,"
-        "\"Kinder\":[],\"Partner\":null}}"_qs);
-    QTest::newRow("invalid") << u"/json"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+        "\"Kinder\":[],\"Partner\":null}}"_s);
+    QTest::newRow("invalid") << u"/json"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs,
+    query.addQueryItem(u"field"_s,
                        u"{\"Herausgeber\":\"Xema\",\"Nummer\":\"1234-5678-9012-3456\",\"Deckung\":"
                        "2e%2B6,\"Waehrung\":\"EURO\",\"Inhaber\":{\"Name\":\"Mustermann\","
                        "\"Vorname\":\"Max\",\"maennlich\":true,\"Hobbys\":[\"Reiten\",\"Golfen\","
-                       "\"Lesen\"],\"Alter\":42,\"Kinder\":[],\"Partner\":null}}"_qs);
-    QTest::newRow("valid-object") << u"/jsonObject"_qs
+                       "\"Lesen\"],\"Alter\":42,\"Kinder\":[],\"Partner\":null}}"_s);
+    QTest::newRow("valid-object") << u"/jsonObject"_s
                                   << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"[\"value1\", \"value2\", \"value3\"]"_qs);
+    query.addQueryItem(u"field"_s, u"[\"value1\", \"value2\", \"value3\"]"_s);
     QTest::newRow("invalid-object")
-        << u"/jsonObject"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/jsonObject"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"[\"value1\", \"value2\", \"value3\"]"_qs);
-    QTest::newRow("valid-array") << u"/jsonArray"_qs
-                                 << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+    query.addQueryItem(u"field"_s, u"[\"value1\", \"value2\", \"value3\"]"_s);
+    QTest::newRow("valid-array") << u"/jsonArray"_s << query.toString(QUrl::FullyEncoded).toLatin1()
+                                 << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs,
+    query.addQueryItem(u"field"_s,
                        u"{\"Herausgeber\":\"Xema\",\"Nummer\":\"1234-5678-9012-3456\",\"Deckung\":"
                        "2e%2B6,\"Waehrung\":\"EURO\",\"Inhaber\":{\"Name\":\"Mustermann\","
                        "\"Vorname\":\"Max\",\"maennlich\":true,\"Hobbys\":[\"Reiten\",\"Golfen\","
-                       "\"Lesen\"],\"Alter\":42,\"Kinder\":[],\"Partner\":null}}"_qs);
+                       "\"Lesen\"],\"Alter\":42,\"Kinder\":[],\"Partner\":null}}"_s);
     QTest::newRow("invalid-array")
-        << u"/jsonArray"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/jsonArray"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 }
 
 void TestValidator::testValidatorMax_data()
@@ -3160,64 +3137,64 @@ void TestValidator::testValidatorMax_data()
     // **** Start testing ValidatorMax *****
 
     QUrlQuery query;
-    query.addQueryItem(u"type"_qs, u"sint"_qs);
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    QTest::newRow("sint-empty") << u"/max"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"sint"_s);
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    QTest::newRow("sint-empty") << u"/max"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                 << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"sint"_qs);
-    query.addQueryItem(u"field"_qs, u"-5"_qs);
-    QTest::newRow("sint-valid") << u"/max"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"sint"_s);
+    query.addQueryItem(u"field"_s, u"-5"_s);
+    QTest::newRow("sint-valid") << u"/max"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                 << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"sint"_qs);
-    query.addQueryItem(u"field"_qs, u"15"_qs);
-    QTest::newRow("sint-invalid") << u"/max"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"sint"_s);
+    query.addQueryItem(u"field"_s, u"15"_s);
+    QTest::newRow("sint-invalid") << u"/max"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                   << invalid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"uint"_qs);
-    query.addQueryItem(u"field"_qs, u"5"_qs);
-    QTest::newRow("uint-valid") << u"/max"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"uint"_s);
+    query.addQueryItem(u"field"_s, u"5"_s);
+    QTest::newRow("uint-valid") << u"/max"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                 << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"uint"_qs);
-    query.addQueryItem(u"field"_qs, u"15"_qs);
-    QTest::newRow("uint-invalid") << u"/max"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"uint"_s);
+    query.addQueryItem(u"field"_s, u"15"_s);
+    QTest::newRow("uint-invalid") << u"/max"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                   << invalid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"float"_qs);
-    query.addQueryItem(u"field"_qs, u"-5.234652435"_qs);
-    QTest::newRow("uint-valid") << u"/max"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"float"_s);
+    query.addQueryItem(u"field"_s, u"-5.234652435"_s);
+    QTest::newRow("uint-valid") << u"/max"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                 << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"float"_qs);
-    query.addQueryItem(u"field"_qs, u"15.912037"_qs);
-    QTest::newRow("uint-invalid") << u"/max"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"float"_s);
+    query.addQueryItem(u"field"_s, u"15.912037"_s);
+    QTest::newRow("uint-invalid") << u"/max"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                   << invalid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"string"_qs);
-    query.addQueryItem(u"field"_qs, u"abcdefghij"_qs);
-    QTest::newRow("uint-valid") << u"/max"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"string"_s);
+    query.addQueryItem(u"field"_s, u"abcdefghij"_s);
+    QTest::newRow("uint-valid") << u"/max"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                 << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"string"_qs);
-    query.addQueryItem(u"field"_qs, u"abcdefghijlmnop"_qs);
-    QTest::newRow("uint-invalid") << u"/max"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"string"_s);
+    query.addQueryItem(u"field"_s, u"abcdefghijlmnop"_s);
+    QTest::newRow("uint-invalid") << u"/max"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                   << invalid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"strsdf"_qs);
-    query.addQueryItem(u"field"_qs, u"abcdefghijlmnop"_qs);
+    query.addQueryItem(u"type"_s, u"strsdf"_s);
+    query.addQueryItem(u"field"_s, u"abcdefghijlmnop"_s);
     QTest::newRow("validationdataerror")
-        << u"/max"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << validationDataError;
+        << u"/max"_s << query.toString(QUrl::FullyEncoded).toLatin1() << validationDataError;
 }
 
 void TestValidator::testValidatorMin_data()
@@ -3229,64 +3206,64 @@ void TestValidator::testValidatorMin_data()
     // **** Start testing ValidatorMin *****
 
     QUrlQuery query;
-    query.addQueryItem(u"type"_qs, u"sint"_qs);
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    QTest::newRow("sint-empty") << u"/min"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"sint"_s);
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    QTest::newRow("sint-empty") << u"/min"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                 << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"sint"_qs);
-    query.addQueryItem(u"field"_qs, u"15"_qs);
-    QTest::newRow("sint-valid") << u"/min"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"sint"_s);
+    query.addQueryItem(u"field"_s, u"15"_s);
+    QTest::newRow("sint-valid") << u"/min"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                 << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"sint"_qs);
-    query.addQueryItem(u"field"_qs, u"-5"_qs);
-    QTest::newRow("sint-invalid") << u"/min"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"sint"_s);
+    query.addQueryItem(u"field"_s, u"-5"_s);
+    QTest::newRow("sint-invalid") << u"/min"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                   << invalid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"uint"_qs);
-    query.addQueryItem(u"field"_qs, u"15"_qs);
-    QTest::newRow("uint-valid") << u"/min"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"uint"_s);
+    query.addQueryItem(u"field"_s, u"15"_s);
+    QTest::newRow("uint-valid") << u"/min"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                 << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"uint"_qs);
-    query.addQueryItem(u"field"_qs, u"5"_qs);
-    QTest::newRow("uint-invalid") << u"/min"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"uint"_s);
+    query.addQueryItem(u"field"_s, u"5"_s);
+    QTest::newRow("uint-invalid") << u"/min"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                   << invalid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"float"_qs);
-    query.addQueryItem(u"field"_qs, u"15.912037"_qs);
-    QTest::newRow("float-valid") << u"/min"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"float"_s);
+    query.addQueryItem(u"field"_s, u"15.912037"_s);
+    QTest::newRow("float-valid") << u"/min"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                  << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"float"_qs);
-    query.addQueryItem(u"field"_qs, u"-5.234652435"_qs);
+    query.addQueryItem(u"type"_s, u"float"_s);
+    query.addQueryItem(u"field"_s, u"-5.234652435"_s);
     QTest::newRow("float-invalid")
-        << u"/min"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/min"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"string"_qs);
-    query.addQueryItem(u"field"_qs, u"abcdefghijklmnop"_qs);
-    QTest::newRow("string-valid") << u"/min"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"string"_s);
+    query.addQueryItem(u"field"_s, u"abcdefghijklmnop"_s);
+    QTest::newRow("string-valid") << u"/min"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                   << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"string"_qs);
-    query.addQueryItem(u"field"_qs, u"abcdef"_qs);
+    query.addQueryItem(u"type"_s, u"string"_s);
+    query.addQueryItem(u"field"_s, u"abcdef"_s);
     QTest::newRow("string-invalid")
-        << u"/min"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/min"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"strsdf"_qs);
-    query.addQueryItem(u"field"_qs, u"abcdefghijlmnop"_qs);
+    query.addQueryItem(u"type"_s, u"strsdf"_s);
+    query.addQueryItem(u"field"_s, u"abcdefghijlmnop"_s);
     QTest::newRow("validationdataerror")
-        << u"/min"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << validationDataError;
+        << u"/min"_s << query.toString(QUrl::FullyEncoded).toLatin1() << validationDataError;
 }
 
 void TestValidator::testValidatorNotIn_data()
@@ -3298,13 +3275,12 @@ void TestValidator::testValidatorNotIn_data()
     // **** Start testing ValidatorNotIn *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"fünf"_qs);
-    QTest::newRow("valid") << u"/notIn"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
-                           << valid;
+    query.addQueryItem(u"field"_s, u"fünf"_s);
+    QTest::newRow("valid") << u"/notIn"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"vier"_qs);
-    QTest::newRow("invalid") << u"/notIn"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"vier"_s);
+    QTest::newRow("invalid") << u"/notIn"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << invalid;
 }
 
@@ -3316,42 +3292,34 @@ void TestValidator::testValidatorNumeric_data()
 
     // **** Start testing ValidatorNumeric *****
 
-    const QList<QString> validNumerics({u"23"_qs,
-                                        u"-3465"_qs,
-                                        u"23.45"_qs,
-                                        u"-3456.32453245"_qs,
-                                        u"23.345345e15"_qs,
-                                        u"-1.23e4"_qs});
+    const QList<QString> validNumerics(
+        {u"23"_s, u"-3465"_s, u"23.45"_s, u"-3456.32453245"_s, u"23.345345e15"_s, u"-1.23e4"_s});
 
     int count = 0;
     QUrlQuery query;
     for (const QString &num : validNumerics) {
         query.clear();
-        query.addQueryItem(u"field"_qs, num);
-        QTest::newRow(qUtf8Printable(u"valid0%1"_qs.arg(count)))
-            << u"/numeric"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        query.addQueryItem(u"field"_s, num);
+        QTest::newRow(qUtf8Printable(u"valid0%1"_s.arg(count)))
+            << u"/numeric"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
         count++;
     }
 
-    const QList<QString> invalidNumerics({u"2s3"_qs,
-                                          u"-a3465"_qs,
-                                          u"23:45"_qs,
-                                          u"-3456:32453245"_qs,
-                                          u"23.345345c15"_qs,
-                                          u"-1.23D4"_qs});
+    const QList<QString> invalidNumerics(
+        {u"2s3"_s, u"-a3465"_s, u"23:45"_s, u"-3456:32453245"_s, u"23.345345c15"_s, u"-1.23D4"_s});
 
     count = 0;
     for (const QString &num : invalidNumerics) {
         query.clear();
-        query.addQueryItem(u"field"_qs, num);
-        QTest::newRow(qUtf8Printable(u"invalid0%1"_qs.arg(count)))
-            << u"/numeric"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        query.addQueryItem(u"field"_s, num);
+        QTest::newRow(qUtf8Printable(u"invalid0%1"_s.arg(count)))
+            << u"/numeric"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
         count++;
     }
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    QTest::newRow("empty") << u"/numeric"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    QTest::newRow("empty") << u"/numeric"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                            << valid;
 }
 
@@ -3364,13 +3332,13 @@ void TestValidator::testValidatorPresent_data()
     // **** Start testing ValidatorPresent *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    QTest::newRow("valid") << u"/present"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    QTest::newRow("valid") << u"/present"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                            << valid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"asdfasdf"_qs);
-    QTest::newRow("invalid") << u"/present"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field2"_s, u"asdfasdf"_s);
+    QTest::newRow("invalid") << u"/present"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << invalid;
 }
 
@@ -3384,23 +3352,23 @@ void TestValidator::testValidatorPwQuality_data()
     // **** Start testing ValidatorPwQuality
 
     const QList<QString> invalidPws({
-        u"ovkaCPa"_qs,  // too short, lower than 8
-        u"password"_qs, // dictionary
-        u"aceg1234"_qs  // score too low
+        u"ovkaCPa"_s,  // too short, lower than 8
+        u"password"_s, // dictionary
+        u"aceg1234"_s  // score too low
     });
     int count = 0;
     QUrlQuery query;
     for (const QString &pw : invalidPws) {
         query.clear();
-        query.addQueryItem(u"field"_qs, pw);
-        QTest::newRow(qUtf8Printable(u"invalid0%1"_qs.arg(count)))
-            << u"/pwQuality"_qs << query.toString(QUrl::FullyEncoded).toUtf8() << invalid;
+        query.addQueryItem(u"field"_s, pw);
+        QTest::newRow(qUtf8Printable(u"invalid0%1"_s.arg(count)))
+            << u"/pwQuality"_s << query.toString(QUrl::FullyEncoded).toUtf8() << invalid;
         count++;
     }
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"niK3sd2eHAm@M0vZ!8sd$uJv?4AYlDaP6"_qs);
-    QTest::newRow("valid") << u"/pwQuality"_qs << query.toString(QUrl::FullyEncoded).toUtf8()
+    query.addQueryItem(u"field"_s, u"niK3sd2eHAm@M0vZ!8sd$uJv?4AYlDaP6"_s);
+    QTest::newRow("valid") << u"/pwQuality"_s << query.toString(QUrl::FullyEncoded).toUtf8()
                            << valid;
 }
 #endif
@@ -3414,19 +3382,17 @@ void TestValidator::testValidatorRegex_data()
     // **** Start testing ValidatorRegex *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"08/12/1985"_qs);
-    QTest::newRow("valid") << u"/regex"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
-                           << valid;
+    query.addQueryItem(u"field"_s, u"08/12/1985"_s);
+    QTest::newRow("valid") << u"/regex"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"8/2/85"_qs);
-    QTest::newRow("invalid") << u"/regex"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"8/2/85"_s);
+    QTest::newRow("invalid") << u"/regex"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    QTest::newRow("empty") << u"/regex"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
-                           << valid;
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    QTest::newRow("empty") << u"/regex"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 }
 
 void TestValidator::testValidatorRequired_data()
@@ -3438,18 +3404,18 @@ void TestValidator::testValidatorRequired_data()
     // **** Start testing ValidatorRequired *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"08/12/1985"_qs);
-    QTest::newRow("valid") << u"/required"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"08/12/1985"_s);
+    QTest::newRow("valid") << u"/required"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                            << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    QTest::newRow("empty") << u"/required"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    QTest::newRow("empty") << u"/required"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                            << invalid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"08/12/1985"_qs);
-    QTest::newRow("missing") << u"/required"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field2"_s, u"08/12/1985"_s);
+    QTest::newRow("missing") << u"/required"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << invalid;
 }
 
@@ -3462,42 +3428,42 @@ void TestValidator::testValidatorRequiredIf_data()
     // **** Start testing ValidatorRequiredIf *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"asdfasdf"_qs);
-    query.addQueryItem(u"field2"_qs, u"eins"_qs);
-    QTest::newRow("valid00") << u"/requiredIf"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"asdfasdf"_s);
+    query.addQueryItem(u"field2"_s, u"eins"_s);
+    QTest::newRow("valid00") << u"/requiredIf"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"adfasdf"_qs);
-    query.addQueryItem(u"field2"_qs, u"vier"_qs);
-    QTest::newRow("valid01") << u"/requiredIf"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"adfasdf"_s);
+    query.addQueryItem(u"field2"_s, u"vier"_s);
+    QTest::newRow("valid01") << u"/requiredIf"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    query.addQueryItem(u"field2"_qs, u"vier"_qs);
-    QTest::newRow("valid02") << u"/requiredIf"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    query.addQueryItem(u"field2"_s, u"vier"_s);
+    QTest::newRow("valid02") << u"/requiredIf"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << valid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"vier"_qs);
-    QTest::newRow("valid03") << u"/requiredIf"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field2"_s, u"vier"_s);
+    QTest::newRow("valid03") << u"/requiredIf"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << valid;
 
     query.clear();
-    query.addQueryItem(u"field3"_qs, u"eins"_qs);
-    QTest::newRow("valid04") << u"/requiredIf"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field3"_s, u"eins"_s);
+    QTest::newRow("valid04") << u"/requiredIf"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    query.addQueryItem(u"field2"_qs, u"eins"_qs);
-    QTest::newRow("invalid00") << u"/requiredIf"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    query.addQueryItem(u"field2"_s, u"eins"_s);
+    QTest::newRow("invalid00") << u"/requiredIf"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                << invalid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"eins"_qs);
-    QTest::newRow("invalid01") << u"/requiredIf"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field2"_s, u"eins"_s);
+    QTest::newRow("invalid01") << u"/requiredIf"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                << invalid;
 }
 
@@ -3510,43 +3476,43 @@ void TestValidator::testValidatorRequiredIfStash_data()
     // **** Start testing ValidatorRequiredIfStash *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"adsf"_qs);
-    QTest::newRow("valid01") << u"/requiredIfStashMatch"_qs
+    query.addQueryItem(u"field"_s, u"adsf"_s);
+    QTest::newRow("valid01") << u"/requiredIfStashMatch"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"adsf"_qs);
-    QTest::newRow("valid02") << u"/requiredIfStashNotMatch"_qs
+    query.addQueryItem(u"field"_s, u"adsf"_s);
+    QTest::newRow("valid02") << u"/requiredIfStashNotMatch"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"adsf"_qs);
-    QTest::newRow("valid03") << u"/requiredIfStashMatchStashKey"_qs
+    query.addQueryItem(u"field"_s, u"adsf"_s);
+    QTest::newRow("valid03") << u"/requiredIfStashMatchStashKey"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"adsf"_qs);
-    QTest::newRow("valid04") << u"/requiredIfStashNotMatchStashKey"_qs
+    query.addQueryItem(u"field"_s, u"adsf"_s);
+    QTest::newRow("valid04") << u"/requiredIfStashNotMatchStashKey"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"adsf"_qs);
-    QTest::newRow("invalid01") << u"/requiredIfStashNotMatch"_qs
+    query.addQueryItem(u"field2"_s, u"adsf"_s);
+    QTest::newRow("invalid01") << u"/requiredIfStashNotMatch"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"adsf"_qs);
-    QTest::newRow("invalid02") << u"/requiredIfStashMatch"_qs
+    query.addQueryItem(u"field2"_s, u"adsf"_s);
+    QTest::newRow("invalid02") << u"/requiredIfStashMatch"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"adsf"_qs);
-    QTest::newRow("invalid03") << u"/requiredIfStashNotMatchStashKey"_qs
+    query.addQueryItem(u"field2"_s, u"adsf"_s);
+    QTest::newRow("invalid03") << u"/requiredIfStashNotMatchStashKey"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"adsf"_qs);
-    QTest::newRow("invalid04") << u"/requiredIfStashMatchStashKey"_qs
+    query.addQueryItem(u"field2"_s, u"adsf"_s);
+    QTest::newRow("invalid04") << u"/requiredIfStashMatchStashKey"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 }
 
@@ -3559,37 +3525,37 @@ void TestValidator::testValidatorRequiredUnless_data()
     // **** Start testing ValidatorRequiredUnless *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"asdfasdf"_qs);
-    query.addQueryItem(u"field2"_qs, u"eins"_qs);
-    QTest::newRow("valid00") << u"/requiredUnless"_qs
+    query.addQueryItem(u"field"_s, u"asdfasdf"_s);
+    query.addQueryItem(u"field2"_s, u"eins"_s);
+    QTest::newRow("valid00") << u"/requiredUnless"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"asdfasdf"_qs);
-    query.addQueryItem(u"field2"_qs, u"vier"_qs);
-    QTest::newRow("valid01") << u"/requiredUnless"_qs
+    query.addQueryItem(u"field"_s, u"asdfasdf"_s);
+    query.addQueryItem(u"field2"_s, u"vier"_s);
+    QTest::newRow("valid01") << u"/requiredUnless"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    query.addQueryItem(u"field2"_qs, u"eins"_qs);
-    QTest::newRow("valid02") << u"/requiredUnless"_qs
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    query.addQueryItem(u"field2"_s, u"eins"_s);
+    QTest::newRow("valid02") << u"/requiredUnless"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"zwei"_qs);
-    QTest::newRow("valid03") << u"/requiredUnless"_qs
+    query.addQueryItem(u"field2"_s, u"zwei"_s);
+    QTest::newRow("valid03") << u"/requiredUnless"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    query.addQueryItem(u"field2"_qs, u"vier"_qs);
-    QTest::newRow("invalid00") << u"/requiredUnless"_qs
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    query.addQueryItem(u"field2"_s, u"vier"_s);
+    QTest::newRow("invalid00") << u"/requiredUnless"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"vier"_qs);
-    QTest::newRow("invalid01") << u"/requiredUnless"_qs
+    query.addQueryItem(u"field2"_s, u"vier"_s);
+    QTest::newRow("invalid01") << u"/requiredUnless"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 }
 
@@ -3602,43 +3568,43 @@ void TestValidator::testValidatorRequiredUnlessStash_data()
     // **** Start testing ValidatorRequiredUnlessStash *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"asdf"_qs);
-    QTest::newRow("valid00") << u"/requiredUnlessStashMatch"_qs
+    query.addQueryItem(u"field"_s, u"asdf"_s);
+    QTest::newRow("valid00") << u"/requiredUnlessStashMatch"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"asdf"_qs);
-    QTest::newRow("valid01") << u"/requiredUnlessStashMatch"_qs
+    query.addQueryItem(u"field2"_s, u"asdf"_s);
+    QTest::newRow("valid01") << u"/requiredUnlessStashMatch"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"asdf"_qs);
-    QTest::newRow("valid02") << u"/requiredUnlessStashNotMatch"_qs
+    query.addQueryItem(u"field"_s, u"asdf"_s);
+    QTest::newRow("valid02") << u"/requiredUnlessStashNotMatch"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"asdf"_qs);
-    QTest::newRow("valid03") << u"/requiredUnlessStashMatchStashKey"_qs
+    query.addQueryItem(u"field"_s, u"asdf"_s);
+    QTest::newRow("valid03") << u"/requiredUnlessStashMatchStashKey"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"asdf"_qs);
-    QTest::newRow("valid04") << u"/requiredUnlessStashMatchStashKey"_qs
+    query.addQueryItem(u"field2"_s, u"asdf"_s);
+    QTest::newRow("valid04") << u"/requiredUnlessStashMatchStashKey"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"asdf"_qs);
-    QTest::newRow("invalid00") << u"/requiredUnlessStashNotMatch"_qs
+    query.addQueryItem(u"field2"_s, u"asdf"_s);
+    QTest::newRow("invalid00") << u"/requiredUnlessStashNotMatch"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"%20"_qs);
-    QTest::newRow("invalid01") << u"/requiredUnlessStashNotMatch"_qs
+    query.addQueryItem(u"field2"_s, u"%20"_s);
+    QTest::newRow("invalid01") << u"/requiredUnlessStashNotMatch"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"asdf"_qs);
-    QTest::newRow("invalid03") << u"/requiredUnlessStashNotMatchStashKey"_qs
+    query.addQueryItem(u"field2"_s, u"asdf"_s);
+    QTest::newRow("invalid03") << u"/requiredUnlessStashNotMatchStashKey"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 }
 
@@ -3651,32 +3617,32 @@ void TestValidator::testValidatorRequiredWith_data()
     // **** Start testing ValidatorRequiredWith *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"wlklasdf"_qs);
-    query.addQueryItem(u"field2"_qs, u"wlklasdf"_qs);
-    QTest::newRow("valid00") << u"/requiredWith"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"wlklasdf"_s);
+    query.addQueryItem(u"field2"_s, u"wlklasdf"_s);
+    QTest::newRow("valid00") << u"/requiredWith"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"wlklasdf"_qs);
-    query.addQueryItem(u"field3"_qs, u"wlklasdf"_qs);
-    QTest::newRow("valid01") << u"/requiredWith"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"wlklasdf"_s);
+    query.addQueryItem(u"field3"_s, u"wlklasdf"_s);
+    QTest::newRow("valid01") << u"/requiredWith"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"wlklasdf"_qs);
-    query.addQueryItem(u"field3"_qs, u"wlklasdf"_qs);
-    QTest::newRow("valid02") << u"/requiredWith"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"wlklasdf"_s);
+    query.addQueryItem(u"field3"_s, u"wlklasdf"_s);
+    QTest::newRow("valid02") << u"/requiredWith"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    query.addQueryItem(u"field2"_qs, u"wlklasdf"_qs);
-    QTest::newRow("invalid00") << u"/requiredWith"_qs
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    query.addQueryItem(u"field2"_s, u"wlklasdf"_s);
+    QTest::newRow("invalid00") << u"/requiredWith"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"wlklasdf"_qs);
-    QTest::newRow("invalid01") << u"/requiredWith"_qs
+    query.addQueryItem(u"field2"_s, u"wlklasdf"_s);
+    QTest::newRow("invalid01") << u"/requiredWith"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 }
 
@@ -3689,46 +3655,46 @@ void TestValidator::testValidatorRequiredWithAll_data()
     // **** Start testing ValidatorRequiredWithAll *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"asdfdasf"_qs);
-    query.addQueryItem(u"field2"_qs, u"asdfdasf"_qs);
-    query.addQueryItem(u"field3"_qs, u"asdfdasf"_qs);
-    query.addQueryItem(u"field4"_qs, u"asdfdasf"_qs);
-    QTest::newRow("valid00") << u"/requiredWithAll"_qs
+    query.addQueryItem(u"field"_s, u"asdfdasf"_s);
+    query.addQueryItem(u"field2"_s, u"asdfdasf"_s);
+    query.addQueryItem(u"field3"_s, u"asdfdasf"_s);
+    query.addQueryItem(u"field4"_s, u"asdfdasf"_s);
+    QTest::newRow("valid00") << u"/requiredWithAll"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"asdfdasf"_qs);
-    query.addQueryItem(u"field2"_qs, u"asdfdasf"_qs);
-    query.addQueryItem(u"field4"_qs, u"asdfdasf"_qs);
-    QTest::newRow("valid01") << u"/requiredWithAll"_qs
+    query.addQueryItem(u"field"_s, u"asdfdasf"_s);
+    query.addQueryItem(u"field2"_s, u"asdfdasf"_s);
+    query.addQueryItem(u"field4"_s, u"asdfdasf"_s);
+    QTest::newRow("valid01") << u"/requiredWithAll"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    query.addQueryItem(u"field2"_qs, u"asdfdasf"_qs);
-    query.addQueryItem(u"field4"_qs, u"asdfdasf"_qs);
-    QTest::newRow("valid02") << u"/requiredWithAll"_qs
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    query.addQueryItem(u"field2"_s, u"asdfdasf"_s);
+    query.addQueryItem(u"field4"_s, u"asdfdasf"_s);
+    QTest::newRow("valid02") << u"/requiredWithAll"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"asdfdasf"_qs);
-    query.addQueryItem(u"field4"_qs, u"asdfdasf"_qs);
-    QTest::newRow("valid03") << u"/requiredWithAll"_qs
+    query.addQueryItem(u"field2"_s, u"asdfdasf"_s);
+    query.addQueryItem(u"field4"_s, u"asdfdasf"_s);
+    QTest::newRow("valid03") << u"/requiredWithAll"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    query.addQueryItem(u"field2"_qs, u"asdfdasf"_qs);
-    query.addQueryItem(u"field3"_qs, u"asdfdasf"_qs);
-    query.addQueryItem(u"field4"_qs, u"asdfdasf"_qs);
-    QTest::newRow("invalid00") << u"/requiredWithAll"_qs
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    query.addQueryItem(u"field2"_s, u"asdfdasf"_s);
+    query.addQueryItem(u"field3"_s, u"asdfdasf"_s);
+    query.addQueryItem(u"field4"_s, u"asdfdasf"_s);
+    QTest::newRow("invalid00") << u"/requiredWithAll"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"asdfdasf"_qs);
-    query.addQueryItem(u"field3"_qs, u"asdfdasf"_qs);
-    query.addQueryItem(u"field4"_qs, u"asdfdasf"_qs);
-    QTest::newRow("invalid01") << u"/requiredWithAll"_qs
+    query.addQueryItem(u"field2"_s, u"asdfdasf"_s);
+    query.addQueryItem(u"field3"_s, u"asdfdasf"_s);
+    query.addQueryItem(u"field4"_s, u"asdfdasf"_s);
+    QTest::newRow("invalid01") << u"/requiredWithAll"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 }
 
@@ -3741,29 +3707,29 @@ void TestValidator::testValidatorRequiredWithout_data()
     // **** Start testing ValidatorRequiredWithout *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"wlklasdf"_qs);
-    query.addQueryItem(u"field2"_qs, u"wlklasdf"_qs);
-    QTest::newRow("valid00") << u"/requiredWithout"_qs
+    query.addQueryItem(u"field"_s, u"wlklasdf"_s);
+    query.addQueryItem(u"field2"_s, u"wlklasdf"_s);
+    QTest::newRow("valid00") << u"/requiredWithout"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"wlklasdf"_qs);
-    QTest::newRow("valid01") << u"/requiredWithout"_qs
+    query.addQueryItem(u"field"_s, u"wlklasdf"_s);
+    QTest::newRow("valid01") << u"/requiredWithout"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    QTest::newRow("invalid00") << u"/requiredWithout"_qs
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    QTest::newRow("invalid00") << u"/requiredWithout"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field4"_qs, u"asdfasdf"_qs);
-    QTest::newRow("invalid01") << u"/requiredWithout"_qs
+    query.addQueryItem(u"field4"_s, u"asdfasdf"_s);
+    QTest::newRow("invalid01") << u"/requiredWithout"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field2"_qs, u"asdfasdf"_qs);
-    QTest::newRow("invalid02") << u"/requiredWithout"_qs
+    query.addQueryItem(u"field2"_s, u"asdfasdf"_s);
+    QTest::newRow("invalid02") << u"/requiredWithout"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 }
 
@@ -3776,29 +3742,29 @@ void TestValidator::testValidatorRequiredWithoutAll_data()
     // **** Start testing ValidatorRequiredWithoutAll *****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"wlklasdf"_qs);
-    query.addQueryItem(u"field2"_qs, u"wlklasdf"_qs);
-    QTest::newRow("valid00") << u"/requiredWithoutAll"_qs
+    query.addQueryItem(u"field"_s, u"wlklasdf"_s);
+    query.addQueryItem(u"field2"_s, u"wlklasdf"_s);
+    QTest::newRow("valid00") << u"/requiredWithoutAll"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"wlklasdf"_qs);
-    QTest::newRow("valid01") << u"/requiredWithoutAll"_qs
+    query.addQueryItem(u"field"_s, u"wlklasdf"_s);
+    QTest::newRow("valid01") << u"/requiredWithoutAll"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"wlklasdf"_qs);
-    query.addQueryItem(u"field4"_qs, u"wlklasdf"_qs);
-    QTest::newRow("valid02") << u"/requiredWithoutAll"_qs
+    query.addQueryItem(u"field"_s, u"wlklasdf"_s);
+    query.addQueryItem(u"field4"_s, u"wlklasdf"_s);
+    QTest::newRow("valid02") << u"/requiredWithoutAll"_s
                              << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    QTest::newRow("invalid00") << u"/requiredWithoutAll"_qs
+    QTest::newRow("invalid00") << u"/requiredWithoutAll"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field4"_qs, u"wlklasdf"_qs);
-    QTest::newRow("invalid01") << u"/requiredWithoutAll"_qs
+    query.addQueryItem(u"field4"_s, u"wlklasdf"_s);
+    QTest::newRow("invalid01") << u"/requiredWithoutAll"_s
                                << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 }
 
@@ -3810,20 +3776,20 @@ void TestValidator::testValidatorSame_data()
 
     // **** Start testing ValidatorSame *****
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"wlklasdf"_qs);
-    query.addQueryItem(u"other"_qs, u"wlklasdf"_qs);
-    QTest::newRow("valid") << u"/same"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+    query.addQueryItem(u"field"_s, u"wlklasdf"_s);
+    query.addQueryItem(u"other"_s, u"wlklasdf"_s);
+    QTest::newRow("valid") << u"/same"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"wlklasdf"_qs);
-    query.addQueryItem(u"other"_qs, u"wlkla"_qs);
-    QTest::newRow("invalid") << u"/same"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"wlklasdf"_s);
+    query.addQueryItem(u"other"_s, u"wlkla"_s);
+    QTest::newRow("invalid") << u"/same"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                              << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    query.addQueryItem(u"other"_qs, u"wlkla"_qs);
-    QTest::newRow("empty") << u"/same"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    query.addQueryItem(u"other"_s, u"wlkla"_s);
+    QTest::newRow("empty") << u"/same"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 }
 
 void TestValidator::testValidatorSize_data()
@@ -3835,64 +3801,64 @@ void TestValidator::testValidatorSize_data()
     // **** Start testing ValidatorSize *****
 
     QUrlQuery query;
-    query.addQueryItem(u"type"_qs, u"sint"_qs);
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    QTest::newRow("sint-empty") << u"/size"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"sint"_s);
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    QTest::newRow("sint-empty") << u"/size"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                 << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"sint"_qs);
-    query.addQueryItem(u"field"_qs, u"10"_qs);
-    QTest::newRow("sint-valid") << u"/size"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"sint"_s);
+    query.addQueryItem(u"field"_s, u"10"_s);
+    QTest::newRow("sint-valid") << u"/size"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                 << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"sint"_qs);
-    query.addQueryItem(u"field"_qs, u"-5"_qs);
-    QTest::newRow("sint-invalid") << u"/size"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"sint"_s);
+    query.addQueryItem(u"field"_s, u"-5"_s);
+    QTest::newRow("sint-invalid") << u"/size"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                   << invalid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"uint"_qs);
-    query.addQueryItem(u"field"_qs, u"10"_qs);
-    QTest::newRow("uint-valid") << u"/size"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"uint"_s);
+    query.addQueryItem(u"field"_s, u"10"_s);
+    QTest::newRow("uint-valid") << u"/size"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                 << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"uint"_qs);
-    query.addQueryItem(u"field"_qs, u"5"_qs);
-    QTest::newRow("uint-invalid") << u"/size"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"uint"_s);
+    query.addQueryItem(u"field"_s, u"5"_s);
+    QTest::newRow("uint-invalid") << u"/size"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                   << invalid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"float"_qs);
-    query.addQueryItem(u"field"_qs, u"10.0"_qs);
-    QTest::newRow("float-valid") << u"/size"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"float"_s);
+    query.addQueryItem(u"field"_s, u"10.0"_s);
+    QTest::newRow("float-valid") << u"/size"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                  << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"float"_qs);
-    query.addQueryItem(u"field"_qs, u"-5.234652435"_qs);
+    query.addQueryItem(u"type"_s, u"float"_s);
+    query.addQueryItem(u"field"_s, u"-5.234652435"_s);
     QTest::newRow("flost-invalid")
-        << u"/size"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/size"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"string"_qs);
-    query.addQueryItem(u"field"_qs, u"abcdefghij"_qs);
-    QTest::newRow("string-valid") << u"/size"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"type"_s, u"string"_s);
+    query.addQueryItem(u"field"_s, u"abcdefghij"_s);
+    QTest::newRow("string-valid") << u"/size"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                   << valid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"string"_qs);
-    query.addQueryItem(u"field"_qs, u"abcdef"_qs);
+    query.addQueryItem(u"type"_s, u"string"_s);
+    query.addQueryItem(u"field"_s, u"abcdef"_s);
     QTest::newRow("string-invalid")
-        << u"/size"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/size"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"type"_qs, u"strsdf"_qs);
-    query.addQueryItem(u"field"_qs, u"abcdefghijlmnop"_qs);
+    query.addQueryItem(u"type"_s, u"strsdf"_s);
+    query.addQueryItem(u"field"_s, u"abcdefghijlmnop"_s);
     QTest::newRow("validationdataerror")
-        << u"/size"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << validationDataError;
+        << u"/size"_s << query.toString(QUrl::FullyEncoded).toLatin1() << validationDataError;
 }
 
 void TestValidator::testValidatorTime_data()
@@ -3905,21 +3871,21 @@ void TestValidator::testValidatorTime_data()
 
     int count = 0;
     for (Qt::DateFormat df : dateFormats) {
-        QTest::newRow(QString(u"valid0%1"_qs.arg(count)).toUtf8().constData())
-            << u"/time?field="_qs + QTime::currentTime().toString(df) << QByteArray() << valid;
+        QTest::newRow(QString(u"valid0%1"_s.arg(count)).toUtf8().constData())
+            << u"/time?field="_s + QTime::currentTime().toString(df) << QByteArray() << valid;
         count++;
     }
 
-    QTest::newRow("invalid") << u"/time?field=123456789"_qs << QByteArray() << invalid;
+    QTest::newRow("invalid") << u"/time?field=123456789"_s << QByteArray() << invalid;
 
-    QTest::newRow("empty") << u"/time?field=%20"_qs << QByteArray() << valid;
+    QTest::newRow("empty") << u"/time?field=%20"_s << QByteArray() << valid;
 
-    QTest::newRow("format-valid") << u"/timeFormat?field="_qs +
-                                         QTime::currentTime().toString(u"m:hh"_qs)
+    QTest::newRow("format-valid") << u"/timeFormat?field="_s +
+                                         QTime::currentTime().toString(u"m:hh"_s)
                                   << QByteArray() << valid;
 
     QTest::newRow("format-invalid")
-        << u"/timeFormat?field="_qs + QTime::currentTime().toString(u"m:AP"_qs) << QByteArray()
+        << u"/timeFormat?field="_s + QTime::currentTime().toString(u"m:AP"_s) << QByteArray()
         << invalid;
 }
 
@@ -3932,87 +3898,87 @@ void TestValidator::testValidatorUrl_data()
     // **** Start testing ValidatorUrl*****
 
     QUrlQuery query;
-    query.addQueryItem(u"field"_qs, u"http://www.example.org"_qs);
-    QTest::newRow("url-valid00") << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"http://www.example.org"_s);
+    QTest::newRow("url-valid00") << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                  << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"/home/user"_qs);
-    QTest::newRow("url-valid01") << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"/home/user"_s);
+    QTest::newRow("url-valid01") << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                  << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"user"_qs);
-    QTest::newRow("url-valid02") << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"user"_s);
+    QTest::newRow("url-valid02") << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                  << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"file:///home/user/test.txt"_qs);
-    QTest::newRow("url-valid03") << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"file:///home/user/test.txt"_s);
+    QTest::newRow("url-valid03") << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                  << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"%20"_qs);
-    QTest::newRow("url-empty") << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1()
+    query.addQueryItem(u"field"_s, u"%20"_s);
+    QTest::newRow("url-empty") << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1()
                                << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"http://www.example.org"_qs);
-    query.addQueryItem(u"constraints"_qs, u"NoRelative"_qs);
+    query.addQueryItem(u"field"_s, u"http://www.example.org"_s);
+    query.addQueryItem(u"constraints"_s, u"NoRelative"_s);
     QTest::newRow("url-norelative-valid")
-        << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"/home/user"_qs);
-    query.addQueryItem(u"constraints"_qs, u"NoRelative"_qs);
+    query.addQueryItem(u"field"_s, u"/home/user"_s);
+    query.addQueryItem(u"constraints"_s, u"NoRelative"_s);
     QTest::newRow("url-norelative-invalid")
-        << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"http://www.example.org"_qs);
-    query.addQueryItem(u"constraints"_qs, u"NoLocalFile"_qs);
+    query.addQueryItem(u"field"_s, u"http://www.example.org"_s);
+    query.addQueryItem(u"constraints"_s, u"NoLocalFile"_s);
     QTest::newRow("url-nolocalfile-valid00")
-        << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"/home/user/test.txt"_qs);
-    query.addQueryItem(u"constraints"_qs, u"NoLocalFile"_qs);
+    query.addQueryItem(u"field"_s, u"/home/user/test.txt"_s);
+    query.addQueryItem(u"constraints"_s, u"NoLocalFile"_s);
     QTest::newRow("url-nolocalfile-valid01")
-        << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"file:///home/user/test.txt"_qs);
-    query.addQueryItem(u"constraints"_qs, u"NoLocalFile"_qs);
+    query.addQueryItem(u"field"_s, u"file:///home/user/test.txt"_s);
+    query.addQueryItem(u"constraints"_s, u"NoLocalFile"_s);
     QTest::newRow("url-nolocalfile-invalid")
-        << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"http://www.example.org"_qs);
-    query.addQueryItem(u"schemes"_qs, u"HTTP,https"_qs);
+    query.addQueryItem(u"field"_s, u"http://www.example.org"_s);
+    query.addQueryItem(u"schemes"_s, u"HTTP,https"_s);
     QTest::newRow("url-scheme-valid")
-        << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"ftp://www.example.org"_qs);
-    query.addQueryItem(u"schemes"_qs, u"HTTP,https"_qs);
+    query.addQueryItem(u"field"_s, u"ftp://www.example.org"_s);
+    query.addQueryItem(u"schemes"_s, u"HTTP,https"_s);
     QTest::newRow("url-scheme-invalid")
-        << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
 
     query.clear();
-    query.addQueryItem(u"field"_qs, u"http://www.example.org"_qs);
-    query.addQueryItem(u"constraints"_qs, u"WebsiteOnly"_qs);
+    query.addQueryItem(u"field"_s, u"http://www.example.org"_s);
+    query.addQueryItem(u"constraints"_s, u"WebsiteOnly"_s);
     QTest::newRow("url-websiteonly-valid")
-        << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
+        << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1() << valid;
 
     const QStringList invalidWebsiteUrls(
-        {u"ftp://www.example.org"_qs, u"file:///home/user/test.txt"_qs, u"/home/user"_qs});
+        {u"ftp://www.example.org"_s, u"file:///home/user/test.txt"_s, u"/home/user"_s});
     int count = 0;
     for (const QString &invalidWebsite : invalidWebsiteUrls) {
         query.clear();
-        query.addQueryItem(u"field"_qs, invalidWebsite);
-        query.addQueryItem(u"constraints"_qs, u"WebsiteOnly"_qs);
-        QTest::newRow(qUtf8Printable(u"url-websiteonly-invalid0%1"_qs.arg(count)))
-            << u"/url"_qs << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
+        query.addQueryItem(u"field"_s, invalidWebsite);
+        query.addQueryItem(u"constraints"_s, u"WebsiteOnly"_s);
+        QTest::newRow(qUtf8Printable(u"url-websiteonly-invalid0%1"_s.arg(count)))
+            << u"/url"_s << query.toString(QUrl::FullyEncoded).toLatin1() << invalid;
         count++;
     }
 }

--- a/tests/testviewjson.cpp
+++ b/tests/testviewjson.cpp
@@ -13,6 +13,7 @@
 #include <QtTest/QTest>
 
 using namespace Cutelyst;
+using namespace Qt::Literals::StringLiterals;
 
 class TestViewJSON : public Controller
 {
@@ -26,7 +27,7 @@ public:
     C_ATTR(test0, :Local)
     void test0(Context *c)
     {
-        c->response()->setContentType("text/plain"_qba);
+        c->response()->setContentType("text/plain"_ba);
         c->setStash(QStringLiteral("foo"), QByteArrayLiteral("bar"));
         c->setStash(QStringLiteral("bar"), QByteArrayLiteral("baz"));
         c->forward(c->view());
@@ -149,7 +150,7 @@ void TestActionRenderView::doTest()
     QUrl urlAux(url);
     Headers sendHeaders;
     if (sendXJsonVersion) {
-        sendHeaders.pushHeader("X-Prototype-Version"_qba, "1.5.0");
+        sendHeaders.pushHeader("X-Prototype-Version"_ba, "1.5.0");
     }
     auto result = m_engine->createRequest(
         method, urlAux.path(), urlAux.query(QUrl::FullyEncoded).toLatin1(), sendHeaders, nullptr);
@@ -171,7 +172,7 @@ void TestActionRenderView::testController_data()
     QTest::addColumn<QString>("contentType");
     QTest::addColumn<bool>("hasXJson");
 
-    const auto get = "GET"_qba;
+    const auto get = "GET"_ba;
 
     QTest::newRow("viewjson-test-00")
         << get << QStringLiteral("/test/view/json/test0") << true << 200


### PR DESCRIPTION
An we now have Qt 6.4 as minimum requirement, this fixes some deprecated code, especially the use of ""_qs and ""_qba string literal operators. Qt 6.4 introduced the Qt::Literals::StringLiterals that provides the ""_s and ""_ba string literal operators.