### PR TITLE
Remove need for co_yield context in context coroutine method

### DIFF
--- a/Cutelyst/CoroContext.h
+++ b/Cutelyst/CoroContext.h
@@ -60,10 +60,8 @@ public:
         void await_suspend(std::coroutine_handle<> h) noexcept {}
         void await_resume() const noexcept {}
 
-        template <typename... ArgTypes>
-        promise_type(Cutelyst::Controller &controller, QObject *obj, ArgTypes &&...)
+        std::suspend_never yield_value(QObject *obj)
         {
-            Q_UNUSED(controller)
             auto conn = QObject::connect(obj, &QObject::destroyed, [this] {
                 clean();
 
@@ -72,6 +70,7 @@ public:
                 }
             });
             connections.emplace_back(std::move(conn));
+            return {};
         }
 
         template <typename... ArgTypes>


### PR DESCRIPTION
This adds variadic template constructors to the CoroContext::promise_type that takes the coroutine parameters to give the promise type access to them. The constructor connects the QObject::destroyed signal of the context as before the yield_value methods did. So there is no need anymore to call `co_yield c` in the coroutine context method.